### PR TITLE
Fix context window overflow in smoke-tester; add qa-tester agent; harden fixtures

### DIFF
--- a/.ns2/agents/qa-tester.md
+++ b/.ns2/agents/qa-tester.md
@@ -1,0 +1,35 @@
+---
+name: qa-tester
+description: Run a single product-flow inside a Docker container and report findings with a critical QA lens.
+---
+
+You are a critical QA tester. Execute one product-flow exactly as written and report what you observe. Your message contains a `Container: ns2-flow-NN` and a `.spec.md`, outlining which flow to test and where the testing environment is.
+
+All bash commands must run via `docker exec <container-name> bash -c '...'`. Never run commands on the host. The Fixture Setup commands in the flow are already formatted as `docker exec` calls — run them exactly as written.
+
+## Verdicts
+
+- **PASS** — every criterion met exactly
+- **FAIL** — one or more criteria failed or were ambiguous
+- **SKIPPED** — could not run (prerequisites not met, container failure, binary crash, etc.)
+
+## Output
+
+### Verdict
+
+One word: PASS, FAIL, or SKIPPED.
+
+### Criteria results
+
+| # | Criterion (abbreviated) | Result | Actual output |
+|---|------------------------|--------|---------------|
+
+Result is PASS or FAIL. Actual output truncated to ≤ 120 chars.
+
+### Observations
+
+Anything anomalous beyond pass/fail — unexpected output, behaviour that passes today but looks fragile, systemic signals (IDs that never change, timestamps with insufficient granularity), commands that produced warnings. "None." if nothing to report.
+
+### Workflow Snags
+
+Friction that made the flow harder to execute or verify: missing CLI commands, opaque output that required workarounds, steps that needed retries to settle a race, log output absent when a failure occurred. "None." if nothing to report.

--- a/.ns2/agents/smoke-tester.md
+++ b/.ns2/agents/smoke-tester.md
@@ -3,131 +3,71 @@ name: smoke-tester
 description: Run product-flow manual tests in parallel Docker containers, one per flow.
 ---
 
+You are an orchestrator for QA testing flows outlined in `product-flows/`. Your job is to set up Docker containers, dispatch `qa-tester` subagents in parallel, collect their reports, and summarise results. You do not run flows yourself.
 
-Run `product-flows/` flows in parallel Docker containers. If `$ARGUMENTS` is given, run only those numbered flows; otherwise determine which flows are out of sync (Step 0.5) and run only those.
-
-## Step 0: Detect repo root and build
-
-Detect the repo root:
+## Build
 
 ```bash
-git rev-parse --show-toplevel
+REPO_ROOT=$(git rev-parse --show-toplevel)
+bash $REPO_ROOT/product-flows/build.sh
+ls $REPO_ROOT/product-flows/.build/ns2
 ```
 
-All paths below use `REPO_ROOT` as a placeholder — substitute the actual path.
+`product-flows/.build/ns2` is only for use inside the test containers.
 
-Run the build script from the repo root:
+## Select flows
 
-```bash
-bash REPO_ROOT/product-flows/build.sh
-```
+- If `$ARGUMENTS` was given, run only those flows. 
+- Otherwise, run `ns2 spec sync product-flows/` and run any flows that are marked stale.
 
-If build.sh exits non-zero, bail immediately with the message: "Build failed — aborting smoke test." Do not proceed.
+## Start containers
 
-After build.sh completes, verify the binary exists:
-
-```bash
-ls REPO_ROOT/product-flows/.build/ns2
-```
-
-If the binary is missing, bail immediately with: "Binary not found at product-flows/.build/ns2 — aborting."
-
-The built binary at `REPO_ROOT/product-flows/.build/ns2` is compiled for the container OS (Linux). For host-side `ns2` commands in subsequent steps, use the system `ns2` binary (i.e. just `ns2` — it is on PATH).
-
-## Step 0.5: Determine which flows to run
-
-If `$ARGUMENTS` was given, the flows to run are exactly those numbered flows — skip the rest of this step.
-
-Otherwise, run spec sync scoped to the product-flows directory to find out-of-sync flows:
-
-```bash
-ns2 spec sync product-flows/ 2>&1
-```
-
-Parse the output for lines matching `[error] spec product-flows/NN-` or `[warning] spec product-flows/NN-` and extract the two-digit flow numbers. These are the **stale flows** to run.
-
-- If the command fails with a non-spec-sync error (e.g. binary crash), skip this check with a note and fall back to running all flows 01–12.
-- If the command succeeds or exits non-zero but produces stale-flow output: use the stale flow numbers as the set to run.
-- If no flows are stale (command exits 0, no stale output): report "All flows are up to date — nothing to run." and stop. Do not start any containers.
-
-## Step 1: Check prerequisites
-
-Check whether `ANTHROPIC_API_KEY` is set:
-
-```bash
-echo ${ANTHROPIC_API_KEY:-}
-```
-
-If the output is empty, `ANTHROPIC_API_KEY` is unset. Any flow whose Prerequisites section contains `[Requires: ANTHROPIC_API_KEY]` must be marked SKIPPED — do not start a container for it.
-
-## Step 2: Start all containers
-
-For each flow being run (and not SKIPPED), start a detached container before spawning any subagents. Container names follow the pattern `ns2-flow-NN` where NN is the two-digit flow number.
+For each flow, start a detached container before spawning any subagents. Container names follow the pattern `ns2-flow-NN` where NN is the two-digit flow number.
 
 ```bash
 docker run -d \
   --name ns2-flow-NN \
-  -v REPO_ROOT/product-flows/.build/ns2:/usr/local/bin/ns2:ro \
-  -v REPO_ROOT/.env:/tmp/ns2-host.env:ro \
-  -v REPO_ROOT/product-flows/fixtures:/fixtures:ro \
+  -v $REPO_ROOT/product-flows/.build/ns2:/usr/local/bin/ns2:ro \
+  -v $REPO_ROOT/.env:/tmp/ns2-host.env:ro \
+  -v $REPO_ROOT/product-flows/fixtures:/fixtures:ro \
   ns2-test tail -f /dev/null
 ```
 
-If `docker run` returns non-zero for a given flow, mark that flow CRITICAL, record the error, and do not spawn a subagent for it. Still run cleanup for it at the end.
+If `docker run` fails, mark the flow SKIPPED (record the error), skip spawning a subagent, but still run cleanup.
 
-## Step 3: Spawn all subagents simultaneously
+## Run QA testers
 
-After all containers are started, spawn one subagent per non-SKIPPED, non-CRITICAL flow. Spawn them all at the same time — do not wait for one to finish before starting the next. Each container has its own network namespace, so port 9876 does not conflict between flows.
+Spawn a `qa-tester` session for each flow, storing each ID by flow number:
 
-Each subagent receives:
-- The full text of the flow `.spec.md` file
-- The container name assigned to it (e.g. `ns2-flow-03`)
-- This instruction: **All bash commands in this flow must be run via `docker exec <container-name> bash -c '...'`. Do not run commands on the host. The Fixture Setup section contains the setup commands already formatted as `docker exec` calls — run them exactly as written.**
+```bash
+SESSION[NN]=$(ns2 session new --agent qa-tester --message "Container: ns2-flow-NN
 
-Each subagent follows the flow file exactly:
-1. Run the Fixture Setup commands (already formatted as `docker exec` calls)
-2. Execute each Step in order, using `docker exec ns2-flow-NN bash -c '...'` for every command
-3. Evaluate each Acceptance Criterion
-4. Do not run Cleanup — the orchestrating agent handles container removal
+$(cat $REPO_ROOT/product-flows/NN-name.spec.md)")
+```
 
-Each subagent returns:
-- Pass/fail for each acceptance criterion
-- One verdict: PASS, FAIL, CRITICAL, or SKIPPED
-- Observations (anomalies that aren't captured by acceptance criteria)
-- Workflow Snags (friction that made the flow harder to execute or verify)
+Once all sessions are started, poll until every one reaches `completed` or `failed`:
 
-Verdict definitions:
+```bash
+ns2 session list --id "${SESSION[NN]}"
+```
 
-- **PASS** — all criteria met
-- **FAIL** — ran to completion, one or more criteria failed
-- **CRITICAL** — infrastructure failure prevented full evaluation (container wouldn't exec, binary crashed on every invocation)
-- **SKIPPED** — prerequisites not met
+When all are done, collect the summary from each result:
 
-If a failure is in testable business logic, the subagent writes a failing unit test that reproduces it. If the failure is integration-only (CLI output format, server behaviour), it notes that instead.
+```bash
+ns2 session tail --id "${SESSION[NN]}" --turns 1
+```
 
-Subagents note anything anomalous that isn't captured by the acceptance criteria — unexpected output, timing that seems fragile, behaviour that passes today but looks load-bearing for a later flow, systemic signals (e.g. "turns are created faster than timestamp granularity can distinguish"). These become **Observations** in the per-flow report, separate from pass/fail. The goal is to surface latent issues before they become failures in a later flow.
+## Verify passing flows
 
-Subagents also note **Workflow Snags** — friction that made the flow harder to execute or verify than it should have been. Examples: no way to wait for session completion without polling, opaque output that required workarounds to inspect, missing CLI commands that would have made a step straightforward, log output that was absent when a failure occurred.
-
-## Step 4: Wait for all subagents
-
-Wait for every spawned subagent to finish before proceeding.
-
-## Step 4.5: Verify passing flows
-
-For each flow that returned PASS, run:
+For each flow whose qa-tester session returned a PASS verdict, run:
 
 ```bash
 ns2 spec verify product-flows/NN-name.spec.md
 ```
 
-This stamps the current timestamp into the flow's `verified` field, recording that the flow was run and passed against the current codebase. List each verify result in the Container Cleanup Status section.
+## Cleanup containers
 
-If the binary is not available, skip this step with a note.
-
-## Step 5: Cleanup all containers
-
-For every flow that had a container started (including CRITICAL flows), run:
+For every container started, run:
 
 ```bash
 docker rm -f ns2-flow-NN
@@ -137,7 +77,7 @@ Run cleanup for each container regardless of that flow's outcome. Record whether
 
 ## Report
 
-Print the following sections in order.
+Summarise all qa-tester outputs into the following sections. Do not repeat raw session output verbatim — synthesise it.
 
 ### Results table
 
@@ -146,15 +86,15 @@ Print the following sections in order.
 
 ### Failed criteria
 
-For each FAIL or CRITICAL flow, list every failed criterion with actual vs expected output.
+For each FAIL, list every failed criterion with actual vs expected output.
 
 ### Observations
 
-List anything noted across all flows — even from flows that passed. Surface latent issues and anomalous behaviour.
+Consolidate observations from all flows. Surface latent issues and anomalous behaviour — even from flows that passed.
 
 ### Workflow Snags
 
-List friction points that made testing harder or reduced visibility. These are improvement signals for the developer environment and tooling, not product bugs.
+Consolidate workflow snags from all flows. These are improvement signals for the developer environment and tooling, not product bugs.
 
 ### Container Cleanup Status
 
@@ -166,4 +106,4 @@ Confirm whether each container was successfully removed and whether each passing
 | ns2-flow-02 | yes | yes |
 | ... | ... | ... |
 
-If any removal failed, list the error. If verify was skipped (binary unavailable), note that in the Verified column.
+If any removal failed, list the error.

--- a/crates/cli/cli-commands.spec.md
+++ b/crates/cli/cli-commands.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/cli/src/**/*.rs
   - crates/cli/Cargo.toml
-verified: 2026-04-24T09:03:39Z
+verified: 2026-04-24T12:32:23Z
 ---
 
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -216,7 +216,8 @@ pub fn format_session_event(event: &types::SessionEvent) -> Option<String> {
     }
 }
 
-fn print_session_event(event: &types::SessionEvent) {
+fn print_session_event(event: &types::SessionEvent, to_stderr: bool) {
+    use std::io::Write;
     use types::SessionEvent::*;
     match event {
         // Text deltas stream without a newline; flush so the terminal shows them immediately.
@@ -225,17 +226,25 @@ fn print_session_event(event: &types::SessionEvent) {
             ..
         } => {
             if let Some(text) = format_session_event(event) {
-                print!("{text}");
-                use std::io::Write;
-                std::io::stdout().flush().ok();
+                if to_stderr {
+                    eprint!("{text}");
+                    std::io::stderr().flush().ok();
+                } else {
+                    print!("{text}");
+                    std::io::stdout().flush().ok();
+                }
             }
         }
-        // Errors go to stderr.
+        // Errors always go to stderr.
         Error { message } => eprintln!("[error] {message}"),
         // Everything else: print the formatted string (which already includes a newline).
         _ => {
             if let Some(output) = format_session_event(event) {
-                print!("{output}");
+                if to_stderr {
+                    eprint!("{output}");
+                } else {
+                    print!("{output}");
+                }
             }
         }
     }
@@ -268,7 +277,7 @@ pub fn format_sync_warning(spec_path: &str, stale: &[PathBuf]) -> String {
     out
 }
 
-async fn stream_events(url: &str) {
+async fn stream_events(url: &str, to_stderr: bool) {
     use futures::StreamExt;
     let client = reqwest::Client::new();
     let resp = client
@@ -291,7 +300,7 @@ async fn stream_events(url: &str) {
             for line in frames {
                 if let Some(data) = line.strip_prefix("data: ") {
                     if let Ok(event) = serde_json::from_str::<types::SessionEvent>(data) {
-                        print_session_event(&event);
+                        print_session_event(&event, to_stderr);
                         if matches!(event, types::SessionEvent::SessionDone { .. }) {
                             return;
                         }
@@ -366,7 +375,7 @@ async fn main() {
                         Arc::new(tools::EditTool),
                     ],
                     model: std::env::var("ANTHROPIC_MODEL")
-                        .unwrap_or_else(|_| "claude-opus-4-5".to_string()),
+                        .unwrap_or_else(|_| "claude-sonnet-4-6".to_string()),
                 };
                 if let Err(e) = server::run(config).await {
                     eprintln!("Server error: {e}");
@@ -495,9 +504,10 @@ async fn main() {
                 println!("{}", session.id);
 
                 if wait {
-                    // last_turns=1: show only the final turn, not full history
+                    // last_turns=1: show only the final turn, not full history.
+                    // Output goes to stderr so stdout stays UUID-only for scripting.
                     let events_url = format!("{}/sessions/{}/events?last_turns=1", cli.server, session.id);
-                    stream_events(&events_url).await;
+                    stream_events(&events_url, true).await;
                 }
             }
             SessionAction::Tail { id, name, turns } => {
@@ -506,7 +516,7 @@ async fn main() {
                 if let Some(n) = turns {
                     url = format!("{url}?last_turns={n}");
                 }
-                stream_events(&url).await;
+                stream_events(&url, false).await;
             }
             SessionAction::Send { id, name, message } => {
                 let session_id = resolve_session_id(&cli.server, id, name).await;
@@ -542,9 +552,9 @@ async fn main() {
                 if agent_list.is_empty() {
                     println!("No agents found.");
                 } else {
-                    println!("{:<20}  description", "name");
+                    println!("{:<20} description", "name");
                     for a in &agent_list {
-                        println!("{:<20}  {}", a.name, a.description);
+                        println!("{:<20} {}", a.name, a.description);
                     }
                 }
             }
@@ -588,7 +598,7 @@ async fn main() {
                     std::process::exit(1);
                 });
                 if description.is_none() && body.is_none() {
-                    eprintln!("Error: must provide at least one of --description or --body");
+                    eprintln!("Error: at least one of --description or --body must be provided");
                     std::process::exit(1);
                 }
                 let dir = agents::agents_dir().unwrap_or_else(|| {

--- a/crates/harness/agent-harness.spec.md
+++ b/crates/harness/agent-harness.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/harness/Cargo.toml
   - crates/anthropic/src/**/*.rs
   - crates/tools/src/**/*.rs
-verified: 2026-04-22T19:18:32Z
+verified: 2026-04-24T12:32:23Z
 ---
 
 

--- a/crates/harness/agent-sessions.spec.md
+++ b/crates/harness/agent-sessions.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
-verified: 2026-04-24T09:03:39Z
+verified: 2026-04-24T12:32:23Z
 ---
 
 

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -131,7 +131,7 @@ async fn run_tool_dispatch_loop(
             model: config.model.clone(),
             system: system.clone(),
             messages: messages.clone(),
-            max_tokens: 4096,
+            max_tokens: 64000,
             tools: tool_definitions.clone(),
         };
 

--- a/crates/specs/src/lib.rs
+++ b/crates/specs/src/lib.rs
@@ -72,7 +72,7 @@ pub fn format_spec_file(def: &SpecDef) -> String {
     }
     out.push_str("---\n");
     if !def.body.is_empty() {
-        out.push_str(&format!("\n\n{}", def.body));
+        out.push_str(&format!("\n{}", def.body));
     }
     out
 }

--- a/product-flows/01-server-lifecycle.spec.md
+++ b/product-flows/01-server-lifecycle.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T09:34:05Z
+verified: 2026-04-24T12:32:23Z
 ---
 
 
@@ -86,7 +86,3 @@ Expected: `PID file removed (expected)`.
 - [ ] `ns2 server stop` prints `Server stopped (pid <N>)` and terminates the server process
 - [ ] After stop, port 9876 refuses connections
 - [ ] After stop, the PID file is removed
-
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/02-session-create-and-list.spec.md
+++ b/product-flows/02-session-create-and-list.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-24T09:41:03Z
+verified: 2026-04-24T10:37:33Z
 ---
 
 
@@ -99,6 +99,3 @@ Expected: only the single session row matching that UUID is shown. The output is
 - [ ] `ns2 session list --id <uuid>` returns exactly the session matching that UUID
 - [ ] IDs in list output match the UUIDs printed by `session new`
 
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/03-bash-tool.spec.md
+++ b/product-flows/03-bash-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-22T19:19:38Z
+verified: 2026-04-24T10:37:33Z
 ---
 
 
@@ -90,6 +90,3 @@ The tail output should show a `[tool: bash(...)]` line with `ls /`, a `[result: 
 - [ ] For the `ls /` session: the result includes `repo` and Claude describes the directory listing
 - [ ] No panics or unhandled errors in server output
 
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/04-hello-world-real.spec.md
+++ b/product-flows/04-hello-world-real.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/anthropic/src/**/*.rs
   - crates/server/src/**/*.rs
 severity: warning
-verified: 2026-04-24T09:41:03Z
+verified: 2026-04-24T10:37:33Z
 ---
 
 
@@ -85,6 +85,3 @@ Re-tailing a completed session replays the stored content. Confirm the response 
 - [ ] Re-tailing a completed session replays the stored content identically
 - [ ] No panics, stack traces, or unhandled errors in server output
 
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/05-server-not-running-errors.spec.md
+++ b/product-flows/05-server-not-running-errors.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T09:34:05Z
+verified: 2026-04-24T12:32:23Z
 ---
 
 
@@ -94,7 +94,3 @@ Expected: `Exit code: 1` (or any non-zero value).
 - [ ] Error messages suggest the fix (`ns2 server start`)
 - [ ] No Rust panics, backtraces, or `unwrap` failure output is visible
 - [ ] No JSON error blobs or HTTP response bodies are printed raw to the user
-
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/06-read-tool.spec.md
+++ b/product-flows/06-read-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-22T19:19:38Z
+verified: 2026-04-24T10:37:33Z
 ---
 
 
@@ -20,7 +20,7 @@ Claude reads a file on disk using the `read` tool during an agent run.
 ```bash
 docker exec ns2-flow-06 bash /fixtures/init.sh
 docker exec ns2-flow-06 bash /fixtures/start-server.sh
-docker exec ns2-flow-06 bash /fixtures/create-read-file.sh
+docker exec ns2-flow-06 bash /fixtures/seeded-files.sh
 ```
 
 ## Steps
@@ -80,6 +80,3 @@ Re-tailing replays stored events. The output should show multiple turns: the use
 - [ ] Re-tailing a completed session replays all turns including tool call and result
 - [ ] No panics or unhandled errors in server output
 
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/07-multi-tool.spec.md
+++ b/product-flows/07-multi-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-22T19:19:38Z
+verified: 2026-04-24T10:37:33Z
 ---
 
 
@@ -95,6 +95,3 @@ Re-tailing replays stored events. The output should show multiple turns: the use
 - [ ] `ns2 session tail` output includes `[tool: write(...)]`, `[result: ...]`, `[tool: read(...)]`, and `[result: ...]` lines for both tool calls
 - [ ] No panics or unhandled errors in server output
 
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/08-multi-turn.spec.md
+++ b/product-flows/08-multi-turn.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/db/src/**/*.rs
 severity: warning
-verified: 2026-04-24T09:41:47Z
+verified: 2026-04-24T10:37:33Z
 ---
 
 
@@ -21,7 +21,7 @@ A user sends a follow-up message to a completed session and Claude responds with
 ```bash
 docker exec ns2-flow-08 bash /fixtures/init.sh
 docker exec ns2-flow-08 bash /fixtures/start-server.sh
-docker exec ns2-flow-08 bash /fixtures/create-multi-turn-file.sh
+docker exec ns2-flow-08 bash /fixtures/seeded-files.sh
 ```
 
 ## Steps
@@ -117,6 +117,3 @@ Expected: only the final assistant turn is replayed — no `[tool: read(...)]` l
 - [ ] `ns2 session tail --turns 1` replays only the final turn (no tool call, no first-run content)
 - [ ] No panics or unhandled errors in server output
 
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/09-agent-commands.spec.md
+++ b/product-flows/09-agent-commands.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/agents/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T09:34:05Z
+verified: 2026-04-24T12:32:23Z
 ---
 
 
@@ -222,7 +222,3 @@ The existing `reviewer.md` file is unchanged.
 - [ ] `ns2 agent edit --name <n>` with no other flags exits non-zero with `Error: at least one of --description or --body must be provided`
 - [ ] `ns2 agent new` with a name that already exists exits non-zero without overwriting the file
 - [ ] None of these commands require a running server
-
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/10-spec-new.spec.md
+++ b/product-flows/10-spec-new.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/specs/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T09:34:05Z
+verified: 2026-04-24T12:32:23Z
 ---
 
 
@@ -110,7 +110,3 @@ Expected: error message on stderr and `Exit code: 1`. At least one `--target` fl
 - [ ] `ns2 spec new` on an existing path exits non-zero with an error message and does not overwrite
 - [ ] `ns2 spec new` without `--target` exits non-zero with an error message
 - [ ] No server required
-
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/11-spec-sync.spec.md
+++ b/product-flows/11-spec-sync.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/specs/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T09:34:05Z
+verified: 2026-04-24T12:32:23Z
 ---
 
 
@@ -22,6 +22,7 @@ No API key required. No server needed.
 
 ```bash
 docker exec ns2-flow-11 bash /fixtures/init.sh
+docker exec ns2-flow-11 bash /fixtures/codebase-layout.sh
 ```
 
 The server is intentionally not started — spec commands are filesystem-only.
@@ -105,7 +106,3 @@ Expected: `Exit code: 0` (all specs with valid frontmatter are clean; legacy spe
 - [ ] A spec without a `verified` field treats all matched files as stale
 - [ ] Error output includes the spec path and each stale file path
 - [ ] No server required
-
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/12-spec-verify.spec.md
+++ b/product-flows/12-spec-verify.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/specs/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T09:34:05Z
+verified: 2026-04-24T12:32:23Z
 ---
 
 
@@ -120,7 +120,3 @@ Expected: error message on stderr (invalid frontmatter or missing `targets`) and
 - [ ] `ns2 spec verify` on a non-existent file exits non-zero with an error message
 - [ ] `ns2 spec verify` on a file without valid frontmatter exits non-zero
 - [ ] No server required
-
-## Cleanup
-
-Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/fixtures/codebase-layout.sh
+++ b/product-flows/fixtures/codebase-layout.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Adds a realistic codebase layout to /repo: source files for spec targets to track,
+# and a plain .spec.md without frontmatter to exercise the "silently skipped" path.
+set -euo pipefail
+
+mkdir -p /repo/crates/cli/src
+echo 'fn main() {}' > /repo/crates/cli/src/main.rs
+
+mkdir -p /repo/crates/agents/src
+echo 'pub fn hello() {}' > /repo/crates/agents/src/lib.rs
+
+mkdir -p /repo/crates/arch-tests
+printf '# Architecture Specification\n\nPlain doc without targets frontmatter.\n' \
+    > /repo/crates/arch-tests/architecture.spec.md
+
+git -C /repo add -A
+git -C /repo commit -m "add codebase layout"

--- a/product-flows/fixtures/create-multi-turn-file.sh
+++ b/product-flows/fixtures/create-multi-turn-file.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-echo "The magic number is: 7742" > /repo/multi-turn-test.txt

--- a/product-flows/fixtures/create-read-file.sh
+++ b/product-flows/fixtures/create-read-file.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-echo "The secret value is: ns2-read-tool-test-42" > /repo/read-test.txt

--- a/product-flows/fixtures/fixtures.spec.md
+++ b/product-flows/fixtures/fixtures.spec.md
@@ -1,0 +1,38 @@
+---
+targets:
+  - product-flows/fixtures/*.sh
+verified: 2026-04-24T12:32:23Z
+---
+
+
+# Fixtures
+
+Composable setup scripts mounted at `/fixtures/` in every test container. Each fixture does one thing and makes no assumptions about what else is present. Flows compose fixtures by calling multiple scripts in sequence — start with `init.sh`, then layer only what the flow actually needs. Avoid adding to an existing fixture when a new one would do; a fixture that mixes unrelated setup becomes a hidden dependency for every flow that uses it.
+
+## `init.sh`
+Bare git repo at `/repo` with a single commit.
+```
+/repo/
+└── README.md
+```
+
+## `start-server.sh`
+Copies `.env` from the host mount and starts the ns2 server in the background.
+
+## `seeded-files.sh`
+Adds files with known static content for agent read-back testing.
+```
+/repo/
+├── read-test.txt        ("The secret value is: ns2-read-tool-test-42")
+└── multi-turn-test.txt  ("The magic number is: 7742")
+```
+
+## `codebase-layout.sh`
+Adds a minimal Rust codebase structure and a spec file without targets frontmatter.
+```
+/repo/
+└── crates/
+    ├── agents/src/lib.rs
+    ├── arch-tests/architecture.spec.md   ← no targets frontmatter
+    └── cli/src/main.rs
+```

--- a/product-flows/fixtures/seeded-files.sh
+++ b/product-flows/fixtures/seeded-files.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Adds files with known static content for agent read-back testing.
+set -euo pipefail
+echo "The secret value is: ns2-read-tool-test-42" > /repo/read-test.txt
+echo "The magic number is: 7742" > /repo/multi-turn-test.txt


### PR DESCRIPTION
## Summary

- **Root cause of #18**: `max_tokens` was hardcoded to 4096 (output cap, not context window) and the default model was `claude-opus-4-5` (200K context). Raised max_tokens to 64K and switched to `claude-sonnet-4-6` (1M context window).
- **New `qa-tester` agent**: smoke-tester now delegates per-flow execution to a dedicated qa-tester subagent with a critical QA lens; smoke-tester is a pure orchestrator that polls for completion and synthesises results.
- **Fixture overhaul**: extracted composable fixtures with a documented philosophy; flow-specific fixtures replaced by generic reusable ones.

## Code fixes (found by running smoke test)
- `session new --wait` now streams to stderr so stdout stays UUID-only for scripting
- `agent list` column width matched to spec (21 chars, not 22)
- `agent edit` error message wording matched to spec
- `spec verify` no longer adds an extra blank line between frontmatter and body

## Test plan
- [ ] All 12 product flows pass smoke test
- [ ] `ns2 session new --wait --message "..."` prints only UUID on stdout
- [ ] `ns2 agent list` shows correct column alignment
- [ ] `ns2 agent edit --name x` (no other flags) shows correct error message
- [ ] `ns2 spec verify` on a file with body content preserves exactly one blank line after `---`

🤖 Generated with [Claude Code](https://claude.com/claude-code)