### PR TITLE
Add ns2 agent commands and agents crate

### DIFF
--- a/.claude/skills/mutation-test/SKILL.md
+++ b/.claude/skills/mutation-test/SKILL.md
@@ -21,15 +21,15 @@ Wait for the user's answer before proceeding.
 **Diff mode:**
 
 ```
-git diff main.. > /tmp/ns2-mutation.diff && cargo mutants --workspace --in-diff /tmp/ns2-mutation.diff -vV
+git diff main > /tmp/ns2-mutation.diff && cargo mutants --workspace --in-diff /tmp/ns2-mutation.diff -vV; rm -rf mutants.out.old
 ```
 
-If `git diff main..` produces no output (nothing changed relative to `main`), report that and stop — there are no mutations to test.
+If the diff file is empty (nothing changed relative to `main`), report that and stop — there are no mutations to test.
 
 **Full mode:**
 
 ```
-cargo mutants --workspace -j 4 -vV
+cargo mutants --workspace -j 4 -vV; rm -rf mutants.out.old
 ```
 
 Warn the user this may take 15–60 minutes before starting. Capture the full output.

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude/worktrees/
 .env
 mutants.out
+mutants.out.old

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "agents"
+version = "0.1.0"
+dependencies = [
+ "tempfile",
+ "tracing",
+ "workspace",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +388,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 name = "cli"
 version = "0.1.0"
 dependencies = [
+ "agents",
  "anthropic",
  "chrono",
  "clap",
@@ -848,6 +858,7 @@ dependencies = [
 name = "harness"
 version = "0.1.0"
 dependencies = [
+ "agents",
  "anthropic",
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/anthropic",
     "crates/tools",
     "crates/workspace",
+    "crates/agents",
     "crates/harness",
     "crates/server",
     "crates/tui",

--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "agents"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+workspace = { path = "../workspace" }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -1,0 +1,310 @@
+pub struct AgentDef {
+    pub name: String,
+    pub description: String,
+    pub body: String,
+}
+
+pub fn agents_dir() -> Option<std::path::PathBuf> {
+    workspace::git_root().map(|root| root.join(".ns2").join("agents"))
+}
+
+pub fn parse_agent_content(content: &str) -> Option<AgentDef> {
+    let content = content.trim_start();
+    let rest = content.strip_prefix("---\n")?;
+    let (frontmatter, body) = if let Some(pos) = rest.find("\n---\n") {
+        (&rest[..pos], rest[pos + 5..].trim())
+    } else if let Some(stripped) = rest.strip_suffix("\n---") {
+        (stripped, "")
+    } else {
+        return None;
+    };
+
+    let mut name = None;
+    let mut description = String::new();
+    for line in frontmatter.lines() {
+        if let Some(v) = line.strip_prefix("name: ") {
+            name = Some(v.trim().to_string());
+        } else if let Some(v) = line.strip_prefix("description: ") {
+            description = v.trim().to_string();
+        }
+    }
+
+    Some(AgentDef { name: name?, description, body: body.to_string() })
+}
+
+/// Format an agent definition as a frontmatter `.md` file.
+/// Note: `name` and `description` are written verbatim. Newlines or colons in those
+/// fields will produce malformed frontmatter. Callers (e.g. CLI flags) are responsible
+/// for ensuring single-line values.
+pub fn format_agent_file(def: &AgentDef) -> String {
+    format!("---\nname: {}\ndescription: {}\n---\n\n{}", def.name, def.description, def.body)
+}
+
+pub fn load_agent(dir: &std::path::Path, name: &str) -> Option<AgentDef> {
+    let path = dir.join(format!("{name}.md"));
+    let content = std::fs::read_to_string(path).ok()?;
+    parse_agent_content(&content)
+}
+
+pub fn list_agents(dir: &std::path::Path) -> Vec<AgentDef> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return vec![],
+    };
+    let mut agents: Vec<AgentDef> = entries
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                return None;
+            }
+            let content = std::fs::read_to_string(&path).ok()?;
+            match parse_agent_content(&content) {
+                Some(def) => Some(def),
+                None => {
+                    tracing::warn!("skipping {}: invalid frontmatter", path.display());
+                    None
+                }
+            }
+        })
+        .collect();
+    agents.sort_by(|a, b| a.name.cmp(&b.name));
+    agents
+}
+
+/// Write an agent definition to `{dir}/{name}.md`.
+/// Overwrites the file if it already exists. Callers are responsible for checking
+/// existence before calling if overwrite should be prevented (e.g. `agent new`).
+pub fn write_agent(dir: &std::path::Path, def: &AgentDef) -> std::io::Result<()> {
+    std::fs::write(dir.join(format!("{}.md", def.name)), format_agent_file(def))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Tests moved from cli ─────────────────────────────────────────────────
+
+    #[test]
+    fn parse_agent_content_extracts_name_and_description() {
+        let content = "---\nname: coding\ndescription: A coding agent\n---\n\nSystem prompt here.\n";
+        let def = parse_agent_content(content).unwrap();
+        assert_eq!(def.name, "coding");
+        assert_eq!(def.description, "A coding agent");
+        assert_eq!(def.body, "System prompt here.");
+    }
+
+    #[test]
+    fn parse_agent_content_empty_body() {
+        let content = "---\nname: coding\ndescription: minimal\n---\n";
+        let def = parse_agent_content(content).unwrap();
+        assert_eq!(def.name, "coding");
+        assert_eq!(def.body, "");
+    }
+
+    #[test]
+    fn parse_agent_content_missing_description_defaults_to_empty() {
+        let content = "---\nname: coding\n---\n\nBody.\n";
+        let def = parse_agent_content(content).unwrap();
+        assert_eq!(def.description, "");
+        assert_eq!(def.body, "Body.");
+    }
+
+    #[test]
+    fn parse_agent_content_missing_frontmatter_returns_none() {
+        let content = "just some plain text without frontmatter";
+        assert!(parse_agent_content(content).is_none());
+    }
+
+    #[test]
+    fn parse_agent_content_missing_name_returns_none() {
+        let content = "---\ndescription: no name here\n---\n\nBody.\n";
+        assert!(parse_agent_content(content).is_none());
+    }
+
+    #[test]
+    fn format_agent_file_round_trips() {
+        let def = AgentDef {
+            name: "coding".to_string(),
+            description: "A coding agent".to_string(),
+            body: "You are a coding agent.".to_string(),
+        };
+        let formatted = format_agent_file(&def);
+        let parsed = parse_agent_content(&formatted).unwrap();
+        assert_eq!(parsed.name, def.name);
+        assert_eq!(parsed.description, def.description);
+        assert_eq!(parsed.body, def.body);
+    }
+
+    // ── New tests for load_agent and write_agent ─────────────────────────────
+
+    #[test]
+    fn write_agent_then_load_agent_round_trips() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        let def = AgentDef {
+            name: "myagent".to_string(),
+            description: "Does things".to_string(),
+            body: "You are a helpful agent.".to_string(),
+        };
+        write_agent(dir, &def).unwrap();
+        let loaded = load_agent(dir, "myagent").unwrap();
+        assert_eq!(loaded.name, def.name);
+        assert_eq!(loaded.description, def.description);
+        assert_eq!(loaded.body, def.body);
+    }
+
+    #[test]
+    fn load_agent_returns_none_for_missing_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(load_agent(tmp.path(), "nonexistent").is_none());
+    }
+
+    // ── Tests for list_agents ────────────────────────────────────────────────
+
+    #[test]
+    fn list_agents_returns_only_md_files_sorted_by_name() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        write_agent(dir, &AgentDef {
+            name: "zebra".to_string(),
+            description: "last".to_string(),
+            body: "z body".to_string(),
+        })
+        .unwrap();
+        write_agent(dir, &AgentDef {
+            name: "alpha".to_string(),
+            description: "first".to_string(),
+            body: "a body".to_string(),
+        })
+        .unwrap();
+        // Write a non-.md file that must be ignored
+        std::fs::write(dir.join("ignored.txt"), "not an agent").unwrap();
+
+        let agents = list_agents(dir);
+        assert_eq!(agents.len(), 2, "expected exactly 2 agents (ignoring .txt file)");
+        assert_eq!(agents[0].name, "alpha");
+        assert_eq!(agents[1].name, "zebra");
+    }
+
+    #[test]
+    fn list_agents_on_nonexistent_path_returns_empty_vec() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let missing = tmp.path().join("does_not_exist");
+        let agents = list_agents(&missing);
+        assert!(agents.is_empty(), "expected empty vec for nonexistent path");
+    }
+
+    // ── agents_dir() path construction ──────────────────────────────────────
+
+    /// agents_dir() must agree with workspace::git_root().map(|r| r.join(".ns2").join("agents")).
+    /// When git_root() returns None (outside a git repo, e.g. in cargo-mutants temp dir),
+    /// both sides are None and the test still passes, which is fine — the mutation
+    /// `agents_dir() -> None` is indistinguishable from the real implementation outside
+    /// a git repo. The `Some(Default::default())` mutation IS distinguishable because
+    /// git_root() returns None in the temp dir so the real impl returns None too, while
+    /// the mutant would return Some(PathBuf::new()).
+    #[test]
+    fn agents_dir_matches_git_root_join() {
+        let expected = workspace::git_root().map(|r| r.join(".ns2").join("agents"));
+        let actual = agents_dir();
+        assert_eq!(actual, expected, "agents_dir() must equal git_root().join('.ns2').join('agents')");
+    }
+
+    /// agents_dir() must return an absolute path when inside a git repo.
+    /// Skip gracefully when not inside a git repo (e.g. cargo-mutants temp dir).
+    #[test]
+    fn agents_dir_returns_absolute_path() {
+        let dir = match agents_dir() {
+            Some(d) => d,
+            None => return, // not inside a git repo; skip
+        };
+        assert!(dir.is_absolute(), "agents_dir() must return an absolute path, got: {}", dir.display());
+    }
+
+    /// parse_agent_content correctly extracts the body (multi-line).
+    #[test]
+    fn parse_agent_content_multiline_body() {
+        let content = "---\nname: multi\ndescription: test\n---\n\nLine one.\nLine two.\n";
+        let def = parse_agent_content(content).unwrap();
+        assert_eq!(def.body, "Line one.\nLine two.");
+    }
+
+    /// format_agent_file produces a string that starts with "---\n".
+    #[test]
+    fn format_agent_file_starts_with_frontmatter_delimiter() {
+        let def = AgentDef {
+            name: "agent".to_string(),
+            description: "desc".to_string(),
+            body: "body text".to_string(),
+        };
+        let formatted = format_agent_file(&def);
+        assert!(formatted.starts_with("---\n"), "formatted output must start with '---\\n'");
+    }
+
+    /// load_agent returns None for a file that exists but has invalid frontmatter.
+    #[test]
+    fn load_agent_returns_none_for_invalid_content() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("bad.md"), "not valid frontmatter").unwrap();
+        assert!(load_agent(tmp.path(), "bad").is_none());
+    }
+
+    /// The body may contain `---` on its own line (e.g. a markdown horizontal rule).
+    /// The parser finds the *first* `\n---\n` in the file, which is always the
+    /// frontmatter closing delimiter; any `---` in the body is preserved verbatim.
+    #[test]
+    fn parse_agent_content_body_with_horizontal_rule_preserved() {
+        let content = "---\nname: agent\ndescription: desc\n---\n\nSection one.\n\n---\n\nSection two.\n";
+        let def = parse_agent_content(content).unwrap();
+        assert_eq!(def.name, "agent");
+        assert_eq!(def.body, "Section one.\n\n---\n\nSection two.");
+    }
+
+    /// list_agents silently skips `.md` files whose content cannot be parsed
+    /// (no valid frontmatter). Only well-formed agent files are returned.
+    #[test]
+    fn list_agents_skips_invalid_frontmatter_md_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        write_agent(dir, &AgentDef {
+            name: "good".to_string(),
+            description: "valid".to_string(),
+            body: "body".to_string(),
+        })
+        .unwrap();
+        std::fs::write(dir.join("bad.md"), "not valid frontmatter at all").unwrap();
+
+        let agents = list_agents(dir);
+        assert_eq!(agents.len(), 1, "invalid .md file must be silently skipped");
+        assert_eq!(agents[0].name, "good");
+    }
+
+    /// CRLF line endings are not supported: `parse_agent_content` requires LF-only.
+    /// Files with Windows line endings will fail to parse and return `None`.
+    #[test]
+    fn parse_agent_content_crlf_returns_none() {
+        let content = "---\r\nname: agent\r\ndescription: desc\r\n---\r\n\r\nBody.\r\n";
+        assert!(
+            parse_agent_content(content).is_none(),
+            "CRLF line endings are not supported and must return None"
+        );
+    }
+
+    /// write_agent creates a file named `{name}.md` in the given directory.
+    #[test]
+    fn write_agent_creates_correct_filename() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let def = AgentDef {
+            name: "mybot".to_string(),
+            description: "desc".to_string(),
+            body: "body".to_string(),
+        };
+        write_agent(tmp.path(), &def).unwrap();
+        assert!(
+            tmp.path().join("mybot.md").exists(),
+            "write_agent must create {{name}}.md"
+        );
+    }
+}

--- a/crates/arch-tests/architecture.spec.md
+++ b/crates/arch-tests/architecture.spec.md
@@ -20,10 +20,12 @@ The workspace is a flat set of crates, each owning one layer of the system. Depe
 
 **`workspace`** — git worktree management. Creates a worktree for a branch on demand; worktrees persist until explicitly removed via CLI (typically after merge). Purely a git operations crate — no knowledge of sessions. Also exposes `git_root()` — a utility that returns the repository root, used by `cli` for locating config files and data directories. All git interactions belong here.
 
-**`harness`** — the agent turn loop. Depends on `anthropic`, `tools`, `db`, and `workspace`. Owns context window construction, system prompt loading and preprocessing, and tool dispatch. Emits events to a tokio broadcast channel — it has no knowledge of HTTP or subscribers. One instance runs per active session as a tokio task.
+**`agents`** — agent definition files. Reads and writes `.ns2/agents/*.md` files, which define agent types via YAML frontmatter (`name`, `description`) and a system prompt body. Exposes a pure in-memory `AgentDef` type, parsing/formatting helpers, and directory-based list/load/write operations. Depends only on `workspace` for `git_root()` discovery. No knowledge of sessions, turns, or HTTP.
+
+**`harness`** — the agent turn loop. Depends on `anthropic`, `tools`, `db`, and `agents`. Owns context window construction, system prompt loading (reads the agent definition for `session.agent` via the `agents` crate), and tool dispatch. Emits events to a tokio broadcast channel — it has no knowledge of HTTP or subscribers. One instance runs per active session as a tokio task.
 
 **`server`** — axum HTTP server. Exposes routes for session management and SSE streaming: creating session records, listing sessions, queuing user messages. Enforces branch-level concurrency: rejects new sessions on a branch that already has a `running` session (checked against `db` at creation time). Spawns harness tasks for new sessions but doesn't reach into the turn loop — the harness runs independently once started. Subscribes to harness broadcast channels and fans events out to SSE clients. 
 
 **`tui`** — ratatui terminal UI. Connects to the server via SSE and renders sessions. Thin client: all state comes from the server, nothing is computed locally.
 
-**`cli`** — the `ns2` binary. Depends on `workspace` for git root discovery. On launch, checks if a server is already running (via a PID file or a probe to localhost). If not, starts one in the background. Then launches the TUI connected to the orchestrator session. Wires crates together; contains no logic of its own.
+**`cli`** — the `ns2` binary. Depends on `workspace` for git root discovery and `agents` for agent management commands. On launch, checks if a server is already running (via a PID file or a probe to localhost). If not, starts one in the background. Then launches the TUI connected to the orchestrator session. Wires crates together; contains no logic of its own.

--- a/crates/arch-tests/tests/architecture.rs
+++ b/crates/arch-tests/tests/architecture.rs
@@ -165,6 +165,15 @@ fn workspace_has_no_application_deps() {
     }
 }
 
+/// `agents` only depends on `workspace` — must not depend on db, anthropic, harness, server, tui, or cli.
+#[test]
+fn agents_has_no_upper_layer_deps() {
+    let graph = build_dep_graph();
+    for forbidden in &["db", "anthropic", "harness", "server", "tui", "cli"] {
+        assert_no_dep(&graph, "agents", forbidden);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Coverage-ignore allowlist helpers
 // ---------------------------------------------------------------------------
@@ -426,6 +435,14 @@ fn direct_dep_edges_match_spec() {
     assert_no_direct_dep(&graph, "workspace", "server");
     assert_no_direct_dep(&graph, "workspace", "tui");
     assert_no_direct_dep(&graph, "workspace", "cli");
+
+    // agents -> no upper layers (workspace is allowed)
+    assert_no_direct_dep(&graph, "agents", "db");
+    assert_no_direct_dep(&graph, "agents", "anthropic");
+    assert_no_direct_dep(&graph, "agents", "harness");
+    assert_no_direct_dep(&graph, "agents", "server");
+    assert_no_direct_dep(&graph, "agents", "tui");
+    assert_no_direct_dep(&graph, "agents", "cli");
 
     // harness -> no HTTP layer
     assert_no_direct_dep(&graph, "harness", "server");

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 types = { path = "../types" }
 workspace = { path = "../workspace" }
+agents = { path = "../agents" }
 server = { path = "../server" }
 anthropic = { path = "../anthropic" }
 harness = { path = "../harness" }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -25,6 +25,31 @@ enum Command {
         #[command(subcommand)]
         action: SessionAction,
     },
+    Agent {
+        #[command(subcommand)]
+        action: AgentAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentAction {
+    List,
+    New {
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long)]
+        description: Option<String>,
+        #[arg(long)]
+        body: Option<String>,
+    },
+    Edit {
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long)]
+        description: Option<String>,
+        #[arg(long)]
+        body: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -71,6 +96,8 @@ enum SessionAction {
         name: Option<String>,
     },
 }
+
+// ────────────────────────────────────────────────────────────────────────────
 
 fn load_dotenv() {
     let Some(root) = workspace::git_root() else { return };
@@ -221,7 +248,10 @@ async fn main() {
                         let key = std::env::var("ANTHROPIC_API_KEY").ok();
                         let c: Arc<dyn anthropic::AnthropicClient> = match key {
                             Some(k) => Arc::new(anthropic::Client::new(k)),
-                            None => Arc::new(harness::StubClient),
+                            None => {
+                                eprintln!("Warning: ANTHROPIC_API_KEY not set — using stub client (responses will be fake)");
+                                Arc::new(harness::StubClient)
+                            }
                         };
                         c
                     },
@@ -384,6 +414,93 @@ async fn main() {
                 let session_id = resolve_session_id(&cli.server, id, name).await;
                 // For MVP, just print "not implemented" — real cancellation is out of scope
                 println!("Stop not yet implemented for session {session_id}");
+            }
+        },
+        Command::Agent { action } => match action {
+            AgentAction::List => {
+                let dir = agents::agents_dir().unwrap_or_else(|| {
+                    eprintln!("Error: not inside a git repository");
+                    std::process::exit(1);
+                });
+                if !dir.exists() {
+                    println!("No agents found (directory does not exist: {})", dir.display());
+                    return;
+                }
+                let agent_list = agents::list_agents(&dir);
+                if agent_list.is_empty() {
+                    println!("No agents found.");
+                } else {
+                    println!("{:<20}  description", "name");
+                    for a in &agent_list {
+                        println!("{:<20}  {}", a.name, a.description);
+                    }
+                }
+            }
+            AgentAction::New { name, description, body } => {
+                let name = name.unwrap_or_else(|| {
+                    eprintln!("Error: --name is required");
+                    std::process::exit(1);
+                });
+                let dir = agents::agents_dir().unwrap_or_else(|| {
+                    eprintln!("Error: not inside a git repository");
+                    std::process::exit(1);
+                });
+                if let Err(e) = std::fs::create_dir_all(&dir) {
+                    eprintln!("Error creating agents directory: {e}");
+                    std::process::exit(1);
+                }
+                let path = dir.join(format!("{name}.md"));
+                if path.exists() {
+                    eprintln!("Error: agent '{name}' already exists at {}", path.display());
+                    std::process::exit(1);
+                }
+                let open_editor = body.is_none();
+                let def = agents::AgentDef {
+                    name: name.clone(),
+                    description: description.unwrap_or_default(),
+                    body: body.unwrap_or_default(),
+                };
+                if let Err(e) = agents::write_agent(&dir, &def) {
+                    eprintln!("Error writing agent file: {e}");
+                    std::process::exit(1);
+                }
+                if open_editor {
+                    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+                    std::process::Command::new(&editor).arg(&path).status().ok();
+                }
+                eprintln!("Created agent '{name}' at {}", path.display());
+            }
+            AgentAction::Edit { name, description, body } => {
+                let name = name.unwrap_or_else(|| {
+                    eprintln!("Error: --name is required");
+                    std::process::exit(1);
+                });
+                if description.is_none() && body.is_none() {
+                    eprintln!("Error: must provide at least one of --description or --body");
+                    std::process::exit(1);
+                }
+                let dir = agents::agents_dir().unwrap_or_else(|| {
+                    eprintln!("Error: not inside a git repository");
+                    std::process::exit(1);
+                });
+                let mut def = agents::load_agent(&dir, &name).unwrap_or_else(|| {
+                    eprintln!(
+                        "Error: agent '{name}' not found at {}",
+                        dir.join(format!("{name}.md")).display()
+                    );
+                    std::process::exit(1);
+                });
+                if let Some(d) = description {
+                    def.description = d;
+                }
+                if let Some(b) = body {
+                    def.body = b;
+                }
+                if let Err(e) = agents::write_agent(&dir, &def) {
+                    eprintln!("Error writing agent file: {e}");
+                    std::process::exit(1);
+                }
+                eprintln!("Updated agent '{name}'.");
             }
         },
     }

--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -8,6 +8,7 @@ types = { path = "../types" }
 db = { path = "../db" }
 anthropic = { path = "../anthropic" }
 tools = { path = "../tools" }
+agents = { path = "../agents" }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -35,7 +35,6 @@ impl AnthropicClient for StubClient {
 pub struct HarnessConfig {
     pub session: Session,
     pub model: String,
-    pub system: Option<String>,
     pub tools: Vec<Arc<dyn tools::Tool>>,
 }
 
@@ -116,10 +115,21 @@ async fn run_tool_dispatch_loop(
     let tool_definitions: Vec<types::ToolDefinition> =
         config.tools.iter().map(|t| t.definition()).collect();
 
+    let system = config
+        .session
+        .agent
+        .as_deref()
+        .and_then(|name| {
+            let dir = agents::agents_dir()?;
+            agents::load_agent(&dir, name)
+        })
+        .map(|def| def.body)
+        .filter(|s| !s.is_empty());
+
     loop {
         let request = MessageRequest {
             model: config.model.clone(),
-            system: config.system.clone(),
+            system: system.clone(),
             messages: messages.clone(),
             max_tokens: 4096,
             tools: tool_definitions.clone(),
@@ -330,7 +340,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
 
@@ -374,7 +383,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
         let client = Arc::new(StubClient);
@@ -419,7 +427,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
         let client = Arc::new(StubClient);
@@ -440,7 +447,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
         let client = Arc::new(StubClient);
@@ -484,7 +490,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
         let client = Arc::new(StubClient);
@@ -575,7 +580,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
         let client = Arc::new(MultiBlockClient);
@@ -608,7 +612,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
         let client = Arc::new(StubClient);
@@ -706,7 +709,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![Arc::new(AlwaysOkTool)],
         };
         let client = Arc::new(ToolUseClient::new());
@@ -774,7 +776,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![Arc::new(AlwaysErrTool)],
         };
         let client = Arc::new(ToolUseClient::new());
@@ -924,7 +925,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![Arc::new(AlwaysOkTool)],
         };
         let client = Arc::new(TwoToolClient { call_count: std::sync::atomic::AtomicU32::new(0) });
@@ -1033,7 +1033,6 @@ mod tests {
                 updated_at: Utc::now(),
             },
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
 
@@ -1107,7 +1106,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
         let client = Arc::new(MaxTokensClient);
@@ -1203,7 +1201,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![Arc::new(AlwaysOkTool)], // only "read", not "nonexistent_tool"
         };
         let client = Arc::new(UnknownToolClient::new());
@@ -1251,7 +1248,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![], // empty
         };
         let client = Arc::new(StubClient);
@@ -1327,7 +1323,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![Arc::new(AlwaysOkTool)],
         };
         let client = Arc::new(ToolUseClient::new());
@@ -1391,7 +1386,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![Arc::new(AlwaysOkTool)],
         };
         let client = Arc::new(TwoToolOrderingClient {
@@ -1500,7 +1494,6 @@ mod tests {
         let config = HarnessConfig {
             session: session.clone(),
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
         let client = Arc::new(KnownTokenClient);
@@ -1628,7 +1621,6 @@ mod tests {
                 updated_at: Utc::now(),
             },
             model: "claude-opus-4-5".into(),
-            system: None,
             tools: vec![],
         };
 
@@ -1668,6 +1660,184 @@ mod tests {
         assert!(
             matches!(&captured[2].1[0], ContentBlock::Text { text } if text == "follow up"),
             "third message should be 'follow up'"
+        );
+    }
+
+    // --- Agent system prompt tests ---
+
+    /// A client that captures the `system` field from the first request.
+    struct SystemCapturingClient {
+        captured_system: std::sync::Mutex<Option<Option<String>>>,
+    }
+
+    impl SystemCapturingClient {
+        fn new() -> Self {
+            Self { captured_system: std::sync::Mutex::new(None) }
+        }
+
+        fn captured(&self) -> Option<String> {
+            self.captured_system.lock().unwrap().clone().flatten()
+        }
+    }
+
+    #[async_trait]
+    impl AnthropicClient for SystemCapturingClient {
+        async fn complete(&self, request: MessageRequest) -> anthropic::Result<MessageResponse> {
+            let mut guard = self.captured_system.lock().unwrap();
+            if guard.is_none() {
+                *guard = Some(request.system);
+            }
+            Ok(MessageResponse {
+                content: vec![ContentBlock::Text { text: "ok".into() }],
+                stop_reason: "end_turn".into(),
+                input_tokens: 10,
+                output_tokens: 3,
+            })
+        }
+    }
+
+    /// When session.agent is None, the system prompt sent to the API must be None.
+    #[tokio::test]
+    async fn test_no_agent_means_no_system_prompt() {
+        let session = types::Session {
+            id: Uuid::new_v4(),
+            name: "test".into(),
+            status: types::SessionStatus::Running,
+            agent: None, // No agent
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let mock_db = permissive_mock_db();
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "claude-opus-4-5".into(),
+            tools: vec![],
+        };
+        let client = Arc::new(SystemCapturingClient::new());
+        let client_ref = Arc::clone(&client);
+        let db = Arc::new(mock_db);
+        let (event_tx, _rx) = broadcast::channel(64);
+        let (msg_tx, msg_rx) = mpsc::channel(16);
+        msg_tx.send("hello".into()).await.unwrap();
+        drop(msg_tx);
+
+        run(config, client, db, event_tx, msg_rx).await.unwrap();
+
+        assert!(
+            client_ref.captured().is_none(),
+            "system prompt must be None when session.agent is None"
+        );
+    }
+
+    /// When an agent exists with a non-empty body, its body becomes the system prompt.
+    /// When an agent exists with an empty body, system prompt must remain None.
+    /// These tests write real agent files to .ns2/agents/ to exercise the full path.
+    /// They skip when not inside a git repo (e.g. cargo-mutants temp dir) because
+    /// agents::agents_dir() depends on workspace::git_root().
+    #[tokio::test]
+    async fn test_agent_with_nonempty_body_becomes_system_prompt() {
+        // Skip when not inside a git repo (cargo-mutants runs in a temp dir)
+        let dir = match agents::agents_dir() {
+            Some(d) => d,
+            None => return,
+        };
+        // Write a real agent file so agents::load_agent can find it
+        std::fs::create_dir_all(&dir).unwrap();
+        let agent_name = "harness_test_nonempty_body";
+        let def = agents::AgentDef {
+            name: agent_name.to_string(),
+            description: "test agent".to_string(),
+            body: "You are a test harness agent with a non-empty body.".to_string(),
+        };
+        agents::write_agent(&dir, &def).unwrap();
+
+        let session = types::Session {
+            id: Uuid::new_v4(),
+            name: "test".into(),
+            status: types::SessionStatus::Running,
+            agent: Some(agent_name.to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let mock_db = permissive_mock_db();
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "claude-opus-4-5".into(),
+            tools: vec![],
+        };
+        let client = Arc::new(SystemCapturingClient::new());
+        let client_ref = Arc::clone(&client);
+        let db = Arc::new(mock_db);
+        let (event_tx, _rx) = broadcast::channel(64);
+        let (msg_tx, msg_rx) = mpsc::channel(16);
+        msg_tx.send("hello".into()).await.unwrap();
+        drop(msg_tx);
+
+        let result = run(config, client, db, event_tx, msg_rx).await;
+
+        // Cleanup before any assertions that might panic
+        let _ = std::fs::remove_file(dir.join(format!("{agent_name}.md")));
+
+        result.unwrap();
+
+        assert_eq!(
+            client_ref.captured().as_deref(),
+            Some("You are a test harness agent with a non-empty body."),
+            "non-empty agent body must become the system prompt"
+        );
+    }
+
+    /// When an agent exists but has an empty body, the system prompt must be None.
+    /// This catches the `.filter(|s| !s.is_empty())` mutation (flipping ! would let
+    /// empty bodies through and drop non-empty ones).
+    #[tokio::test]
+    async fn test_agent_with_empty_body_produces_no_system_prompt() {
+        // Skip when not inside a git repo (cargo-mutants runs in a temp dir)
+        let dir = match agents::agents_dir() {
+            Some(d) => d,
+            None => return,
+        };
+        std::fs::create_dir_all(&dir).unwrap();
+        let agent_name = "harness_test_empty_body";
+        let def = agents::AgentDef {
+            name: agent_name.to_string(),
+            description: "test agent with no body".to_string(),
+            body: String::new(), // empty body
+        };
+        agents::write_agent(&dir, &def).unwrap();
+
+        let session = types::Session {
+            id: Uuid::new_v4(),
+            name: "test".into(),
+            status: types::SessionStatus::Running,
+            agent: Some(agent_name.to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let mock_db = permissive_mock_db();
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "claude-opus-4-5".into(),
+            tools: vec![],
+        };
+        let client = Arc::new(SystemCapturingClient::new());
+        let client_ref = Arc::clone(&client);
+        let db = Arc::new(mock_db);
+        let (event_tx, _rx) = broadcast::channel(64);
+        let (msg_tx, msg_rx) = mpsc::channel(16);
+        msg_tx.send("hello".into()).await.unwrap();
+        drop(msg_tx);
+
+        let result = run(config, client, db, event_tx, msg_rx).await;
+
+        // Cleanup before any assertions that might panic
+        let _ = std::fs::remove_file(dir.join(format!("{agent_name}.md")));
+
+        result.unwrap();
+
+        assert!(
+            client_ref.captured().is_none(),
+            "empty agent body must NOT become the system prompt (system must be None)"
         );
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -149,7 +149,6 @@ fn spawn_harness_sync(
     let config = harness::HarnessConfig {
         session: session_clone.clone(),
         model,
-        system: None,
         tools,
     };
 

--- a/product-flows/09-agent-commands.md
+++ b/product-flows/09-agent-commands.md
@@ -1,0 +1,231 @@
+# Flow 09: Agent Commands
+
+Create and manage agent type files using `ns2 agent list`, `ns2 agent new`, and `ns2 agent edit`.
+
+These commands operate purely on the filesystem — no server required. Agent files live in
+`.ns2/agents/` relative to the git root of the current repo.
+
+## Setup
+
+```bash
+source product-flows/setup.sh
+cd /tmp/ns2-test-repo
+```
+
+No server needs to be started for any step in this flow.
+
+## Steps
+
+### List agents when the directory does not exist yet
+
+```bash
+$NS2 agent list
+```
+
+Expected output:
+```
+No agents found (directory does not exist: /tmp/ns2-test-repo/.ns2/agents)
+```
+
+Exit code: 0. The `.ns2/agents/` directory does not exist yet; the command prints where
+it looked and exits cleanly rather than erroring.
+
+### Create a first agent with all flags provided
+
+```bash
+$NS2 agent new --name "reviewer" --description "Reviews pull requests for style and correctness" --body "You are a careful code reviewer. Focus on clarity and correctness."
+```
+
+Expected output on stderr:
+```
+Created agent 'reviewer' at /tmp/ns2-test-repo/.ns2/agents/reviewer.md
+```
+
+Verify the file was written correctly:
+```bash
+cat /tmp/ns2-test-repo/.ns2/agents/reviewer.md
+```
+
+Expected file contents:
+```
+---
+name: reviewer
+description: Reviews pull requests for style and correctness
+---
+
+You are a careful code reviewer. Focus on clarity and correctness.
+```
+
+The file has YAML frontmatter followed by a blank line and the body text.
+
+### List agents — shows the new entry
+
+```bash
+$NS2 agent list
+```
+
+Expected output — a two-column table with `name` padded to 20 characters:
+```
+name                 description
+reviewer             Reviews pull requests for style and correctness
+```
+
+### Create a second agent
+
+```bash
+$NS2 agent new --name "planner" --description "Breaks large tasks into actionable steps" --body "You are a planning assistant. Decompose problems into small, concrete steps."
+```
+
+Expected output on stderr:
+```
+Created agent 'planner' at /tmp/ns2-test-repo/.ns2/agents/planner.md
+```
+
+### List shows both agents, sorted by name
+
+```bash
+$NS2 agent list
+```
+
+Expected output — agents appear in alphabetical order by name:
+```
+name                 description
+planner              Breaks large tasks into actionable steps
+reviewer             Reviews pull requests for style and correctness
+```
+
+### Edit the first agent's description
+
+```bash
+$NS2 agent edit --name "reviewer" --description "Reviews code for correctness, style, and test coverage"
+```
+
+Expected output on stderr:
+```
+Updated agent 'reviewer'.
+```
+
+Verify the description changed and the body was preserved:
+```bash
+cat /tmp/ns2-test-repo/.ns2/agents/reviewer.md
+```
+
+Expected file contents:
+```
+---
+name: reviewer
+description: Reviews code for correctness, style, and test coverage
+---
+
+You are a careful code reviewer. Focus on clarity and correctness.
+```
+
+### Edit the first agent's body
+
+```bash
+$NS2 agent edit --name "reviewer" --body "You are a thorough code reviewer. Check for correctness, style, and adequate test coverage."
+```
+
+Expected output on stderr:
+```
+Updated agent 'reviewer'.
+```
+
+Verify the body changed and the description from the previous step was preserved:
+```bash
+cat /tmp/ns2-test-repo/.ns2/agents/reviewer.md
+```
+
+Expected file contents:
+```
+---
+name: reviewer
+description: Reviews code for correctness, style, and test coverage
+---
+
+You are a thorough code reviewer. Check for correctness, style, and adequate test coverage.
+```
+
+## Error Cases
+
+### `agent new` without `--name`
+
+```bash
+$NS2 agent new --description "Missing name flag"
+```
+
+Expected: error message and non-zero exit code. The `--name` flag is required.
+
+```bash
+$NS2 agent new --description "Missing name flag"; echo "Exit code: $?"
+```
+
+Expected: `Exit code: 1` (or any non-zero value).
+
+### `agent edit` without `--name`
+
+```bash
+$NS2 agent edit --description "No name given"
+```
+
+Expected: error message and non-zero exit code. The `--name` flag is required.
+
+```bash
+$NS2 agent edit --description "No name given"; echo "Exit code: $?"
+```
+
+Expected: `Exit code: 1` (or any non-zero value).
+
+### `agent edit` with `--name` but no other flags
+
+```bash
+$NS2 agent edit --name "reviewer"
+```
+
+Expected output (exit code non-zero):
+```
+Error: at least one of --description or --body must be provided
+```
+
+Nothing in the file changes.
+
+### `agent new` with a duplicate name
+
+```bash
+$NS2 agent new --name "reviewer" --description "Duplicate" --body "This should fail."
+```
+
+Expected output (exit code non-zero):
+```
+Error: agent 'reviewer' already exists at /tmp/ns2-test-repo/.ns2/agents/reviewer.md
+```
+
+The existing `reviewer.md` file is unchanged.
+
+## Acceptance Criteria
+
+- [ ] `ns2 agent list` exits 0 and prints `No agents found (directory does not exist: <path>)` when `.ns2/agents/` does not exist
+- [ ] `ns2 agent list` exits 0 and prints `No agents found.` when `.ns2/agents/` exists but is empty
+- [ ] `ns2 agent new` creates `.ns2/agents/` if it does not exist (no manual `mkdir` needed)
+- [ ] `ns2 agent new --name <n> --description <d> --body <b>` creates `.ns2/agents/<n>.md` with correct YAML frontmatter and body
+- [ ] Created file has a blank line between the closing `---` and the body text
+- [ ] `ns2 agent new` prints `Created agent '<name>' at <path>` on stderr and exits 0
+- [ ] `ns2 agent list` shows a two-column table with `name` padded to 20 characters and `description`
+- [ ] `ns2 agent list` output is sorted alphabetically by name
+- [ ] `ns2 agent edit --name <n> --description <d>` updates only the `description` frontmatter field, leaving the body intact
+- [ ] `ns2 agent edit --name <n> --body <b>` replaces only the body, leaving frontmatter intact
+- [ ] `ns2 agent edit` prints `Updated agent '<name>'.` on stderr and exits 0
+- [ ] `ns2 agent new` without `--name` exits non-zero with an error message
+- [ ] `ns2 agent edit` without `--name` exits non-zero with an error message
+- [ ] `ns2 agent edit --name <n>` with no other flags exits non-zero with `Error: at least one of --description or --body must be provided`
+- [ ] `ns2 agent new` with a name that already exists exits non-zero without overwriting the file
+- [ ] None of these commands require a running server
+
+## Cleanup
+
+```bash
+rm -f /tmp/ns2-test-repo/.ns2/agents/reviewer.md
+rm -f /tmp/ns2-test-repo/.ns2/agents/planner.md
+rmdir /tmp/ns2-test-repo/.ns2/agents 2>/dev/null || true
+rmdir /tmp/ns2-test-repo/.ns2 2>/dev/null || true
+```


### PR DESCRIPTION
## Summary

- **New `agents` crate** — owns all agent definition file logic: `AgentDef`, `parse_agent_content`, `format_agent_file`, `load_agent`, `list_agents`, `write_agent`. Emits `tracing::warn` on invalid frontmatter rather than silently skipping. Doc comments on overwrite behaviour and escaping constraints. 19 unit tests including round-trip, tempdir I/O, invalid frontmatter, CRLF handling, and body containing `---` delimiters.
- **`harness`** — drops the dead `system: Option<String>` field from `HarnessConfig`; now loads the system prompt at runtime from `session.agent` via the `agents` crate at the start of each tool dispatch loop.
- **`cli`** — thin wrapper over `agents` for `ns2 agent list/new/edit`; startup warning when `ANTHROPIC_API_KEY` is absent and stub client is used.
- **`arch-tests`** — `agents` crate added to architecture spec and dependency graph enforcement tests.
- **`mutation-test` skill** — fix `git diff main..` → `git diff main` (catches uncommitted changes); clean up `mutants.out.old` after each run; add `mutants.out.old` to `.gitignore`.
- **`product-flows/09-agent-commands.md`** — new smoke test flow covering list/new/edit happy paths, alphabetical sorting, field-level edits, all four error cases, and implicit directory creation.

## Test plan

- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (160 tests)
- [ ] `ns2 agent list` when `.ns2/agents/` absent prints path hint and exits 0
- [ ] `ns2 agent new --name X --description Y --body Z` creates `.ns2/agents/X.md` with correct frontmatter, creates directory if absent
- [ ] `ns2 agent edit --name X --description Y` updates only description, preserves body
- [ ] `ns2 agent edit --name X` with no other flags exits 1 with error
- [ ] `ns2 server start` without `ANTHROPIC_API_KEY` prints warning to stderr
- [ ] Run product flow 09 manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)