### PR TITLE
Session & issue lifecycle cleanup

### DIFF
--- a/crates/cli/cli-commands.spec.md
+++ b/crates/cli/cli-commands.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/cli/src/**/*.rs
   - crates/cli/Cargo.toml
-verified: 2026-04-24T15:24:08Z
+verified: 2026-04-25T10:02:12Z
 ---
 
 # CLI Commands Spec
@@ -485,6 +485,7 @@ Commands:
   comment   Post a comment to an issue.
   start     Create an agent session for this issue and start it.
   complete  Mark an issue as completed.
+  reopen    Move a failed or completed issue back to open.
   list      List issues.
   wait      Block until all specified issues reach a terminal state.
   help      Print this message or the help of the given subcommand(s)
@@ -516,6 +517,9 @@ Options:
 
       --blocked-on <BLOCKED_ON>...
           Issue IDs that must be completed before this one. Repeat for multiple.
+
+      --start
+          Immediately start the issue after creating it. Requires --assignee.
 
   -h, --help
           Print help (see a summary with '-h')
@@ -643,6 +647,36 @@ Usage: ns2 issue wait [OPTIONS]
 Options:
       --id <IDS>...
           Issue IDs to wait on. Repeat for multiple.
+
+  -h, --help
+          Print help (see a summary with '-h')
+```
+
+### `ns2 issue reopen --help`
+
+```
+Moves a failed or completed issue back to open so work can resume on the same thread.
+Preserves all existing comments.
+
+Behavior differs by prior state:
+  failed    → clears session_id so a fresh session is created on next start
+  completed → keeps session_id so the existing session history is resumed on next start
+
+Only failed or completed issues can be reopened. Attempting to reopen an issue in any
+other state is an error.
+
+Usage: ns2 issue reopen [OPTIONS] --id <ID>
+
+Options:
+      --id <ID>
+          The issue ID. Required.
+
+      --comment <COMMENT>
+          Append a comment to the issue thread before transitioning back to open.
+          Author is 'user'. Gives context to the agent when it resumes.
+
+      --start
+          Immediately start the issue after reopening it.
 
   -h, --help
           Print help (see a summary with '-h')

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -172,6 +172,8 @@ enum IssueAction {
         parent: Option<String>,
         #[arg(long = "blocked-on", num_args = 1.., help = "Issue IDs that must be completed before this one. Repeat for multiple.")]
         blocked_on: Vec<String>,
+        #[arg(long, help = "Immediately start the issue after creating it. Requires --assignee.")]
+        start: bool,
     },
     #[command(about = "Edit an existing issue.", long_about = "Edit fields of an existing issue. Only the flags you provide are changed.")]
     Edit {
@@ -208,6 +210,15 @@ enum IssueAction {
         id: String,
         #[arg(long, help = "A final summary of what was done. Required.")]
         comment: String,
+    },
+    #[command(about = "Move a failed or completed issue back to open.", long_about = "Moves a failed or completed issue back to open so work can resume on the same thread. Preserves all existing comments.\n\n- failed → reopen → clears the session_id link so a fresh session will be created on next start.\n- completed → reopen → keeps the session_id so the existing session history is resumed on next start.\n\nOnly failed or completed issues can be reopened. Attempting to reopen an issue in any other state is an error.")]
+    Reopen {
+        #[arg(long, help = "The issue ID. Required.")]
+        id: String,
+        #[arg(long, help = "Append a comment to the issue thread before transitioning back to open. Author is 'user'.")]
+        comment: Option<String>,
+        #[arg(long, help = "Immediately start the issue after reopening it.")]
+        start: bool,
     },
     #[command(about = "List issues.", long_about = "List issues, newest first. Use flags to filter.\n\nOutput columns: id, title, status, assignee, created_at")]
     List {
@@ -948,7 +959,11 @@ async fn main() {
         Command::Issue { action } => {
             let client = reqwest::Client::new();
             match action {
-                IssueAction::New { title, body, assignee, parent, blocked_on } => {
+                IssueAction::New { title, body, assignee, parent, blocked_on, start } => {
+                    if start && assignee.is_none() {
+                        eprintln!("Error: --start requires --assignee (start needs an agent to run)");
+                        std::process::exit(1);
+                    }
                     if let Some(ref a) = assignee {
                         if let Some(dir) = agents::agents_dir() {
                             if agents::load_agent(&dir, a).is_none() {
@@ -977,6 +992,25 @@ async fn main() {
                     });
                     eprintln!("Created issue: {} ({})", issue.title, issue.id);
                     println!("{}", issue.id);
+
+                    if start {
+                        let start_url = format!("{}/issues/{}/start", cli.server, issue.id);
+                        let start_resp = client.post(&start_url).send().await.unwrap_or_else(|e| {
+                            handle_connection_error(&e);
+                        });
+                        if !start_resp.status().is_success() {
+                            if start_resp.status() == reqwest::StatusCode::NOT_FOUND {
+                                eprintln!("Error: issue not found: {}", issue.id);
+                                std::process::exit(1);
+                            }
+                            print_error_response(start_resp).await;
+                        }
+                        let started: Issue = start_resp.json().await.unwrap_or_else(|e| {
+                            eprintln!("Error parsing response: {e}");
+                            std::process::exit(1);
+                        });
+                        eprintln!("Started issue {}. Session: {}", started.id, started.session_id.map(|id| id.to_string()).unwrap_or_default());
+                    }
                 }
                 IssueAction::Edit { id, title, body, assignee, parent, blocked_on } => {
                     let url = format!("{}/issues/{}", cli.server, id);
@@ -1076,6 +1110,40 @@ async fn main() {
                         print_error_response(resp).await;
                     }
                     eprintln!("Issue {id} marked as completed.");
+                }
+                IssueAction::Reopen { id, comment, start } => {
+                    let url = format!("{}/issues/{}/reopen", cli.server, id);
+                    let req_body = json!({ "comment": comment });
+                    let resp = client.post(&url).json(&req_body).send().await.unwrap_or_else(|e| {
+                        handle_connection_error(&e);
+                    });
+                    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+                        eprintln!("Error: issue not found: {id}");
+                        std::process::exit(1);
+                    }
+                    if !resp.status().is_success() {
+                        print_error_response(resp).await;
+                    }
+                    eprintln!("Issue {id} reopened.");
+
+                    if start {
+                        let start_url = format!("{}/issues/{}/start", cli.server, id);
+                        let start_resp = client.post(&start_url).send().await.unwrap_or_else(|e| {
+                            handle_connection_error(&e);
+                        });
+                        if !start_resp.status().is_success() {
+                            if start_resp.status() == reqwest::StatusCode::NOT_FOUND {
+                                eprintln!("Error: issue not found: {id}");
+                                std::process::exit(1);
+                            }
+                            print_error_response(start_resp).await;
+                        }
+                        let started: Issue = start_resp.json().await.unwrap_or_else(|e| {
+                            eprintln!("Error parsing response: {e}");
+                            std::process::exit(1);
+                        });
+                        eprintln!("Started issue {id}. Session: {}", started.session_id.map(|id| id.to_string()).unwrap_or_default());
+                    }
                 }
                 IssueAction::List { status, assignee, parent, blocked_on } => {
                     let mut url = format!("{}/issues", cli.server);
@@ -1488,6 +1556,104 @@ mod tests {
                 assert!(ids.iter().any(|id| id == uuid2));
             }
             _ => panic!("expected session wait command"),
+        }
+    }
+
+    // --- issue reopen CLI parse tests ---
+
+    #[test]
+    fn issue_reopen_parses_id_flag() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "reopen", "--id", "ab12"]).unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Reopen { id, .. } } => {
+                assert_eq!(id, "ab12");
+            }
+            _ => panic!("expected issue reopen command"),
+        }
+    }
+
+    #[test]
+    fn issue_reopen_missing_id_fails_to_parse() {
+        let result = Cli::try_parse_from(["ns2", "issue", "reopen"]);
+        assert!(result.is_err(), "reopen without --id should fail to parse");
+    }
+
+    #[test]
+    fn issue_reopen_parses_comment_flag() {
+        let cli = Cli::try_parse_from([
+            "ns2", "issue", "reopen", "--id", "ab12", "--comment", "fix the test",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Reopen { id, comment, .. } } => {
+                assert_eq!(id, "ab12");
+                assert_eq!(comment.as_deref(), Some("fix the test"));
+            }
+            _ => panic!("expected issue reopen command"),
+        }
+    }
+
+    #[test]
+    fn issue_reopen_no_comment_is_none() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "reopen", "--id", "ab12"]).unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Reopen { comment, .. } } => {
+                assert!(comment.is_none());
+            }
+            _ => panic!("expected issue reopen command"),
+        }
+    }
+
+    #[test]
+    fn issue_reopen_parses_start_flag() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "reopen", "--id", "ab12", "--start"])
+            .unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Reopen { start, .. } } => {
+                assert!(start);
+            }
+            _ => panic!("expected issue reopen command"),
+        }
+    }
+
+    #[test]
+    fn issue_reopen_no_start_flag_is_false() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "reopen", "--id", "ab12"]).unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Reopen { start, .. } } => {
+                assert!(!start);
+            }
+            _ => panic!("expected issue reopen command"),
+        }
+    }
+
+    #[test]
+    fn issue_new_parses_start_flag() {
+        let cli = Cli::try_parse_from([
+            "ns2", "issue", "new", "--title", "t", "--body", "b", "--assignee", "swe", "--start",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Issue {
+                action: IssueAction::New { start, .. },
+            } => {
+                assert!(start);
+            }
+            _ => panic!("expected issue new command"),
+        }
+    }
+
+    #[test]
+    fn issue_new_no_start_flag_is_false() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "new", "--title", "t", "--body", "b"])
+            .unwrap();
+        match cli.command {
+            Command::Issue {
+                action: IssueAction::New { start, .. },
+            } => {
+                assert!(!start);
+            }
+            _ => panic!("expected issue new command"),
         }
     }
 }

--- a/crates/db/data-model.spec.md
+++ b/crates/db/data-model.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/db/Cargo.toml
   - crates/types/src/**/*.rs
-verified: 2026-04-24T15:24:42Z
+verified: 2026-04-25T10:02:12Z
 ---
 
 # Data Model Spec

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -55,6 +55,7 @@ pub trait IssueDb {
         assignee: Option<String>,
         parent_id: Option<String>,
     ) -> Result<Vec<Issue>>;
+    async fn list_issues_by_session_id(&self, session_id: Uuid) -> Result<Vec<Issue>>;
     async fn update_issue(&self, issue: &Issue) -> Result<()>;
 }
 
@@ -388,6 +389,16 @@ impl IssueDb for SqliteDb {
             .filter(|i| assignee.as_ref().is_none_or(|a| i.assignee.as_deref() == Some(a.as_str())))
             .filter(|i| parent_id.as_ref().is_none_or(|p| i.parent_id.as_deref() == Some(p.as_str())))
             .collect())
+    }
+
+    async fn list_issues_by_session_id(&self, session_id: Uuid) -> Result<Vec<Issue>> {
+        let rows = sqlx::query(
+            "SELECT id, title, body, status, assignee, session_id, parent_id, blocked_on, comments, created_at, updated_at FROM issues WHERE session_id = ? ORDER BY created_at DESC, id ASC",
+        )
+        .bind(session_id.to_string())
+        .fetch_all(&self.pool)
+        .await?;
+        rows.iter().map(parse_issue_row).collect()
     }
 
     async fn update_issue(&self, issue: &Issue) -> Result<()> {
@@ -891,5 +902,57 @@ mod tests {
         db.create_issue(&issue).await.unwrap();
         let fetched = db.get_issue("ab12".into()).await.unwrap();
         assert_eq!(fetched.session_id, Some(session_id));
+    }
+
+    // --- list_issues_by_session_id tests ---
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_list_issues_by_session_id_finds_linked_issue(pool: SqlitePool) {
+        let db = SqliteDb::from_pool(pool);
+        let session_id = Uuid::new_v4();
+
+        let mut issue = make_issue("ab12");
+        issue.session_id = Some(session_id);
+        db.create_issue(&issue).await.unwrap();
+
+        // Another issue with a different session_id — should NOT be returned
+        let other_session_id = Uuid::new_v4();
+        let mut other = make_issue("cd34");
+        other.session_id = Some(other_session_id);
+        db.create_issue(&other).await.unwrap();
+
+        let found = db.list_issues_by_session_id(session_id).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, "ab12");
+        assert_eq!(found[0].session_id, Some(session_id));
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_list_issues_by_session_id_returns_empty_when_none(pool: SqlitePool) {
+        let db = SqliteDb::from_pool(pool);
+        let session_id = Uuid::new_v4();
+
+        // Issue with no session_id
+        let issue = make_issue("ab12");
+        db.create_issue(&issue).await.unwrap();
+
+        let found = db.list_issues_by_session_id(session_id).await.unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_list_issues_by_session_id_returns_multiple(pool: SqlitePool) {
+        let db = SqliteDb::from_pool(pool);
+        let session_id = Uuid::new_v4();
+
+        let mut i1 = make_issue("ab12");
+        i1.session_id = Some(session_id);
+        let mut i2 = make_issue("cd34");
+        i2.session_id = Some(session_id);
+        db.create_issue(&i1).await.unwrap();
+        db.create_issue(&i2).await.unwrap();
+
+        let found = db.list_issues_by_session_id(session_id).await.unwrap();
+        assert_eq!(found.len(), 2);
     }
 }

--- a/crates/harness/agent-harness.spec.md
+++ b/crates/harness/agent-harness.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/harness/Cargo.toml
   - crates/anthropic/src/**/*.rs
   - crates/tools/src/**/*.rs
-verified: 2026-04-24T15:24:26Z
+verified: 2026-04-25T10:02:12Z
 ---
 
 # Agent Harness Spec

--- a/crates/harness/agent-sessions.spec.md
+++ b/crates/harness/agent-sessions.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:02:12Z
 ---
 
 # Agent Sessions Spec
@@ -38,9 +38,9 @@ created → running → [waiting → running → ... →] completed | failed | c
 
 ## State & Persistence
 
-- **SQLite:** source of truth. session metadata, status, full turn + message history, tool call results
-- **In-memory:** active tokio task handle per running session, SSE subscriber list per session
-- Server is largely stateless — on restart, sessions in `running` state are marked `failed` and can be retried
+- **SQLite:** source of truth. Session metadata, status, full turn + message history, tool call results. A fresh harness can reconstruct the complete conversation from the DB with no in-memory dependency.
+- **In-memory:** active tokio task handle per running session, SSE broadcast channel per session. These are ephemeral — dropped on harness exit or server restart.
+- Server is stateless except for SSE channels — on restart, orphaned `running` sessions are swept to `failed` and can be reopened; `completed` sessions remain intact and accept new messages by spawning a fresh harness that loads history from SQLite.
 
 ## Concurrency
 

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -315,6 +315,7 @@ mod tests {
                 assignee: Option<String>,
                 parent_id: Option<String>,
             ) -> db::Result<Vec<types::Issue>>;
+            async fn list_issues_by_session_id(&self, session_id: uuid::Uuid) -> db::Result<Vec<types::Issue>>;
             async fn update_issue(&self, issue: &types::Issue) -> db::Result<()>;
         }
 

--- a/crates/server/src/issue-lifecycle.spec.md
+++ b/crates/server/src/issue-lifecycle.spec.md
@@ -1,0 +1,123 @@
+---
+targets:
+  - crates/server/src/**/*.rs
+  - crates/db/src/**/*.rs
+  - crates/types/src/**/*.rs
+  - crates/cli/src/**/*.rs
+verified: 2026-04-25T10:02:12Z
+---
+
+# Issue Lifecycle Spec
+
+## Overview
+
+Issues are the primary user-facing work unit. Each issue moves through a simple lifecycle
+driven by the agent session it spawns. The DB is the single source of truth; the server
+holds no authoritative issue state in memory.
+
+## States and Transitions
+
+```
+open → running → completed
+              ↘ failed
+         ↑ (reopen)
+```
+
+- **`open`** — issue created, not yet started. The default state after `ns2 issue new`.
+- **`running`** — `ns2 issue start` has been called; a session is active.
+- **`completed`** — the agent session finished successfully, or the user called
+  `ns2 issue complete`. Terminal.
+- **`failed`** — the agent session hit an error, or the server restarted while the
+  session was active (orphan recovery). Terminal unless explicitly reopened.
+
+Both `failed` and `completed` issues can be moved back to `open` via `ns2 issue reopen`.
+The behavior differs by prior state — see the Reopen section below.
+
+## Auto-Complete: Issue Watcher Task
+
+When `ns2 issue start` spawns a harness, the server also spawns an `issue_watcher` task
+that subscribes to the session's broadcast channel. The watcher:
+
+1. Accumulates the current turn's text content as `ContentBlockDelta { TextDelta }`
+   events arrive, building a `current_turn_text` buffer.
+2. On `TurnDone` — saves `current_turn_text` into `last_turn_text`; resets
+   `current_turn_text` to empty.
+3. On `SessionDone` — posts `last_turn_text` as a comment on the issue (author =
+   `issue.assignee` or `"agent"` if no assignee), then marks the issue `completed`.
+4. On `Error { message }` — posts `message` as a comment (author = `"system"`), then
+   marks the issue `failed`.
+
+The comment is written to the DB before the status transition, so a reader that polls
+on status will always see the comment once the issue is terminal.
+
+## Comment Protocol
+
+Comments are stored in the `issues.comments` JSON array. Each comment has:
+- `author` — string; `"user"` for human comments, agent name for agent comments,
+  `"system"` for server-generated notices (orphan recovery, error messages)
+- `created_at` — UTC timestamp
+- `body` — text content
+
+`ns2 issue comment --id <id> --body <text> [--author <name>]` adds a comment manually.
+`ns2 issue complete --id <id> --comment <text>` adds a final user comment and transitions
+the issue to `completed`.
+`ns2 issue reopen --id <id> --comment <text>` adds a user comment before transitioning
+back to `open`.
+
+## Orphan Recovery
+
+On server start, the orphan sweep (see Session Lifecycle Spec) identifies issues whose
+linked session was `running` at the time of restart. For each such issue:
+
+1. The issue is transitioned to `failed`.
+2. A comment is appended:
+   ```
+   session lost on server restart
+   ```
+   Author: `"system"`.
+
+After recovery, the issue is in a clean terminal state and can be inspected, commented
+on, or reopened.
+
+## Reopen (`ns2 issue reopen`)
+
+`ns2 issue reopen --id <id> [--comment <text>] [--start]` moves a `failed` or
+`completed` issue back to `open`. **Behavior differs by prior state:**
+
+- **`failed` → reopen** — clears `session_id` so `issue start` creates a fresh session.
+  The failed session's history is not replayed (the harness is long dead).
+- **`completed` → reopen** — keeps `session_id` so `issue start` resumes the existing
+  session with full history. This lets the agent continue from where it left off.
+
+For both states:
+- Existing comments are preserved — the history of what happened is retained.
+- If `--comment <text>` is provided, a comment with `author = "user"` is appended
+  **before** the status transition, so it is visible in history when the agent resumes.
+- If `--start` is provided, `issue start` is called immediately after reopening.
+- The `updated_at` timestamp is refreshed.
+- Only `failed` and `completed` issues can be reopened. Attempting to reopen an `open`
+  or `running` issue returns an error.
+
+After reopening, the normal `open → running → completed` lifecycle applies.
+
+## Validation Rules
+
+- **`ns2 issue start`** requires:
+  - Issue must be in `open` state (not `running`, `completed`, or `failed`).
+  - Issue must have an assignee; returns an error if `assignee` is `None`.
+  - The assignee agent must exist in `.ns2/agents/`.
+- **`ns2 issue complete`** requires:
+  - Issue must not already be in a terminal state (`completed` or `failed`).
+  - `--comment` flag is required.
+- **`ns2 issue reopen`** requires:
+  - Issue must be in `failed` or `completed` state.
+- **`ns2 issue new --start`** requires:
+  - `--assignee` must be provided (start needs an agent to run).
+
+## Connect Sections
+
+- **session lifecycle:** `crates/server/src/session-lifecycle.spec.md` — session states,
+  orphan sweep, SSE event stream
+- **CLI commands:** `crates/cli/cli-commands.spec.md` — `ns2 issue` subcommand reference
+- **data model:** `crates/db/data-model.spec.md` — schema for issues and comments
+- **architecture:** `crates/arch-tests/architecture.spec.md` — crate dependency rules

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -168,18 +168,45 @@ fn spawn_harness_sync(
         let mut rx = tx.subscribe();
         let db_watch = Arc::clone(&state.db);
         tokio::spawn(async move {
+            let mut current_turn_text = String::new();
+            let mut last_turn_text = String::new();
+
             while let Ok(event) = rx.recv().await {
                 match event {
+                    SessionEvent::ContentBlockDelta {
+                        delta: types::ContentBlockDelta::TextDelta { text },
+                        ..
+                    } => {
+                        current_turn_text.push_str(&text);
+                    }
+                    SessionEvent::TurnDone { .. } if !current_turn_text.is_empty() => {
+                        last_turn_text = std::mem::take(&mut current_turn_text);
+                    }
                     SessionEvent::SessionDone { .. } => {
                         if let Ok(mut issue) = db_watch.get_issue(id.clone()).await {
+                            // Post agent's final turn as comment before marking completed
+                            if !last_turn_text.is_empty() {
+                                let author = issue.assignee.clone()
+                                    .unwrap_or_else(|| "agent".to_string());
+                                issue.comments.push(IssueComment {
+                                    author,
+                                    created_at: Utc::now(),
+                                    body: last_turn_text.clone(),
+                                });
+                            }
                             issue.status = IssueStatus::Completed;
                             issue.updated_at = Utc::now();
                             let _ = db_watch.update_issue(&issue).await;
                         }
                         break;
                     }
-                    SessionEvent::Error { .. } => {
+                    SessionEvent::Error { message } => {
                         if let Ok(mut issue) = db_watch.get_issue(id.clone()).await {
+                            issue.comments.push(IssueComment {
+                                author: "system".to_string(),
+                                created_at: Utc::now(),
+                                body: message.clone(),
+                            });
                             issue.status = IssueStatus::Failed;
                             issue.updated_at = Utc::now();
                             let _ = db_watch.update_issue(&issue).await;
@@ -221,10 +248,12 @@ fn spawn_harness_sync(
             smap.remove(&session_id);
         }
 
-        // Ensure the watcher task is cleaned up when the harness exits.
-        if let Some(watcher) = issue_watcher {
-            watcher.abort();
-        }
+        // Note: we do NOT abort the watcher here because it may still be processing
+        // the final SessionDone or Error event from the broadcast channel. The watcher
+        // exits naturally once it handles a terminal event (its while-loop breaks on
+        // SessionDone and Error), or when the broadcast channel closes (all tx senders
+        // are dropped after this task ends), causing rx.recv() to return Err.
+        drop(issue_watcher);
     });
 
     msg_tx_ret
@@ -366,11 +395,14 @@ async fn send_message(
         other => Error::Db(other),
     })?;
 
-    // For `created` sessions, spawn the harness now and send the initial message.
-    // Guard against two concurrent requests both reaching here simultaneously using the
-    // `spawning` set as an atomic "already in flight" guard.
+    // For `created`, `running`, and `completed` sessions, spawn a harness (if not already
+    // running) and deliver the message. `completed` sessions resume from full DB history
+    // so no in-memory state is required.
+    //
+    // Guard against two concurrent requests both reaching the spawn path simultaneously
+    // using the `spawning` set as an atomic "already in flight" guard.
     match session.status {
-        SessionStatus::Created | SessionStatus::Running => {
+        SessionStatus::Created | SessionStatus::Running | SessionStatus::Completed => {
             // Acquire both locks together to make the check-then-act atomic.
             let mut spawning = state.spawning.lock().await;
             let senders = state.msg_senders.lock().await;
@@ -412,8 +444,14 @@ async fn send_message(
             msg_tx.send(req.message).await.ok();
             Ok(StatusCode::OK)
         }
-        // `completed` or `failed` with no sender means the harness already exited.
-        _ => Err(Error::NotFound),
+        // `failed` and `cancelled` are terminal states that cannot accept new messages.
+        // The caller must explicitly reopen the session (e.g. via `issue reopen`) first.
+        SessionStatus::Failed => Err(Error::BadRequest(
+            "session is in failed state and cannot accept messages; reopen it first".into(),
+        )),
+        SessionStatus::Cancelled => Err(Error::BadRequest(
+            "session is in cancelled state and cannot accept messages; reopen it first".into(),
+        )),
     }
 }
 
@@ -429,6 +467,60 @@ async fn update_session_status(
     state.db.update_session_status(id, new_status).await?;
     let session = state.db.get_session(id).await?;
     Ok(Json(session))
+}
+
+/// Orphan sweep: run at startup before accepting any connections.
+///
+/// Finds all sessions stuck in `running` state (no live harness after restart),
+/// marks them `failed`, and for any linked issue does the same while appending a
+/// system comment so the issue history is self-explanatory.
+///
+/// Errors are logged and swallowed — a sweep failure must not crash the server.
+pub(crate) async fn orphan_sweep(db: &Arc<dyn db::Db>) {
+    let orphans = match db.list_sessions(Some(SessionStatus::Running)).await {
+        Ok(sessions) => sessions,
+        Err(e) => {
+            eprintln!("[orphan_sweep] failed to list running sessions: {e}");
+            return;
+        }
+    };
+
+    for session in orphans {
+        // 1. Mark the session failed.
+        if let Err(e) = db.update_session_status(session.id, SessionStatus::Failed).await {
+            eprintln!("[orphan_sweep] failed to update session {} to failed: {e}", session.id);
+            // Continue — try the rest.
+        }
+
+        // 2. Find any issue linked to this session and recover it too.
+        let issues = match db.list_issues_by_session_id(session.id).await {
+            Ok(issues) => issues,
+            Err(e) => {
+                eprintln!(
+                    "[orphan_sweep] failed to list issues for session {}: {e}",
+                    session.id
+                );
+                continue;
+            }
+        };
+
+        for mut issue in issues {
+            issue.comments.push(IssueComment {
+                author: "system".into(),
+                body: "session lost on server restart".into(),
+                created_at: Utc::now(),
+            });
+            issue.status = types::IssueStatus::Failed;
+            issue.updated_at = Utc::now();
+
+            if let Err(e) = db.update_issue(&issue).await {
+                eprintln!(
+                    "[orphan_sweep] failed to update issue {} to failed: {e}",
+                    issue.id
+                );
+            }
+        }
+    }
 }
 
 fn generate_issue_id() -> String {
@@ -637,6 +729,52 @@ async fn complete_issue(
     Ok(Json(issue))
 }
 
+async fn reopen_issue(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    body: Option<Json<ReopenIssueRequest>>,
+) -> std::result::Result<Json<Issue>, Error> {
+    let mut issue = state.db.get_issue(id.clone()).await?;
+
+    // Only `failed` and `completed` can be reopened
+    let keep_session_id = match issue.status {
+        IssueStatus::Failed => false,   // clear session_id → fresh session on next start
+        IssueStatus::Completed => true, // keep session_id → resume history on next start
+        _ => {
+            return Err(Error::BadRequest(format!(
+                "cannot reopen issue {id}: only failed or completed issues can be reopened (current status: {})",
+                issue.status
+            )));
+        }
+    };
+
+    // Optionally append a user comment before the status transition
+    if let Some(Json(req)) = body {
+        if let Some(comment_text) = req.comment {
+            if !comment_text.is_empty() {
+                issue.comments.push(IssueComment {
+                    author: "user".into(),
+                    created_at: Utc::now(),
+                    body: comment_text,
+                });
+            }
+        }
+    }
+
+    issue.status = IssueStatus::Open;
+    if !keep_session_id {
+        issue.session_id = None;
+    }
+    issue.updated_at = Utc::now();
+    state.db.update_issue(&issue).await?;
+    Ok(Json(issue))
+}
+
+#[derive(Deserialize, Default)]
+struct ReopenIssueRequest {
+    comment: Option<String>,
+}
+
 fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
@@ -653,6 +791,7 @@ fn build_router(state: AppState) -> Router {
         .route("/issues/:id/comments", post(add_comment))
         .route("/issues/:id/start", post(start_issue))
         .route("/issues/:id/complete", post(complete_issue))
+        .route("/issues/:id/reopen", post(reopen_issue))
         .with_state(state)
 }
 
@@ -674,6 +813,9 @@ pub async fn run(config: ServerConfig) -> Result<()> {
         tools: config.tools,
         model: config.model,
     };
+
+    // Recover orphaned sessions before accepting any connections.
+    orphan_sweep(&state.db).await;
 
     let app = build_router(state);
 
@@ -1581,8 +1723,8 @@ mod tests {
         assert!(raw.contains("turn-2"), "should contain last turn's content");
     }
 
-    /// A Completed session must still accept new messages via POST /sessions/:id/messages.
-    /// This verifies that the broadcast sender remains alive in the map after completion.
+    /// A Completed session (with active harness still waiting for messages) accepts follow-up
+    /// messages and returns 200. This is the in-process multi-turn case.
     #[tokio::test]
     async fn test_completed_session_sender_still_alive() {
         let (app, state) = test_app_with_state().await;
@@ -1604,26 +1746,22 @@ mod tests {
         let id = created["id"].as_str().unwrap().to_owned();
         let session_id: Uuid = id.parse().unwrap();
 
-        // Wait for the harness to complete (StubClient → fast response)
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-
-        // Manually insert a live sender into the sessions map to simulate a completed session
-        // that still has a live harness channel (multi-turn scenario).
-        // The current harness implementation removes the sender on exit, so we verify the route
-        // accepts the message while the sender exists.
-        {
-            let senders = state.msg_senders.lock().await;
-            // After harness finishes, sender is removed. To test the "sender alive" path,
-            // we check that while the sender IS in the map, the route works.
-            // The test for this is already covered by test_send_message_to_running_session_returns_200.
-            // Here we test the specific claim: POST /sessions/:id/messages on a session
-            // whose harness sender is still in the map returns 200.
-            let _ = session_id; // referenced in assertion below
-            let _ = senders;
+        // Wait for the session to reach Completed status in the DB
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let session = state.db.get_session(session_id).await.unwrap();
+            if session.status == SessionStatus::Completed {
+                break;
+            }
+            if tokio::time::Instant::now() > deadline {
+                panic!("session did not reach Completed within 3s; status={}", session.status);
+            }
         }
 
-        // Instead: verify the session exists and that sending returns either 200 (sender alive)
-        // or 404 (harness already exited). The important invariant is that it doesn't 500.
+        // The harness is still alive (waiting for next message in its loop), so the
+        // msg sender is still in the map — this is the normal in-process case.
+        // POST /sessions/:id/messages must return 200 via the fast path (sender in map).
         let resp = app
             .oneshot(
                 Request::builder()
@@ -1631,17 +1769,165 @@ mod tests {
                     .uri(format!("/sessions/{id}/messages"))
                     .header("content-type", "application/json")
                     .body(Body::from(
-                        serde_json::to_vec(&serde_json::json!({"message": "new msg"}))
+                        serde_json::to_vec(&serde_json::json!({"message": "follow-up msg"}))
                             .unwrap(),
                     ))
                     .unwrap(),
             )
             .await
             .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "completed session must accept follow-up messages and return 200"
+        );
+    }
+
+    /// POST /sessions/:id/messages on a `Completed` session with no active sender
+    /// must return 200 OK and spawn a fresh harness.
+    #[tokio::test]
+    async fn test_send_message_to_completed_session_returns_200() {
+        let (app, state) = test_app_with_state().await;
+
+        // Directly insert a completed session into the DB (no harness ever spawned)
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "completed-no-harness".into(),
+            status: SessionStatus::Completed,
+            agent: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&session).await.unwrap();
+        state
+            .db
+            .update_session_status(session.id, SessionStatus::Completed)
+            .await
+            .unwrap();
+
+        // Confirm no sender in the map
+        {
+            let senders = state.msg_senders.lock().await;
+            assert!(!senders.contains_key(&session.id));
+        }
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/sessions/{}/messages", session.id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"message": "resume me"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "completed session with no active sender must return 200 OK (fresh harness spawned)"
+        );
+    }
+
+    /// POST /sessions/:id/messages on a `Failed` session must return a non-2xx status
+    /// with an error body (sessions in Failed state cannot accept messages).
+    #[tokio::test]
+    async fn test_send_message_to_failed_session_returns_bad_request() {
+        let (app, state) = test_app_with_state().await;
+
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "failed-session".into(),
+            status: SessionStatus::Failed,
+            agent: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&session).await.unwrap();
+        state
+            .db
+            .update_session_status(session.id, SessionStatus::Failed)
+            .await
+            .unwrap();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/sessions/{}/messages", session.id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"message": "should fail"}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
         let status = resp.status();
         assert!(
-            status == StatusCode::OK || status == StatusCode::NOT_FOUND,
-            "expected 200 or 404, got {status}"
+            !status.is_success(),
+            "failed session must not accept messages; expected non-2xx, got {status}"
+        );
+
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            v["error"].is_string(),
+            "response body must contain an 'error' field, got: {v}"
+        );
+    }
+
+    /// POST /sessions/:id/messages on a `Cancelled` session must return a non-2xx status
+    /// with an error body (sessions in Cancelled state cannot accept messages).
+    #[tokio::test]
+    async fn test_send_message_to_cancelled_session_returns_bad_request() {
+        let (app, state) = test_app_with_state().await;
+
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "cancelled-session".into(),
+            status: SessionStatus::Cancelled,
+            agent: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&session).await.unwrap();
+        state
+            .db
+            .update_session_status(session.id, SessionStatus::Cancelled)
+            .await
+            .unwrap();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/sessions/{}/messages", session.id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"message": "should fail"}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let status = resp.status();
+        assert!(
+            !status.is_success(),
+            "cancelled session must not accept messages; expected non-2xx, got {status}"
+        );
+
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            v["error"].is_string(),
+            "response body must contain an 'error' field, got: {v}"
         );
     }
 
@@ -2240,5 +2526,817 @@ mod tests {
         let arr = v.as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["title"], "Blocked issue");
+    }
+
+    // ─── Orphan sweep tests ───────────────────────────────────────────────────
+
+    /// Helper: build an AppState with a fresh in-memory DB (no router).
+    async fn test_state() -> AppState {
+        let db = Arc::new(SqliteDb::connect("sqlite::memory:").await.unwrap()) as Arc<dyn db::Db>;
+        let client = Arc::new(TestClient) as Arc<dyn anthropic::AnthropicClient>;
+        AppState {
+            db,
+            sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            msg_senders: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            spawning: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+            client,
+            tools: vec![],
+            model: "claude-opus-4-5".into(),
+        }
+    }
+
+    /// A `running` session is swept to `failed` by `orphan_sweep`.
+    #[tokio::test]
+    async fn test_orphan_sweep_marks_running_session_failed() {
+        let state = test_state().await;
+
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "orphan".into(),
+            status: SessionStatus::Running,
+            agent: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&session).await.unwrap();
+
+        orphan_sweep(&state.db).await;
+
+        let fetched = state.db.get_session(session.id).await.unwrap();
+        assert_eq!(
+            fetched.status,
+            SessionStatus::Failed,
+            "orphan sweep must mark a running session as failed"
+        );
+    }
+
+    /// A `running` session linked to a `running` issue: both swept to `failed`,
+    /// and a system comment is appended to the issue.
+    #[tokio::test]
+    async fn test_orphan_sweep_marks_linked_issue_failed_with_comment() {
+        let state = test_state().await;
+
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "orphan-with-issue".into(),
+            status: SessionStatus::Running,
+            agent: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&session).await.unwrap();
+
+        let issue = types::Issue {
+            id: "ab12".into(),
+            title: "Test issue".into(),
+            body: "body".into(),
+            status: types::IssueStatus::Running,
+            assignee: None,
+            session_id: Some(session.id),
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        orphan_sweep(&state.db).await;
+
+        // Issue must be failed
+        let fetched_issue = state.db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(
+            fetched_issue.status,
+            types::IssueStatus::Failed,
+            "orphan sweep must mark the linked issue as failed"
+        );
+
+        // Issue must have the system comment
+        assert_eq!(
+            fetched_issue.comments.len(),
+            1,
+            "orphan sweep must append exactly one comment"
+        );
+        let comment = &fetched_issue.comments[0];
+        assert_eq!(comment.author, "system");
+        assert!(
+            comment.body.contains("session lost on server restart"),
+            "comment body must contain 'session lost on server restart', got: '{}'",
+            comment.body
+        );
+    }
+
+    /// `completed` and `cancelled` sessions are NOT swept.
+    #[tokio::test]
+    async fn test_orphan_sweep_ignores_non_running_sessions() {
+        let state = test_state().await;
+
+        let statuses = [
+            SessionStatus::Completed,
+            SessionStatus::Cancelled,
+            SessionStatus::Created,
+            SessionStatus::Failed,
+        ];
+
+        let mut session_ids = Vec::new();
+        for (i, status) in statuses.iter().enumerate() {
+            let session = Session {
+                id: Uuid::new_v4(),
+                name: format!("sess-{i}"),
+                status: status.clone(),
+                agent: None,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            };
+            session_ids.push((session.id, status.clone()));
+            state.db.create_session(&session).await.unwrap();
+        }
+
+        orphan_sweep(&state.db).await;
+
+        // Each session must retain its original status — the sweep touches only `running`.
+        for (id, original_status) in &session_ids {
+            let fetched = state.db.get_session(*id).await.unwrap();
+            assert_eq!(
+                fetched.status,
+                *original_status,
+                "session with original status '{}' must not have been changed by orphan sweep",
+                original_status
+            );
+        }
+    }
+
+    /// A `running` session with NO linked issue is swept to `failed` without error.
+    #[tokio::test]
+    async fn test_orphan_sweep_no_linked_issue_does_not_error() {
+        let state = test_state().await;
+
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "orphan-no-issue".into(),
+            status: SessionStatus::Running,
+            agent: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&session).await.unwrap();
+
+        // Must not panic or return an error
+        orphan_sweep(&state.db).await;
+
+        let fetched = state.db.get_session(session.id).await.unwrap();
+        assert_eq!(
+            fetched.status,
+            SessionStatus::Failed,
+            "session with no linked issue must still be marked failed"
+        );
+    }
+
+    // ─── POST /issues/:id/reopen tests ───────────────────────────────────────
+
+    /// Helper: create a failed issue directly in the DB.
+    async fn create_issue_with_status(state: &AppState, status: IssueStatus) -> String {
+        let now = chrono::Utc::now();
+        let issue = types::Issue {
+            id: generate_issue_id(),
+            title: "Test issue".into(),
+            body: "body".into(),
+            status,
+            assignee: None,
+            session_id: Some(Uuid::new_v4()),
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![IssueComment {
+                author: "system".into(),
+                body: "session lost on server restart".into(),
+                created_at: now,
+            }],
+            created_at: now,
+            updated_at: now,
+        };
+        state.db.create_issue(&issue).await.unwrap();
+        issue.id
+    }
+
+    /// POST /issues/:id/reopen on a failed issue → 200, status becomes open, session_id is null,
+    /// comments are preserved.
+    #[tokio::test]
+    async fn test_reopen_failed_issue_returns_200_and_transitions_to_open() {
+        let (app, state) = test_app_with_state().await;
+        let id = create_issue_with_status(&state, IssueStatus::Failed).await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/issues/{id}/reopen"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "open", "status must become open");
+        assert!(v["session_id"].is_null(), "session_id must be cleared to null");
+        // Comments must be preserved
+        let comments = v["comments"].as_array().unwrap();
+        assert_eq!(comments.len(), 1, "existing comment must be preserved");
+        assert_eq!(comments[0]["author"], "system");
+        assert_eq!(comments[0]["body"], "session lost on server restart");
+    }
+
+    /// POST /issues/:id/reopen on an open issue → 400 with error body.
+    #[tokio::test]
+    async fn test_reopen_open_issue_returns_400() {
+        let (app, state) = test_app_with_state().await;
+        let id = create_issue_with_status(&state, IssueStatus::Open).await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/issues/{id}/reopen"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(v["error"].is_string(), "response must contain 'error' field");
+        let err_msg = v["error"].as_str().unwrap();
+        assert!(
+            err_msg.contains(&id),
+            "error message must contain the issue id, got: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("cannot reopen"),
+            "error message must mention 'cannot reopen', got: {err_msg}"
+        );
+    }
+
+    /// POST /issues/:id/reopen on a running issue → 400 with error body.
+    #[tokio::test]
+    async fn test_reopen_running_issue_returns_400() {
+        let (app, state) = test_app_with_state().await;
+        let id = create_issue_with_status(&state, IssueStatus::Running).await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/issues/{id}/reopen"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(v["error"].is_string());
+        let err_msg = v["error"].as_str().unwrap();
+        assert!(
+            err_msg.contains("cannot reopen"),
+            "error must mention 'cannot reopen', got: {err_msg}"
+        );
+    }
+
+    // --- New reopen behavior tests ---
+
+    /// POST /issues/:id/reopen on a completed issue → 200, status becomes open,
+    /// session_id is KEPT (so next start resumes the existing session history),
+    /// comments are preserved.
+    #[tokio::test]
+    async fn test_reopen_completed_issue_keeps_session_id() {
+        let (app, state) = test_app_with_state().await;
+        let id = create_issue_with_status(&state, IssueStatus::Completed).await;
+
+        // Fetch the original session_id before reopening
+        let original = state.db.get_issue(id.clone()).await.unwrap();
+        let original_session_id = original.session_id.expect("should have a session_id");
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/issues/{id}/reopen"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "open", "status must become open");
+        // session_id must be preserved for completed issues
+        assert_eq!(
+            v["session_id"].as_str().unwrap(),
+            original_session_id.to_string(),
+            "session_id must be kept when reopening a completed issue"
+        );
+        // Comments preserved
+        let comments = v["comments"].as_array().unwrap();
+        assert_eq!(comments.len(), 1, "existing comment must be preserved");
+    }
+
+    /// POST /issues/:id/reopen on a failed issue → session_id is cleared.
+    #[tokio::test]
+    async fn test_reopen_failed_issue_clears_session_id() {
+        let (app, state) = test_app_with_state().await;
+        let id = create_issue_with_status(&state, IssueStatus::Failed).await;
+
+        // Verify the issue has a session_id before reopening
+        let original = state.db.get_issue(id.clone()).await.unwrap();
+        assert!(original.session_id.is_some(), "test setup: issue should have a session_id");
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/issues/{id}/reopen"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "open", "status must become open");
+        assert!(v["session_id"].is_null(), "session_id must be cleared for failed issues");
+    }
+
+    /// POST /issues/:id/reopen with a comment in body → comment is prepended before
+    /// status transition (comment appears in the response).
+    #[tokio::test]
+    async fn test_reopen_with_comment_appends_comment_before_status_change() {
+        let (app, state) = test_app_with_state().await;
+        let id = create_issue_with_status(&state, IssueStatus::Failed).await;
+
+        let resp = app
+            .oneshot(issue_req(
+                "POST",
+                &format!("/issues/{id}/reopen"),
+                serde_json::json!({ "comment": "the tests were failing because of X" }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "open");
+
+        let comments = v["comments"].as_array().unwrap();
+        // Original comment + new one
+        assert_eq!(comments.len(), 2, "should have original comment plus new one");
+
+        // The new comment must be the last one and have author="user"
+        let new_comment = &comments[comments.len() - 1];
+        assert_eq!(new_comment["author"], "user");
+        assert_eq!(new_comment["body"], "the tests were failing because of X");
+    }
+
+    /// POST /issues/:id/reopen without a comment body → no extra comment added.
+    #[tokio::test]
+    async fn test_reopen_without_comment_adds_no_comment() {
+        let (app, state) = test_app_with_state().await;
+        let id = create_issue_with_status(&state, IssueStatus::Failed).await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/issues/{id}/reopen"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // Only the original system comment from create_issue_with_status
+        let comments = v["comments"].as_array().unwrap();
+        assert_eq!(comments.len(), 1, "no new comment should be added when no comment provided");
+    }
+
+    /// POST /issues/zzzz/reopen → 404.
+    #[tokio::test]
+    async fn test_reopen_nonexistent_issue_returns_404() {
+        let app = test_app().await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/issues/zzzz/reopen")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ─── issue_watcher: final turn text posted as comment ─────────────────────
+
+    /// Test 1: start_issue → session runs → SessionDone; issue must have at least one comment
+    /// with author == assignee containing the stub response text ("stub response").
+    #[tokio::test]
+    async fn test_issue_watcher_posts_final_turn_as_comment_on_session_done() {
+        let (app, state) = test_app_with_state().await;
+
+        // Create an issue with an assignee
+        let create_resp = app
+            .clone()
+            .oneshot(issue_req("POST", "/issues", serde_json::json!({
+                "title": "Watcher comment test",
+                "body": "Please respond",
+                "assignee": "swe-agent"
+            })))
+            .await
+            .unwrap();
+        let body = response_body_bytes(create_resp).await;
+        let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let issue_id = created["id"].as_str().unwrap().to_string();
+
+        // Start the issue — spawns harness with TestClient that returns "stub response"
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/issues/{issue_id}/start"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Poll until the issue reaches Completed
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            let issue = state.db.get_issue(issue_id.clone()).await.unwrap();
+            if issue.status == IssueStatus::Completed {
+                break;
+            }
+            if tokio::time::Instant::now() > deadline {
+                panic!("issue did not auto-complete within 5 seconds; status={}", issue.status);
+            }
+        }
+
+        let issue = state.db.get_issue(issue_id.clone()).await.unwrap();
+        assert_eq!(issue.status, IssueStatus::Completed);
+
+        // There must be at least one comment with author == assignee
+        let agent_comments: Vec<_> = issue.comments.iter()
+            .filter(|c| c.author == "swe-agent")
+            .collect();
+        assert!(
+            !agent_comments.is_empty(),
+            "expected at least one comment from 'swe-agent', got comments: {:?}",
+            issue.comments
+        );
+
+        // The comment body must contain the stub response text
+        let has_stub_text = agent_comments.iter().any(|c| c.body.contains("stub response"));
+        assert!(
+            has_stub_text,
+            "expected a comment containing 'stub response', got: {:?}",
+            agent_comments.iter().map(|c| &c.body).collect::<Vec<_>>()
+        );
+    }
+
+    /// Test 2: on Error event, issue must have a comment with author == "system" containing
+    /// the error message, and status must be Failed.
+    #[tokio::test]
+    async fn test_issue_watcher_posts_error_as_system_comment_on_error() {
+        use async_trait::async_trait;
+
+        // A client that always returns an error
+        struct ErrorClient;
+
+        #[async_trait]
+        impl anthropic::AnthropicClient for ErrorClient {
+            async fn complete(
+                &self,
+                _request: anthropic::MessageRequest,
+            ) -> anthropic::Result<anthropic::MessageResponse> {
+                Err(anthropic::Error::Api {
+                    status: 500,
+                    message: "simulated api failure".into(),
+                })
+            }
+        }
+
+        let db = Arc::new(SqliteDb::connect("sqlite::memory:").await.unwrap()) as Arc<dyn db::Db>;
+        let client = Arc::new(ErrorClient) as Arc<dyn anthropic::AnthropicClient>;
+        let state = AppState {
+            db,
+            sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            msg_senders: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            spawning: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
+            client,
+            tools: vec![],
+            model: "claude-opus-4-5".into(),
+        };
+        let app = build_router(state.clone());
+
+        // Create an issue with an assignee
+        let create_resp = app
+            .clone()
+            .oneshot(issue_req("POST", "/issues", serde_json::json!({
+                "title": "Error test issue",
+                "body": "trigger an error",
+                "assignee": "swe-agent"
+            })))
+            .await
+            .unwrap();
+        let body = response_body_bytes(create_resp).await;
+        let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let issue_id = created["id"].as_str().unwrap().to_string();
+
+        // Start the issue — the ErrorClient will cause a harness error
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/issues/{issue_id}/start"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Poll until the issue reaches Failed
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            let issue = state.db.get_issue(issue_id.clone()).await.unwrap();
+            if issue.status == IssueStatus::Failed {
+                break;
+            }
+            if tokio::time::Instant::now() > deadline {
+                panic!("issue did not reach Failed within 5 seconds; status={}", issue.status);
+            }
+        }
+
+        let issue = state.db.get_issue(issue_id.clone()).await.unwrap();
+        assert_eq!(issue.status, IssueStatus::Failed);
+
+        // Must have a system comment containing the error message
+        let system_comments: Vec<_> = issue.comments.iter()
+            .filter(|c| c.author == "system")
+            .collect();
+        assert!(
+            !system_comments.is_empty(),
+            "expected at least one 'system' comment, got: {:?}",
+            issue.comments
+        );
+
+        // Comment body must contain the error text
+        let has_error_text = system_comments.iter()
+            .any(|c| c.body.contains("simulated api failure"));
+        assert!(
+            has_error_text,
+            "expected system comment containing error message, got: {:?}",
+            system_comments.iter().map(|c| &c.body).collect::<Vec<_>>()
+        );
+    }
+
+    /// Test 3: when a session produces multiple turns (simulate two TurnDone events before
+    /// SessionDone), only the text from the *last* turn is posted as a comment.
+    /// We verify this by manually driving events through a broadcast channel.
+    #[tokio::test]
+    async fn test_issue_watcher_only_posts_last_turn_text() {
+        // Build state so we can call spawn_harness_sync and inject events directly.
+        let state = test_state().await;
+
+        // Create an issue
+        let now = chrono::Utc::now();
+        let issue = types::Issue {
+            id: "tt01".to_string(),
+            title: "Multi-turn test".to_string(),
+            body: "body".to_string(),
+            status: IssueStatus::Running,
+            assignee: Some("bot".to_string()),
+            session_id: None,
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: now,
+            updated_at: now,
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        // Create a broadcast channel and subscribe the watcher manually,
+        // mirroring what spawn_harness_sync does for the issue_watcher.
+        let (tx, _rx) = tokio::sync::broadcast::channel::<SessionEvent>(256);
+        let mut rx = tx.subscribe();
+        let db_watch = Arc::clone(&state.db);
+        let issue_id = "tt01".to_string();
+
+        // Spawn the watcher logic directly (copied from the production code path)
+        tokio::spawn(async move {
+            let mut current_turn_text = String::new();
+            let mut last_turn_text = String::new();
+            while let Ok(event) = rx.recv().await {
+                match event {
+                    SessionEvent::ContentBlockDelta {
+                        delta: types::ContentBlockDelta::TextDelta { text },
+                        ..
+                    } => {
+                        current_turn_text.push_str(&text);
+                    }
+                    SessionEvent::TurnDone { .. } => {
+                        if !current_turn_text.is_empty() {
+                            last_turn_text = std::mem::take(&mut current_turn_text);
+                        }
+                    }
+                    SessionEvent::SessionDone { .. } => {
+                        if let Ok(mut issue) = db_watch.get_issue(issue_id.clone()).await {
+                            if !last_turn_text.is_empty() {
+                                let author = issue.assignee.clone()
+                                    .unwrap_or_else(|| "agent".to_string());
+                                issue.comments.push(IssueComment {
+                                    author,
+                                    created_at: Utc::now(),
+                                    body: last_turn_text.clone(),
+                                });
+                            }
+                            issue.status = IssueStatus::Completed;
+                            issue.updated_at = Utc::now();
+                            let _ = db_watch.update_issue(&issue).await;
+                        }
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let session_id = Uuid::new_v4();
+        let turn_id1 = Uuid::new_v4();
+        let turn_id2 = Uuid::new_v4();
+
+        // Turn 1: text "first turn text"
+        tx.send(SessionEvent::ContentBlockDelta {
+            turn_id: turn_id1,
+            index: 0,
+            delta: types::ContentBlockDelta::TextDelta { text: "first turn text".into() },
+        }).unwrap();
+        tx.send(SessionEvent::TurnDone { turn_id: turn_id1 }).unwrap();
+
+        // Turn 2: text "second turn text"
+        tx.send(SessionEvent::ContentBlockDelta {
+            turn_id: turn_id2,
+            index: 0,
+            delta: types::ContentBlockDelta::TextDelta { text: "second turn text".into() },
+        }).unwrap();
+        tx.send(SessionEvent::TurnDone { turn_id: turn_id2 }).unwrap();
+
+        // Session done
+        tx.send(SessionEvent::SessionDone { session_id }).unwrap();
+
+        // Wait for the watcher to process and write to DB
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let fetched = state.db.get_issue("tt01".to_string()).await.unwrap();
+            if fetched.status == IssueStatus::Completed {
+                break;
+            }
+            if tokio::time::Instant::now() > deadline {
+                panic!("issue did not complete within 3s");
+            }
+        }
+
+        let fetched = state.db.get_issue("tt01".to_string()).await.unwrap();
+
+        // Exactly one comment, containing only the last turn text
+        assert_eq!(fetched.comments.len(), 1, "expected exactly 1 comment");
+        let comment = &fetched.comments[0];
+        assert_eq!(comment.author, "bot");
+        assert_eq!(
+            comment.body, "second turn text",
+            "comment must contain only the last turn text; got: '{}'",
+            comment.body
+        );
+        assert!(
+            !comment.body.contains("first turn text"),
+            "comment must NOT contain first turn text"
+        );
+    }
+
+    /// Test 4: if the session produces no text content (only tool calls), no empty comment
+    /// is posted.
+    #[tokio::test]
+    async fn test_issue_watcher_no_comment_when_no_text_content() {
+        let state = test_state().await;
+
+        let now = chrono::Utc::now();
+        let issue = types::Issue {
+            id: "nt01".to_string(),
+            title: "No text test".to_string(),
+            body: "body".to_string(),
+            status: IssueStatus::Running,
+            assignee: Some("bot".to_string()),
+            session_id: None,
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: now,
+            updated_at: now,
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        let (tx, _rx) = tokio::sync::broadcast::channel::<SessionEvent>(256);
+        let mut rx = tx.subscribe();
+        let db_watch = Arc::clone(&state.db);
+        let issue_id = "nt01".to_string();
+
+        // Spawn the same watcher logic
+        tokio::spawn(async move {
+            let mut current_turn_text = String::new();
+            let mut last_turn_text = String::new();
+            while let Ok(event) = rx.recv().await {
+                match event {
+                    SessionEvent::ContentBlockDelta {
+                        delta: types::ContentBlockDelta::TextDelta { text },
+                        ..
+                    } => {
+                        current_turn_text.push_str(&text);
+                    }
+                    SessionEvent::TurnDone { .. } => {
+                        if !current_turn_text.is_empty() {
+                            last_turn_text = std::mem::take(&mut current_turn_text);
+                        }
+                    }
+                    SessionEvent::SessionDone { .. } => {
+                        if let Ok(mut issue) = db_watch.get_issue(issue_id.clone()).await {
+                            if !last_turn_text.is_empty() {
+                                let author = issue.assignee.clone()
+                                    .unwrap_or_else(|| "agent".to_string());
+                                issue.comments.push(IssueComment {
+                                    author,
+                                    created_at: Utc::now(),
+                                    body: last_turn_text.clone(),
+                                });
+                            }
+                            issue.status = IssueStatus::Completed;
+                            issue.updated_at = Utc::now();
+                            let _ = db_watch.update_issue(&issue).await;
+                        }
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        let session_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+
+        // A turn with only a tool-use block (no ContentBlockDelta TextDelta events)
+        // TurnDone without any text accumulated
+        tx.send(SessionEvent::TurnDone { turn_id }).unwrap();
+
+        // Session done with no text content
+        tx.send(SessionEvent::SessionDone { session_id }).unwrap();
+
+        // Wait for watcher to write Completed
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let fetched = state.db.get_issue("nt01".to_string()).await.unwrap();
+            if fetched.status == IssueStatus::Completed {
+                break;
+            }
+            if tokio::time::Instant::now() > deadline {
+                panic!("issue did not complete within 3s");
+            }
+        }
+
+        let fetched = state.db.get_issue("nt01".to_string()).await.unwrap();
+        assert_eq!(fetched.status, IssueStatus::Completed);
+        assert!(
+            fetched.comments.is_empty(),
+            "expected no comments when session has no text content, got: {:?}",
+            fetched.comments
+        );
     }
 }

--- a/crates/server/src/session-lifecycle.spec.md
+++ b/crates/server/src/session-lifecycle.spec.md
@@ -1,0 +1,134 @@
+---
+targets:
+  - crates/server/src/**/*.rs
+  - crates/harness/src/**/*.rs
+  - crates/db/src/**/*.rs
+  - crates/types/src/**/*.rs
+verified: 2026-04-25T10:02:12Z
+---
+
+# Session Lifecycle Spec
+
+## Overview
+
+Sessions are the internal agent run units that power issues. Every session is fully
+reconstructable from SQLite — the server holds no authoritative state beyond the active
+SSE broadcast channels and the in-progress harness tasks that feed them.
+
+## States and Transitions
+
+```
+created → running → completed
+                 ↘ failed
+                 ↘ cancelled
+```
+
+- **`created`** — session record exists; no harness is running. Occurs when a session
+  is created with no initial message, or when the server restarts and the in-memory
+  harness map is empty.
+- **`running`** — a harness task is active and processing turns.
+- **`completed`** — the harness finished with `stop_reason: end_turn` (or equivalent).
+  Terminal; the session's turn history is fully persisted.
+- **`failed`** — the harness encountered an unrecoverable error, the API key was missing,
+  or the server restarted while the session was `running` (orphan recovery, see below).
+  Terminal unless explicitly reopened.
+- **`cancelled`** — manually cancelled by the user or orchestrator. Terminal.
+
+There is no `waiting` state in the current implementation (reserved for a future input-
+request tool).
+
+## Persistence Model
+
+SQLite is the single source of truth. Everything the harness produces is persisted
+before it is used to build the next turn's context:
+
+- `sessions` table — id, name, agent type, status, branch, timestamps
+- `turns` table — one row per completed turn, with token count
+- `content_blocks` table — one row per content block within a turn (text, tool_use,
+  tool_result, thinking), with role, ordering index, and JSON-encoded content
+
+Because all history is in SQLite, a fresh harness can reconstruct the full conversation
+by loading every content block for the session, ordered by turn and block index, and
+presenting them to the API as the prior `messages` array. No in-memory state beyond the
+SSE broadcast channel and the message-queue sender is needed.
+
+## In-Memory State (the only exception)
+
+Two maps live in the server's `AppState`:
+
+- `sessions: Mutex<HashMap<Uuid, broadcast::Sender<SessionEvent>>>` — the SSE broadcast
+  channel for each live session. Dropped when the harness exits; SSE clients that
+  reconnect after a restart receive history-only streams.
+- `msg_senders: Mutex<HashMap<Uuid, mpsc::Sender<String>>>` — the message queue channel
+  for each running harness. Dropped on harness exit.
+
+These maps are intentionally ephemeral. Nothing in the DB depends on them.
+
+## Resume After Restart (`Completed` Sessions Accept New Messages)
+
+A session in `completed` state has no live harness. When `POST /sessions/:id/messages`
+is called on such a session:
+
+1. A new harness is spawned.
+2. The harness loads the full turn history from SQLite via `db.list_turns_with_blocks`.
+3. The full history is presented to the Anthropic API as the `messages` array so the
+   model has complete context.
+4. The session transitions back to `running`.
+5. SSE listeners that were connected before the restart are gone; new SSE subscribers
+   can connect and receive the new turn's events live.
+
+The `created` and `running` states already handle this path. The `completed` state adds
+the same spawn-on-demand behaviour so multi-turn sessions work seamlessly across restarts.
+
+A `failed` or `cancelled` session must first be explicitly reopened (see Issue Lifecycle
+Spec, `ns2 issue reopen`) before accepting new messages.
+
+## Server-Restart Orphan Recovery
+
+On `serve()` startup, before accepting any requests, the server performs an orphan sweep:
+
+1. Query the DB for all sessions with status `running`.
+2. For each such session, the harness map is empty (cold start), so the session is
+   orphaned.
+3. Transition the session to `failed` with `updated_at = now`.
+4. If the session is linked to an issue (identified via `issues.session_id`), mark that
+   issue `failed` and append a comment:
+   ```
+   session lost on server restart
+   ```
+   The comment author is set to `"system"`.
+
+The orphan sweep happens synchronously (with the DB) before the HTTP listener accepts
+connections, so clients never observe a half-recovered state.
+
+## SSE Event Stream
+
+`GET /sessions/:id/events` replays history then streams live:
+
+1. Load all turns + blocks from SQLite in order.
+2. Emit `TurnStarted`, `ContentBlockStarted`, `ContentBlockDelta` (one per stored text
+   delta), `ContentBlockDone`, `TurnDone` events for each persisted turn.
+3. If the session is terminal, emit `SessionDone` and close the stream.
+4. If the session is live, subscribe to the broadcast channel and forward events as they
+   arrive.
+
+The `?last_turns=N` query parameter limits history replay to the final N turns (0 = skip
+history entirely, absent = all turns).
+
+## Concurrency Invariants
+
+- Exactly one harness runs per session at a time. The `spawning` set in `AppState` is
+  the mutex-guarded "in flight" guard that prevents two concurrent `send_message` calls
+  from both reaching the spawn path.
+- The broadcast sender and message sender are inserted into their maps atomically (under
+  a combined lock) before the spawning task yields, so late-arriving concurrent requests
+  always find the sender in the map.
+
+## Connect Sections
+
+- **harness:** `crates/harness/agent-harness.spec.md` — turn loop, context window
+  construction, tool dispatch
+- **data model:** `crates/db/data-model.spec.md` — schema, migrations, query interface
+- **architecture:** `crates/arch-tests/architecture.spec.md` — crate dependency rules
+- **issue lifecycle:** `crates/server/src/issue-lifecycle.spec.md` — issue states,
+  orphan recovery from the issue perspective

--- a/product-flows/01-server-lifecycle.spec.md
+++ b/product-flows/01-server-lifecycle.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 01: Server Lifecycle

--- a/product-flows/02-session-create-and-list.spec.md
+++ b/product-flows/02-session-create-and-list.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 02: Session Create and List

--- a/product-flows/03-bash-tool.spec.md
+++ b/product-flows/03-bash-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-24T15:24:26Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 03: Bash Tool

--- a/product-flows/04-hello-world-real.spec.md
+++ b/product-flows/04-hello-world-real.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/anthropic/src/**/*.rs
   - crates/server/src/**/*.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 04: Hello World (Real Claude API)

--- a/product-flows/05-server-not-running-errors.spec.md
+++ b/product-flows/05-server-not-running-errors.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 05: Error Handling When Server Is Down

--- a/product-flows/06-read-tool.spec.md
+++ b/product-flows/06-read-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-24T15:24:26Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 06: Read Tool

--- a/product-flows/07-multi-tool.spec.md
+++ b/product-flows/07-multi-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-24T15:24:26Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 07: Multi-Tool (Write + Read)

--- a/product-flows/08-multi-turn.spec.md
+++ b/product-flows/08-multi-turn.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/db/src/**/*.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 08: Multi-Turn Conversation

--- a/product-flows/09-agent-commands.spec.md
+++ b/product-flows/09-agent-commands.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/agents/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 09: Agent Commands

--- a/product-flows/10-spec-new.spec.md
+++ b/product-flows/10-spec-new.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/specs/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 10: Spec New

--- a/product-flows/11-spec-sync.spec.md
+++ b/product-flows/11-spec-sync.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/specs/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 11: Spec Sync

--- a/product-flows/12-spec-verify.spec.md
+++ b/product-flows/12-spec-verify.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/specs/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 12: Spec Verify

--- a/product-flows/13-issue-lifecycle.spec.md
+++ b/product-flows/13-issue-lifecycle.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-24T16:25:01Z
 ---
 
 # Flow 13: Issue Lifecycle
@@ -92,7 +92,30 @@ docker exec ns2-flow-13 bash -c 'cd /repo && ns2 issue list --status completed'
 
 Expected: the issue shows with status `completed`.
 
-### Step 7: Add a completion comment
+### Step 7: Verify the agent posted a final-turn comment automatically
+
+```bash
+docker exec ns2-flow-13 bash -c '
+  ISSUE=$(cat /tmp/issue_id.txt)
+  curl -sf "http://localhost:9876/issues/$ISSUE" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+comments = d[\"comments\"]
+agent_comments = [c for c in comments if c[\"author\"] == \"swe\"]
+print(\"Agent comments:\", len(agent_comments))
+if len(agent_comments) >= 1:
+    print(\"OK\")
+else:
+    print(\"FAIL\")
+    sys.exit(1)
+"
+'
+```
+
+Expected: `OK` — the `issue_watcher` task automatically posted the agent's final turn text
+as a comment (author = `"swe"`) before transitioning the issue to `completed`.
+
+### Step 8: Add a manual completion comment
 
 ```bash
 docker exec ns2-flow-13 bash -c 'cd /repo && ns2 issue complete --id "$(cat /tmp/issue_id.txt)" --comment "Verified: hello.txt created with correct content."'
@@ -103,7 +126,7 @@ Expected output on stderr:
 Issue <id> marked completed.
 ```
 
-### Step 8: Add a regular comment
+### Step 9: Add a regular comment
 
 ```bash
 docker exec ns2-flow-13 bash -c 'cd /repo && ns2 issue comment --id "$(cat /tmp/issue_id.txt)" --body "Good work!" --author reviewer'
@@ -122,6 +145,7 @@ Expected: command exits 0 with no error.
 - [ ] The session receives the issue title and body as the opening message
 - [ ] `ns2 issue wait --id <id>` blocks until the issue reaches a terminal state
 - [ ] `ns2 issue wait` exits 0 when the issue completes successfully
-- [ ] `ns2 issue complete --id <id> --comment "..."` adds a summary comment
+- [ ] When the session completes, the agent's final turn text is automatically posted as a comment with `author == assignee`
+- [ ] `ns2 issue complete --id <id> --comment "..."` adds a manual summary comment (in addition to the auto-posted agent comment)
 - [ ] `ns2 issue comment` adds comments with the specified author
 - [ ] Issue status transitions: open → running → completed

--- a/product-flows/13-issue-lifecycle.spec.md
+++ b/product-flows/13-issue-lifecycle.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-24T16:25:01Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 13: Issue Lifecycle

--- a/product-flows/14-issue-list-filter.spec.md
+++ b/product-flows/14-issue-list-filter.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/cli/src/main.rs
   - crates/db/src/**/*.rs
 severity: warning
-verified: 2026-04-24T15:24:20Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 14: Issue List and Filtering

--- a/product-flows/15-issue-relationships.spec.md
+++ b/product-flows/15-issue-relationships.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-24T15:24:21Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 15: Issue Relationships

--- a/product-flows/16-issue-error-cases.spec.md
+++ b/product-flows/16-issue-error-cases.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-24T15:24:21Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 16: Issue Error Cases

--- a/product-flows/17-session-wait.spec.md
+++ b/product-flows/17-session-wait.spec.md
@@ -1,7 +1,7 @@
 ---
 targets:
   - crates/cli/src/main.rs
-verified: 2026-04-24T15:24:42Z
+verified: 2026-04-25T10:02:12Z
 ---
 
 # Flow 17: Session Wait

--- a/product-flows/18-stateless-session-resume.spec.md
+++ b/product-flows/18-stateless-session-resume.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-24T16:25:01Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 18: Stateless Session Resume

--- a/product-flows/18-stateless-session-resume.spec.md
+++ b/product-flows/18-stateless-session-resume.spec.md
@@ -1,0 +1,137 @@
+---
+targets:
+  - crates/server/src/**/*.rs
+  - crates/harness/src/**/*.rs
+  - crates/db/src/**/*.rs
+  - crates/types/src/**/*.rs
+severity: warning
+verified: 2026-04-24T16:25:01Z
+---
+
+# Flow 18: Stateless Session Resume
+
+Verify that a `completed` session can accept new messages, that the harness reconstructs
+full conversation context from the DB (no in-memory dependency), and that the session
+returns to `completed` after the follow-up turn.
+
+This flow exercises the stateless-session guarantee: if a session's harness has exited,
+`send_message` spawns a fresh harness that loads all turn history from SQLite so the
+agent has full context — no in-memory conversation state is required.
+
+## Prerequisites
+
+**[Requires: ANTHROPIC_API_KEY]** — loaded from `/tmp/ns2-host.env` mounted into the
+container.
+
+## Fixture Setup
+
+```bash
+docker exec ns2-flow-18 bash /fixtures/init.sh
+docker exec ns2-flow-18 bash /fixtures/start-server.sh
+docker exec ns2-flow-18 bash /fixtures/seeded-files.sh
+```
+
+## Steps
+
+### Step 1: Start a session with an initial message
+
+```bash
+docker exec ns2-flow-18 bash -c 'cd /repo && ns2 session new --message "My secret number is 4219. Acknowledge it." > /tmp/sess.txt && cat /tmp/sess.txt'
+```
+
+Expected: a UUID printed to stdout.
+
+### Step 2: Tail until the session completes
+
+```bash
+docker exec ns2-flow-18 bash -c 'cd /repo && ns2 session tail --id "$(cat /tmp/sess.txt)"'
+```
+
+Expected: stream ends with `[done]`. The agent's response acknowledges the number `4219`.
+
+### Step 3: Confirm the session is `completed`
+
+```bash
+docker exec ns2-flow-18 bash -c 'cd /repo && ns2 session list --id "$(cat /tmp/sess.txt)" | grep completed'
+```
+
+Expected: a table row containing `completed`.
+
+### Step 4: Restart the server (simulate process restart)
+
+```bash
+docker exec ns2-flow-18 bash -c 'cd /repo && ns2 server stop && sleep 1 && ns2 server start && sleep 1'
+```
+
+Expected: server stops and restarts cleanly. The session remains `completed` in the DB.
+
+### Step 5: Confirm session is still `completed` after restart
+
+```bash
+docker exec ns2-flow-18 bash -c 'cd /repo && ns2 session list --id "$(cat /tmp/sess.txt)" | grep completed'
+```
+
+Expected: still `completed`. The restart does not change a completed session's status.
+
+### Step 6: Send a follow-up message to the completed session
+
+```bash
+docker exec ns2-flow-18 bash -c 'cd /repo && ns2 session send --id "$(cat /tmp/sess.txt)" --message "What was the secret number I told you?"'
+```
+
+Expected: exits 0. The server accepts the message on a `completed` session and spawns a
+fresh harness that loads history from the DB.
+
+### Step 7: Tail the session to see the second turn
+
+```bash
+docker exec ns2-flow-18 bash -c 'cd /repo && ns2 session tail --id "$(cat /tmp/sess.txt)"'
+```
+
+Expected: the tail replays the first run's events, then shows a second set of turn events
+ending with `[done]`. The agent's second response must reference `4219` — it retrieved
+this from the DB-reconstructed conversation history, not from any in-memory state (the
+harness was cold-started after the server restart).
+
+### Step 8: Confirm session is `completed` again
+
+```bash
+docker exec ns2-flow-18 bash -c 'cd /repo && ns2 session list --id "$(cat /tmp/sess.txt)" | grep completed'
+```
+
+Expected: `completed`. The session returned to terminal state after the second turn.
+
+### Step 9: Verify `session send` on a `failed` session returns an error
+
+```bash
+docker exec ns2-flow-18 bash -c '
+  cd /repo
+  SESS=$(ns2 session new --message "test" )
+  sleep 2
+  # Force status to failed via admin PATCH
+  curl -sf -X PATCH "http://localhost:9876/sessions/$SESS/status" \
+    -H "Content-Type: application/json" \
+    -d "{\"status\":\"failed\"}" > /dev/null
+  ns2 session send --id "$SESS" --message "should fail"
+  echo "Exit: $?"
+'
+```
+
+Expected: a non-zero exit code (e.g., `Exit: 1`) and an error message on stderr indicating
+the session cannot accept messages in its current state.
+
+## Acceptance Criteria
+
+- [ ] `session send` on a `completed` session returns 200 (not 4xx)
+- [ ] A fresh harness is spawned that loads full turn history from SQLite
+- [ ] The second turn's response references context from the first turn (proving DB
+      reconstruction, not in-memory state)
+- [ ] The session transitions back to `running` while the second turn is in progress
+- [ ] The session returns to `completed` after the second turn finishes
+- [ ] A `completed` session's status is not changed by a server restart (no orphan sweep
+      for terminal sessions)
+- [ ] `session send` on a `failed` session returns a non-2xx status
+
+## Cleanup
+
+Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/19-orphan-recovery-and-reopen.spec.md
+++ b/product-flows/19-orphan-recovery-and-reopen.spec.md
@@ -1,0 +1,223 @@
+---
+targets:
+  - crates/server/src/**/*.rs
+  - crates/db/src/**/*.rs
+  - crates/types/src/**/*.rs
+  - crates/cli/src/**/*.rs
+verified: 2026-04-25T10:02:12Z
+---
+
+# Flow 19: Server Restart Orphan Recovery and Issue Reopen
+
+Verify that issues whose linked session was `running` at the time of a server restart are
+automatically recovered to `failed` with a system comment, and that `ns2 issue reopen`
+moves a `failed` issue back to `open` so work can resume.
+
+No API key is required — sessions are created with an initial message but the stub client
+is used (no `ANTHROPIC_API_KEY` in the environment).
+
+## Prerequisites
+
+No API key required. The server is started without `ANTHROPIC_API_KEY`; the stub client
+is used — sessions with an initial message will reach `completed` quickly. To reliably
+test orphan recovery we freeze a session in `running` state using the admin PATCH endpoint
+before restarting.
+
+## Fixture Setup
+
+```bash
+docker exec ns2-flow-19 bash /fixtures/init.sh
+docker exec ns2-flow-19 bash /fixtures/start-server.sh
+```
+
+Create an agent type:
+
+```bash
+docker exec ns2-flow-19 bash -c 'cd /repo && ns2 agent new --name "swe" --description "Software engineer" --body "You are a software engineer."'
+```
+
+## Steps
+
+### Step 1: Create an issue and start it
+
+```bash
+docker exec ns2-flow-19 bash -c 'cd /repo && ns2 issue new --title "Orphan test" --body "This issue will be orphaned" --assignee swe | tee /tmp/issue.txt'
+```
+
+Expected: a 4-character issue ID.
+
+```bash
+docker exec ns2-flow-19 bash -c 'cd /repo && ns2 issue start --id "$(cat /tmp/issue.txt)"'
+```
+
+Expected: `Started session <uuid> for issue <id>` on stderr. Issue is now `running`.
+
+### Step 2: Allow the stub session to complete, then freeze issue back to `running`
+
+```bash
+docker exec ns2-flow-19 bash -c 'sleep 2 && cd /repo && ns2 issue list --id "$(cat /tmp/issue.txt)"'
+```
+
+Expected: issue shows `completed` (stub client ran). Now we manually force it back to
+`running` with its session ID to simulate a mid-flight restart:
+
+```bash
+docker exec ns2-flow-19 bash -c '
+  ISSUE=$(cat /tmp/issue.txt)
+  # Look up the session ID from the issue record
+  SESS=$(curl -sf "http://localhost:9876/issues/$ISSUE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[\"session_id\"])")
+  echo "$SESS" > /tmp/sess.txt
+  # Force the issue back to running so orphan recovery has something to find
+  curl -sf -X PATCH "http://localhost:9876/issues/$ISSUE/status" \
+    -H "Content-Type: application/json" \
+    -d "{\"status\":\"running\"}" > /dev/null
+  # Force the session back to running
+  curl -sf -X PATCH "http://localhost:9876/sessions/$SESS/status" \
+    -H "Content-Type: application/json" \
+    -d "{\"status\":\"running\"}" > /dev/null
+  echo "Forced to running"
+'
+```
+
+Expected: `Forced to running`.
+
+### Step 3: Restart the server
+
+```bash
+docker exec ns2-flow-19 bash -c 'cd /repo && ns2 server stop && sleep 1 && ns2 server start && sleep 1'
+```
+
+Expected: server stops and restarts cleanly.
+
+### Step 4: Verify orphaned session is now `failed`
+
+```bash
+docker exec ns2-flow-19 bash -c 'cd /repo && ns2 session list --id "$(cat /tmp/sess.txt)" | grep failed'
+```
+
+Expected: a table row containing `failed`. The orphan sweep ran on startup and marked the
+`running` session `failed`.
+
+### Step 5: Verify orphaned issue is now `failed`
+
+```bash
+docker exec ns2-flow-19 bash -c 'cd /repo && ns2 issue list --id "$(cat /tmp/issue.txt)" | grep failed'
+```
+
+Expected: a table row containing `failed`. The orphan sweep also marked the linked issue
+`failed`.
+
+### Step 6: Verify the system comment was posted on the issue
+
+```bash
+docker exec ns2-flow-19 bash -c '
+  ISSUE=$(cat /tmp/issue.txt)
+  curl -sf "http://localhost:9876/issues/$ISSUE" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+comments = d[\"comments\"]
+found = any(\"session lost on server restart\" in c[\"body\"] for c in comments)
+print(\"FOUND\" if found else \"NOT FOUND\")
+print(\"Comments:\", json.dumps(comments, indent=2))
+"
+'
+```
+
+Expected: `FOUND` — at least one comment with body containing `session lost on server restart`.
+
+### Step 7: Reopen the failed issue
+
+```bash
+docker exec ns2-flow-19 bash -c 'cd /repo && ns2 issue reopen --id "$(cat /tmp/issue.txt)"'
+```
+
+Expected: exits 0 with output on stderr:
+```
+Issue <id> reopened.
+```
+
+### Step 8: Verify issue is now `open`
+
+```bash
+docker exec ns2-flow-19 bash -c 'cd /repo && ns2 issue list --id "$(cat /tmp/issue.txt)" | grep open'
+```
+
+Expected: a table row containing `open`. The `session_id` link has been cleared.
+
+### Step 9: Verify existing comments are preserved after reopen
+
+```bash
+docker exec ns2-flow-19 bash -c '
+  ISSUE=$(cat /tmp/issue.txt)
+  curl -sf "http://localhost:9876/issues/$ISSUE" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+comments = d[\"comments\"]
+found = any(\"session lost on server restart\" in c[\"body\"] for c in comments)
+print(\"PRESERVED\" if found else \"LOST\")
+"
+'
+```
+
+Expected: `PRESERVED` — the system comment added during orphan recovery is still present.
+
+### Step 10: Error — reopen a non-failed issue
+
+```bash
+docker exec ns2-flow-19 bash -c '
+  cd /repo
+  ID=$(ns2 issue new --title "Open issue" --body "Still open" --assignee swe)
+  ns2 issue reopen --id "$ID"
+  echo "Exit: $?"
+'
+```
+
+Expected: error message on stderr (e.g., `Error: issue <id> is not in failed state`) and
+non-zero exit code.
+
+### Step 11: Error — reopen a nonexistent issue
+
+```bash
+docker exec ns2-flow-19 bash -c 'cd /repo && ns2 issue reopen --id "zzzz"; echo "Exit: $?"'
+```
+
+Expected: `Error: issue not found: zzzz` on stderr and non-zero exit code.
+
+### Step 12: Verify non-`running` sessions are not affected by orphan sweep
+
+```bash
+docker exec ns2-flow-19 bash -c '
+  cd /repo
+  # Create a completed session
+  SESS=$(ns2 session new --message "hello")
+  sleep 2
+  # Restart the server
+  ns2 server stop && sleep 1 && ns2 server start && sleep 1
+  # The completed session should remain completed
+  ns2 session list --id "$SESS" | grep -v running | grep -v failed
+  echo "Exit: $?"
+'
+```
+
+Expected: the session row shows `completed` (or `created` if the stub did not run), not
+`failed`. Only `running` sessions are swept.
+
+## Acceptance Criteria
+
+- [ ] On server restart, sessions with status `running` are transitioned to `failed`
+- [ ] Issues linked to swept sessions are transitioned to `failed`
+- [ ] A system comment `"session lost on server restart"` is posted on each affected issue
+- [ ] Sessions in `completed`, `created`, `cancelled`, or `failed` status are not affected
+      by the orphan sweep
+- [ ] `ns2 issue reopen --id <id>` transitions a `failed` issue to `open`
+- [ ] `ns2 issue reopen` prints `Issue <id> reopened.` on stderr and exits 0
+- [ ] `ns2 issue reopen` clears the `session_id` link on the issue
+- [ ] `ns2 issue reopen` preserves all existing comments
+- [ ] `ns2 issue reopen` fails with a clear error if the issue is not in `failed` state
+- [ ] `ns2 issue reopen` fails with `Error: issue not found: <id>` for unknown IDs
+- [ ] `POST /issues/:id/reopen` endpoint (or equivalent) is exposed for CLI use
+- [ ] `PATCH /issues/:id/status` endpoint accepts status values for test control
+
+## Cleanup
+
+Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/20-auto-complete-posts-comment.spec.md
+++ b/product-flows/20-auto-complete-posts-comment.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-24T16:25:01Z
+verified: 2026-04-25T10:03:20Z
 ---
 
 # Flow 20: Auto-Complete Posts Final Turn as Comment

--- a/product-flows/20-auto-complete-posts-comment.spec.md
+++ b/product-flows/20-auto-complete-posts-comment.spec.md
@@ -1,0 +1,210 @@
+---
+targets:
+  - crates/server/src/**/*.rs
+  - crates/db/src/**/*.rs
+  - crates/types/src/**/*.rs
+severity: warning
+verified: 2026-04-24T16:25:01Z
+---
+
+# Flow 20: Auto-Complete Posts Final Turn as Comment
+
+When an agent session linked to an issue finishes, the `issue_watcher` task automatically:
+1. Collects the final turn's text content as it streams.
+2. Posts that text as a comment on the issue (author = agent name).
+3. Transitions the issue to `completed`.
+
+This flow also verifies that on session error, the error message is posted as a comment
+and the issue is transitioned to `failed`.
+
+## Prerequisites
+
+**[Requires: ANTHROPIC_API_KEY]** — loaded from `/tmp/ns2-host.env` mounted into the
+container.
+
+## Fixture Setup
+
+```bash
+docker exec ns2-flow-20 bash /fixtures/init.sh
+docker exec ns2-flow-20 bash /fixtures/start-server.sh
+```
+
+Create agent types:
+
+```bash
+docker exec ns2-flow-20 bash -c 'cd /repo && ns2 agent new --name "swe" --description "Software engineer" --body "You are a software engineer. Respond concisely and always end your response with the exact phrase: TASK COMPLETE."'
+```
+
+## Steps
+
+### Step 1: Create an issue and start it
+
+```bash
+docker exec ns2-flow-20 bash -c 'cd /repo && ns2 issue new --title "Write greeting" --body "Write a single sentence greeting for the user. End your response with TASK COMPLETE." --assignee swe | tee /tmp/issue.txt'
+```
+
+Expected: a 4-character issue ID.
+
+```bash
+docker exec ns2-flow-20 bash -c 'cd /repo && ns2 issue start --id "$(cat /tmp/issue.txt)"'
+```
+
+Expected: `Started session <uuid> for issue <id>` on stderr.
+
+### Step 2: Wait for the issue to complete
+
+```bash
+docker exec ns2-flow-20 bash -c 'cd /repo && ns2 issue wait --id "$(cat /tmp/issue.txt)"'
+```
+
+Expected: exits 0. The issue reached `completed`.
+
+### Step 3: Verify issue is `completed`
+
+```bash
+docker exec ns2-flow-20 bash -c 'cd /repo && ns2 issue list --id "$(cat /tmp/issue.txt)" | grep completed'
+```
+
+Expected: a table row containing `completed`.
+
+### Step 4: Verify the agent posted its final turn as a comment
+
+```bash
+docker exec ns2-flow-20 bash -c '
+  ISSUE=$(cat /tmp/issue.txt)
+  curl -sf "http://localhost:9876/issues/$ISSUE" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+comments = d[\"comments\"]
+print(\"Comment count:\", len(comments))
+for c in comments:
+    print(\"  Author:\", c[\"author\"])
+    print(\"  Body preview:\", c[\"body\"][:120])
+    print()
+agent_comments = [c for c in comments if c[\"author\"] == \"swe\"]
+print(\"Agent comments:\", len(agent_comments))
+has_task_complete = any(\"TASK COMPLETE\" in c[\"body\"] for c in agent_comments)
+print(\"Contains TASK COMPLETE:\", has_task_complete)
+"
+'
+```
+
+Expected output (values will vary):
+```
+Comment count: 1
+  Author: swe
+  Body preview: Hello! Wishing you a wonderful day ahead. TASK COMPLETE
+
+Agent comments: 1
+Contains TASK COMPLETE: True
+```
+
+There must be at least one comment with `author == "swe"` containing the agent's final
+turn text, including the phrase `TASK COMPLETE`.
+
+### Step 5: Verify comment was posted before status transition
+
+```bash
+docker exec ns2-flow-20 bash -c '
+  ISSUE=$(cat /tmp/issue.txt)
+  curl -sf "http://localhost:9876/issues/$ISSUE" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+status = d[\"status\"]
+comments = d[\"comments\"]
+agent_comments = [c for c in comments if c[\"author\"] == \"swe\"]
+print(\"Status:\", status)
+print(\"Agent comments present:\", len(agent_comments) > 0)
+# Both status is completed AND agent comment exists — proves comment was written first
+if status == \"completed\" and len(agent_comments) > 0:
+    print(\"OK: comment posted before completion\")
+else:
+    print(\"FAIL\")
+    sys.exit(1)
+"
+'
+```
+
+Expected: `OK: comment posted before completion`.
+
+### Step 6: Create a second issue to test multi-word agent names
+
+```bash
+docker exec ns2-flow-20 bash -c 'cd /repo && ns2 agent new --name "qa-tester" --description "QA tester" --body "You are a QA tester. Respond concisely. End with: QA DONE."'
+docker exec ns2-flow-20 bash -c 'cd /repo && ns2 issue new --title "Review greeting" --body "Confirm the greeting is polite. End your response with QA DONE." --assignee qa-tester | tee /tmp/issue2.txt'
+docker exec ns2-flow-20 bash -c 'cd /repo && ns2 issue start --id "$(cat /tmp/issue2.txt)"'
+docker exec ns2-flow-20 bash -c 'cd /repo && ns2 issue wait --id "$(cat /tmp/issue2.txt)"'
+```
+
+Expected: exits 0.
+
+### Step 7: Verify comment author matches assignee for second issue
+
+```bash
+docker exec ns2-flow-20 bash -c '
+  ISSUE=$(cat /tmp/issue2.txt)
+  curl -sf "http://localhost:9876/issues/$ISSUE" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+comments = d[\"comments\"]
+agent_comments = [c for c in comments if c[\"author\"] == \"qa-tester\"]
+print(\"qa-tester comments:\", len(agent_comments))
+has_qa_done = any(\"QA DONE\" in c[\"body\"] for c in agent_comments)
+print(\"Contains QA DONE:\", has_qa_done)
+if len(agent_comments) > 0 and has_qa_done:
+    print(\"OK\")
+else:
+    print(\"FAIL\")
+    sys.exit(1)
+"
+'
+```
+
+Expected: `OK` — the comment author is `qa-tester`, matching the issue's assignee.
+
+### Step 8: Verify only the final turn's text is posted (not intermediate turns)
+
+```bash
+docker exec ns2-flow-20 bash -c '
+  # Create an issue that requires a tool call (multi-turn within one session run)
+  cd /repo
+  ID=$(ns2 issue new --title "Count words" --body "Use bash to run: echo hello world | wc -w   Report the result. End with: COUNTED." --assignee swe)
+  ns2 issue start --id "$ID"
+  ns2 issue wait --id "$ID"
+  curl -sf "http://localhost:9876/issues/$ID" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+comments = d[\"comments\"]
+agent_comments = [c for c in comments if c[\"author\"] == \"swe\"]
+print(\"Agent comment count:\", len(agent_comments))
+# Should be exactly 1 comment (only the final text turn, not tool_use blocks)
+if len(agent_comments) == 1:
+    print(\"OK: exactly 1 agent comment\")
+else:
+    print(\"FAIL: expected 1, got\", len(agent_comments))
+    sys.exit(1)
+"
+'
+```
+
+Expected: `OK: exactly 1 agent comment`. Only the final prose response is posted — tool
+calls and tool results do not produce separate comments.
+
+## Acceptance Criteria
+
+- [ ] When a session linked to an issue completes, the agent's final turn text is
+      automatically posted as a comment on the issue
+- [ ] The comment `author` equals the issue's `assignee` field
+- [ ] The comment is persisted before the issue status transitions to `completed`
+- [ ] Only the final turn's text content is posted (tool calls/results are excluded)
+- [ ] `ContentBlockDelta { TextDelta }` events are accumulated into the current turn buffer
+- [ ] `TurnDone` saves the buffer as `last_turn_text` and resets the buffer
+- [ ] `SessionDone` posts `last_turn_text` as a comment, then marks issue `completed`
+- [ ] `Error { message }` posts the error message as a comment (author = `"system"`),
+      then marks the issue `failed`
+- [ ] The auto-complete comment is in addition to (not a replacement for) any manual
+      comments added via `ns2 issue comment`
+
+## Cleanup
+
+Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.


### PR DESCRIPTION
## Summary

- **Stateless session resume**: completed sessions now accept new messages; a fresh harness loads full turn history from SQLite so conversations pick up seamlessly across server restarts
- **Orphan recovery**: startup sweep marks any `running` sessions/issues as `failed` with a system comment — no permanently stuck issues after a crash or restart
- **Auto-complete comments**: `issue_watcher` posts the agent's final turn text as a comment before completing the issue; errors post as system comments before failing
- **`issue reopen`** accepts both `failed` and `completed` issues — failed clears `session_id` (fresh session), completed keeps it (history resume); `--comment` flag appends context before transition
- **`--start` flag** on `issue new` and `issue reopen` for one-step create-and-kick-off
- New spec files: `session-lifecycle.spec.md`, `issue-lifecycle.spec.md` in `crates/server/src/`
- New product flows 18, 19, 20 covering resume, orphan recovery/reopen, and auto-complete

Closes #14, #27, #30.

## Test plan
- [ ] `cargo test` passes (274 tests, 0 failed)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Restart server after merging — stale `running` issues from previous sessions sweep to `failed`
- [ ] `ns2 issue reopen --id <completed-id> --comment "..." --start` resumes with history
- [ ] `ns2 issue new --title "..." --assignee swe --start` creates and starts in one command

🤖 Generated with [Claude Code](https://claude.com/claude-code)