### PR TITLE
Add hooks, project config inheritance, and commit-guard stop hook (GH #32, #33, #34)

### DIFF
--- a/.claude/hooks/stop-commit-guard.sh
+++ b/.claude/hooks/stop-commit-guard.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Stop hook: blocks agent completion when there are uncommitted changes.
+# Reads a JSON payload from stdin (e.g. {"session_id": "..."}).
+# Exits 0 if working tree is clean; exits 1 with instructions if dirty.
+
+INPUT=$(cat)  # consume stdin (not currently used, but required by hook protocol)
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+
+if [ -z "$REPO_ROOT" ]; then
+    echo "stop-commit-guard: could not determine repo root" >&2
+    exit 0  # fail open if we can't determine root
+fi
+
+STATUS=$(git -C "$REPO_ROOT" status --short 2>/dev/null)
+
+if [ -n "$STATUS" ]; then
+    echo "You have uncommitted changes. Please commit your work before stopping."
+    echo ""
+    echo "Uncommitted changes:"
+    echo "$STATUS"
+    exit 1
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop-commit-guard.sh",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }

--- a/.ns2/agents/code-review.md
+++ b/.ns2/agents/code-review.md
@@ -1,6 +1,7 @@
 ---
 name: code-review
 description: Code review covering architecture adherence, testability, test coverage, and code quality.
+include_project_config: true
 ---
 
 

--- a/.ns2/agents/product-manager.md
+++ b/.ns2/agents/product-manager.md
@@ -1,6 +1,7 @@
 ---
 name: product-manager
 description: Plans product flows and drives implementation: creates/updates product-flows/ specs, then coordinates swe, code-review, and smoke-test agents via ns2 issues.
+include_project_config: true
 ---
 
 You are a product manager for ns2, a session-based agent orchestration tool.

--- a/.ns2/agents/qa-tester.md
+++ b/.ns2/agents/qa-tester.md
@@ -1,6 +1,7 @@
 ---
 name: qa-tester
 description: Run a single product-flow inside a Docker container and report findings with a critical QA lens.
+include_project_config: true
 ---
 
 You are a critical QA tester. Execute one product-flow exactly as written and report what you observe. Your message contains a `Container: ns2-flow-NN` and a `.spec.md`, outlining which flow to test and where the testing environment is.

--- a/.ns2/agents/smoke-tester.md
+++ b/.ns2/agents/smoke-tester.md
@@ -1,6 +1,7 @@
 ---
 name: smoke-tester
 description: Run product-flow manual tests in parallel Docker containers, one per flow.
+include_project_config: true
 ---
 
 You are an orchestrator for QA testing flows outlined in `product-flows/`. Your job is to set up Docker containers, dispatch `qa-tester` subagents in parallel, collect their reports, and summarise results. You do not run flows yourself.

--- a/.ns2/agents/swe.md
+++ b/.ns2/agents/swe.md
@@ -1,6 +1,7 @@
 ---
 name: swe
 description: Software engineer for the ns2 Rust workspace. Implements features using TDD and the project architecture.
+include_project_config: true
 ---
 
 You are a software engineer working on the ns2 Rust workspace — a session-based agent orchestration tool.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,9 @@ version = 4
 name = "agents"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
  "tempfile",
  "tracing",
  "workspace",
@@ -871,6 +874,7 @@ dependencies = [
  "chrono",
  "db",
  "mockall",
+ "regex",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2087,6 +2091,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "server"
 version = "0.1.0"
 dependencies = [
@@ -2880,6 +2897,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 workspace = { path = "../workspace" }
 tracing = { workspace = true }
+serde = { workspace = true }
+serde_yaml = "0.9"
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -1,7 +1,136 @@
+use serde::Deserialize;
+
+// ── Hook types ───────────────────────────────────────────────────────────────
+
+/// A single hook command with an optional timeout.
+#[derive(Debug, Clone)]
+pub struct HookCommand {
+    pub command: String,
+    /// Timeout in seconds; defaults to 60.
+    pub timeout: u64,
+}
+
+/// One hook entry: an optional matcher regex (None for Stop hooks) + a list of commands.
+#[derive(Debug, Clone)]
+pub struct HookEntry {
+    /// `None` for Stop hooks; regex string for tool hooks.
+    pub matcher: Option<String>,
+    pub hooks: Vec<HookCommand>,
+}
+
+/// All lifecycle hooks declared for an agent.
+#[derive(Debug, Clone, Default)]
+pub struct AgentHooks {
+    pub pre_tool_use: Vec<HookEntry>,
+    pub post_tool_use: Vec<HookEntry>,
+    pub stop: Vec<HookEntry>,
+}
+
+// ── YAML deserialization helpers (private) ────────────────────────────────────
+
+/// Raw serde shape for the `hooks:` sub-block from frontmatter.
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct RawHooks {
+    #[serde(rename = "PreToolUse")]
+    pre_tool_use: Vec<RawHookEntry>,
+    #[serde(rename = "PostToolUse")]
+    post_tool_use: Vec<RawHookEntry>,
+    #[serde(rename = "Stop")]
+    stop: Vec<RawHookEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawHookEntry {
+    matcher: Option<String>,
+    #[serde(default)]
+    hooks: Vec<RawHookCommand>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawHookCommand {
+    command: String,
+    #[serde(default = "default_timeout")]
+    timeout: u64,
+}
+
+fn default_timeout() -> u64 {
+    60
+}
+
+/// Parse a `hooks:` YAML sub-block extracted from frontmatter into `AgentHooks`.
+fn parse_hooks_yaml(yaml_block: &str) -> AgentHooks {
+    let raw: RawHooks = serde_yaml::from_str(yaml_block).unwrap_or_default();
+
+    let convert_entries = |entries: Vec<RawHookEntry>| -> Vec<HookEntry> {
+        entries
+            .into_iter()
+            .map(|e| HookEntry {
+                matcher: e.matcher,
+                hooks: e
+                    .hooks
+                    .into_iter()
+                    .map(|c| HookCommand { command: c.command, timeout: c.timeout })
+                    .collect(),
+            })
+            .collect()
+    };
+
+    AgentHooks {
+        pre_tool_use: convert_entries(raw.pre_tool_use),
+        post_tool_use: convert_entries(raw.post_tool_use),
+        stop: convert_entries(raw.stop),
+    }
+}
+
+/// Extract the indented sub-block that follows a `hooks:` key at the top level
+/// of YAML frontmatter. Returns `None` if `hooks:` is not present.
+///
+/// Strategy: scan frontmatter lines for `hooks:` at column 0, then collect all
+/// subsequent lines that start with whitespace (are indented) until we hit the
+/// next top-level key (non-whitespace, non-empty line) or end of input.
+/// The sub-block is returned without the `hooks:` prefix so it can be parsed
+/// directly by `serde_yaml`.
+fn extract_hooks_subblock(frontmatter: &str) -> Option<String> {
+    let mut lines = frontmatter.lines().peekable();
+    // Find `hooks:` at the top level
+    while let Some(line) = lines.next() {
+        if line == "hooks:" || line.starts_with("hooks: ") {
+            // Collect indented lines
+            let mut sub_lines: Vec<&str> = Vec::new();
+            while let Some(&next) = lines.peek() {
+                // A top-level key starts with a non-whitespace, non-empty character
+                if !next.is_empty() && !next.starts_with(' ') && !next.starts_with('\t') {
+                    break;
+                }
+                sub_lines.push(lines.next().unwrap());
+            }
+            if sub_lines.is_empty() {
+                return None;
+            }
+            // Determine the minimum indentation so we can de-indent
+            let min_indent = sub_lines
+                .iter()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| l.len() - l.trim_start().len())
+                .min()
+                .unwrap_or(0);
+            let dedented: Vec<&str> =
+                sub_lines.iter().map(|l| if l.len() >= min_indent { &l[min_indent..] } else { l }).collect();
+            return Some(dedented.join("\n"));
+        }
+    }
+    None
+}
+
+// ── AgentDef ─────────────────────────────────────────────────────────────────
+
 pub struct AgentDef {
     pub name: String,
     pub description: String,
     pub body: String,
+    pub include_project_config: bool,
+    pub hooks: AgentHooks,
 }
 
 pub fn agents_dir() -> Option<std::path::PathBuf> {
@@ -21,15 +150,30 @@ pub fn parse_agent_content(content: &str) -> Option<AgentDef> {
 
     let mut name = None;
     let mut description = String::new();
+    let mut include_project_config = false;
+
     for line in frontmatter.lines() {
         if let Some(v) = line.strip_prefix("name: ") {
             name = Some(v.trim().to_string());
         } else if let Some(v) = line.strip_prefix("description: ") {
             description = v.trim().to_string();
+        } else if let Some(v) = line.strip_prefix("include_project_config: ") {
+            include_project_config = v.trim() == "true";
         }
     }
 
-    Some(AgentDef { name: name?, description, body: body.to_string() })
+    // Parse hooks sub-block (if present)
+    let hooks = extract_hooks_subblock(frontmatter)
+        .map(|sub| parse_hooks_yaml(&sub))
+        .unwrap_or_default();
+
+    Some(AgentDef {
+        name: name?,
+        description,
+        body: body.to_string(),
+        include_project_config,
+        hooks,
+    })
 }
 
 /// Format an agent definition as a frontmatter `.md` file.
@@ -37,7 +181,56 @@ pub fn parse_agent_content(content: &str) -> Option<AgentDef> {
 /// fields will produce malformed frontmatter. Callers (e.g. CLI flags) are responsible
 /// for ensuring single-line values.
 pub fn format_agent_file(def: &AgentDef) -> String {
-    format!("---\nname: {}\ndescription: {}\n---\n\n{}", def.name, def.description, def.body)
+    let mut frontmatter = format!("---\nname: {}\ndescription: {}", def.name, def.description);
+    if def.include_project_config {
+        frontmatter.push_str("\ninclude_project_config: true");
+    }
+
+    // Serialize hooks if non-empty
+    let hooks_yaml = format_hooks(&def.hooks);
+    if !hooks_yaml.is_empty() {
+        frontmatter.push_str("\nhooks:");
+        frontmatter.push_str(&hooks_yaml);
+    }
+
+    frontmatter.push_str("\n---\n\n");
+    frontmatter.push_str(&def.body);
+    frontmatter
+}
+
+/// Serialize `AgentHooks` to indented YAML lines (without the `hooks:` key itself).
+/// Returns an empty string if there are no hooks.
+fn format_hooks(hooks: &AgentHooks) -> String {
+    let mut out = String::new();
+
+    let write_entries = |out: &mut String, event: &str, entries: &[HookEntry]| {
+        if entries.is_empty() {
+            return;
+        }
+        out.push_str(&format!("\n  {event}:"));
+        for entry in entries {
+            out.push_str("\n    - ");
+            if let Some(ref m) = entry.matcher {
+                out.push_str(&format!("matcher: \"{m}\""));
+                out.push_str("\n      hooks:");
+            } else {
+                out.push_str("hooks:");
+            }
+            for cmd in &entry.hooks {
+                out.push_str("\n        - type: command");
+                out.push_str(&format!("\n          command: {}", cmd.command));
+                if cmd.timeout != 60 {
+                    out.push_str(&format!("\n          timeout: {}", cmd.timeout));
+                }
+            }
+        }
+    };
+
+    write_entries(&mut out, "PreToolUse", &hooks.pre_tool_use);
+    write_entries(&mut out, "PostToolUse", &hooks.post_tool_use);
+    write_entries(&mut out, "Stop", &hooks.stop);
+
+    out
 }
 
 pub fn load_agent(dir: &std::path::Path, name: &str) -> Option<AgentDef> {
@@ -78,9 +271,169 @@ pub fn write_agent(dir: &std::path::Path, def: &AgentDef) -> std::io::Result<()>
     std::fs::write(dir.join(format!("{}.md", def.name)), format_agent_file(def))
 }
 
+/// Load the project CLAUDE.md and resolve any `@path/to/file.md` imports within it.
+///
+/// - Reads `{git_root}/CLAUDE.md`; returns `None` and prints a warning if missing.
+/// - Scans each line for `@(\S+\.md)` patterns; for each unique path (in order),
+///   reads `{git_root}/{path}`. On failure, prints a warning and skips.
+/// - Returns concatenation: CLAUDE.md content + `\n\n` + each imported file's content,
+///   separated by `\n\n`.
+pub fn load_project_config(git_root: &std::path::Path) -> Option<String> {
+    let claude_path = git_root.join("CLAUDE.md");
+    let claude_content = match std::fs::read_to_string(&claude_path) {
+        Ok(c) => c,
+        Err(_) => {
+            eprintln!("warning: CLAUDE.md not found at {}", claude_path.display());
+            return None;
+        }
+    };
+
+    // Collect @-imports: find all `@<something>.md` patterns, deduped in order.
+    let mut seen = std::collections::HashSet::new();
+    let mut imports: Vec<String> = Vec::new();
+    for line in claude_content.lines() {
+        let mut rest = line;
+        while let Some(at_pos) = rest.find('@') {
+            let after_at = &rest[at_pos + 1..];
+            // Extract the path: non-whitespace characters ending with `.md`
+            let path_candidate: String =
+                after_at.chars().take_while(|c| !c.is_whitespace()).collect();
+            if path_candidate.ends_with(".md")
+                    && !path_candidate.is_empty()
+                    && seen.insert(path_candidate.clone())
+                {
+                    imports.push(path_candidate);
+                }
+            // Advance past the `@` we just processed
+            rest = &rest[at_pos + 1..];
+        }
+    }
+
+    // Load each imported file
+    let mut parts: Vec<String> = vec![claude_content];
+    for import_path in &imports {
+        let full_path = git_root.join(import_path);
+        match std::fs::read_to_string(&full_path) {
+            Ok(content) => parts.push(content),
+            Err(_) => {
+                eprintln!(
+                    "warning: could not read @-import '{}' ({})",
+                    import_path,
+                    full_path.display()
+                );
+            }
+        }
+    }
+
+    Some(parts.join("\n\n"))
+}
+
+/// Load hooks from `{git_root}/.claude/settings.json`.
+///
+/// The settings.json format mirrors Claude Code's hook schema:
+/// ```json
+/// {
+///   "hooks": {
+///     "PreToolUse": [ { "matcher": "...", "hooks": [{"type":"command","command":"...","timeout":N}] } ],
+///     "PostToolUse": [ ... ],
+///     "Stop":        [ { "hooks": [...] } ]
+///   }
+/// }
+/// ```
+///
+/// Returns `AgentHooks::default()` if the file is absent, unreadable, or has no `hooks` key.
+/// Any parse error is logged as a warning to stderr and returns default.
+pub fn load_project_hooks(git_root: &std::path::Path) -> AgentHooks {
+    let path = git_root.join(".claude").join("settings.json");
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return AgentHooks::default(),
+    };
+
+    let value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("warning: failed to parse {}: {e}", path.display());
+            return AgentHooks::default();
+        }
+    };
+
+    let hooks_value = match value.get("hooks") {
+        Some(h) => h,
+        None => return AgentHooks::default(),
+    };
+
+    // Deserialise via the same RawHooks shape used for YAML frontmatter.
+    let raw: RawHooks = match serde_json::from_value(hooks_value.clone()) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("warning: failed to parse hooks in {}: {e}", path.display());
+            return AgentHooks::default();
+        }
+    };
+
+    let convert_entries = |entries: Vec<RawHookEntry>| -> Vec<HookEntry> {
+        entries
+            .into_iter()
+            .map(|e| HookEntry {
+                matcher: e.matcher,
+                hooks: e
+                    .hooks
+                    .into_iter()
+                    .map(|c| HookCommand { command: c.command, timeout: c.timeout })
+                    .collect(),
+            })
+            .collect()
+    };
+
+    AgentHooks {
+        pre_tool_use: convert_entries(raw.pre_tool_use),
+        post_tool_use: convert_entries(raw.post_tool_use),
+        stop: convert_entries(raw.stop),
+    }
+}
+
+/// Merge `agent` hooks with `project` hooks.
+///
+/// Strategy for each event type (pre_tool_use, post_tool_use, stop):
+/// 1. Start with all agent entries as-is.
+/// 2. For each project entry, append it only if no agent entry has the same matcher value.
+///    (Agent entries always win for matching matchers.)
+pub fn merge_hooks(agent: AgentHooks, project: AgentHooks) -> AgentHooks {
+    let merge_entries = |mut base: Vec<HookEntry>, additions: Vec<HookEntry>| -> Vec<HookEntry> {
+        for proj_entry in additions {
+            // Check whether any agent entry has the same matcher
+            let duplicate = base.iter().any(|a| a.matcher == proj_entry.matcher);
+            if !duplicate {
+                base.push(proj_entry);
+            }
+        }
+        base
+    };
+
+    AgentHooks {
+        pre_tool_use: merge_entries(agent.pre_tool_use, project.pre_tool_use),
+        post_tool_use: merge_entries(agent.post_tool_use, project.post_tool_use),
+        stop: merge_entries(agent.stop, project.stop),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn make_def_no_hooks(name: &str) -> AgentDef {
+        AgentDef {
+            name: name.to_string(),
+            description: "desc".to_string(),
+            body: "body".to_string(),
+            include_project_config: false,
+            hooks: AgentHooks::default(),
+        }
+    }
 
     // ── Tests moved from cli ─────────────────────────────────────────────────
 
@@ -127,6 +480,8 @@ mod tests {
             name: "coding".to_string(),
             description: "A coding agent".to_string(),
             body: "You are a coding agent.".to_string(),
+            include_project_config: false,
+            hooks: AgentHooks::default(),
         };
         let formatted = format_agent_file(&def);
         let parsed = parse_agent_content(&formatted).unwrap();
@@ -145,6 +500,8 @@ mod tests {
             name: "myagent".to_string(),
             description: "Does things".to_string(),
             body: "You are a helpful agent.".to_string(),
+            include_project_config: false,
+            hooks: AgentHooks::default(),
         };
         write_agent(dir, &def).unwrap();
         let loaded = load_agent(dir, "myagent").unwrap();
@@ -166,18 +523,8 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let dir = tmp.path();
 
-        write_agent(dir, &AgentDef {
-            name: "zebra".to_string(),
-            description: "last".to_string(),
-            body: "z body".to_string(),
-        })
-        .unwrap();
-        write_agent(dir, &AgentDef {
-            name: "alpha".to_string(),
-            description: "first".to_string(),
-            body: "a body".to_string(),
-        })
-        .unwrap();
+        write_agent(dir, &make_def_no_hooks("zebra")).unwrap();
+        write_agent(dir, &make_def_no_hooks("alpha")).unwrap();
         // Write a non-.md file that must be ignored
         std::fs::write(dir.join("ignored.txt"), "not an agent").unwrap();
 
@@ -197,13 +544,6 @@ mod tests {
 
     // ── agents_dir() path construction ──────────────────────────────────────
 
-    /// agents_dir() must agree with workspace::git_root().map(|r| r.join(".ns2").join("agents")).
-    /// When git_root() returns None (outside a git repo, e.g. in cargo-mutants temp dir),
-    /// both sides are None and the test still passes, which is fine — the mutation
-    /// `agents_dir() -> None` is indistinguishable from the real implementation outside
-    /// a git repo. The `Some(Default::default())` mutation IS distinguishable because
-    /// git_root() returns None in the temp dir so the real impl returns None too, while
-    /// the mutant would return Some(PathBuf::new()).
     #[test]
     fn agents_dir_matches_git_root_join() {
         let expected = workspace::git_root().map(|r| r.join(".ns2").join("agents"));
@@ -211,18 +551,15 @@ mod tests {
         assert_eq!(actual, expected, "agents_dir() must equal git_root().join('.ns2').join('agents')");
     }
 
-    /// agents_dir() must return an absolute path when inside a git repo.
-    /// Skip gracefully when not inside a git repo (e.g. cargo-mutants temp dir).
     #[test]
     fn agents_dir_returns_absolute_path() {
         let dir = match agents_dir() {
             Some(d) => d,
-            None => return, // not inside a git repo; skip
+            None => return,
         };
         assert!(dir.is_absolute(), "agents_dir() must return an absolute path, got: {}", dir.display());
     }
 
-    /// parse_agent_content correctly extracts the body (multi-line).
     #[test]
     fn parse_agent_content_multiline_body() {
         let content = "---\nname: multi\ndescription: test\n---\n\nLine one.\nLine two.\n";
@@ -230,19 +567,13 @@ mod tests {
         assert_eq!(def.body, "Line one.\nLine two.");
     }
 
-    /// format_agent_file produces a string that starts with "---\n".
     #[test]
     fn format_agent_file_starts_with_frontmatter_delimiter() {
-        let def = AgentDef {
-            name: "agent".to_string(),
-            description: "desc".to_string(),
-            body: "body text".to_string(),
-        };
+        let def = make_def_no_hooks("agent");
         let formatted = format_agent_file(&def);
         assert!(formatted.starts_with("---\n"), "formatted output must start with '---\\n'");
     }
 
-    /// load_agent returns None for a file that exists but has invalid frontmatter.
     #[test]
     fn load_agent_returns_none_for_invalid_content() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -250,9 +581,6 @@ mod tests {
         assert!(load_agent(tmp.path(), "bad").is_none());
     }
 
-    /// The body may contain `---` on its own line (e.g. a markdown horizontal rule).
-    /// The parser finds the *first* `\n---\n` in the file, which is always the
-    /// frontmatter closing delimiter; any `---` in the body is preserved verbatim.
     #[test]
     fn parse_agent_content_body_with_horizontal_rule_preserved() {
         let content = "---\nname: agent\ndescription: desc\n---\n\nSection one.\n\n---\n\nSection two.\n";
@@ -261,19 +589,12 @@ mod tests {
         assert_eq!(def.body, "Section one.\n\n---\n\nSection two.");
     }
 
-    /// list_agents silently skips `.md` files whose content cannot be parsed
-    /// (no valid frontmatter). Only well-formed agent files are returned.
     #[test]
     fn list_agents_skips_invalid_frontmatter_md_files() {
         let tmp = tempfile::TempDir::new().unwrap();
         let dir = tmp.path();
 
-        write_agent(dir, &AgentDef {
-            name: "good".to_string(),
-            description: "valid".to_string(),
-            body: "body".to_string(),
-        })
-        .unwrap();
+        write_agent(dir, &make_def_no_hooks("good")).unwrap();
         std::fs::write(dir.join("bad.md"), "not valid frontmatter at all").unwrap();
 
         let agents = list_agents(dir);
@@ -281,8 +602,6 @@ mod tests {
         assert_eq!(agents[0].name, "good");
     }
 
-    /// CRLF line endings are not supported: `parse_agent_content` requires LF-only.
-    /// Files with Windows line endings will fail to parse and return `None`.
     #[test]
     fn parse_agent_content_crlf_returns_none() {
         let content = "---\r\nname: agent\r\ndescription: desc\r\n---\r\n\r\nBody.\r\n";
@@ -292,19 +611,581 @@ mod tests {
         );
     }
 
-    /// write_agent creates a file named `{name}.md` in the given directory.
     #[test]
     fn write_agent_creates_correct_filename() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let def = AgentDef {
-            name: "mybot".to_string(),
-            description: "desc".to_string(),
-            body: "body".to_string(),
-        };
-        write_agent(tmp.path(), &def).unwrap();
+        write_agent(tmp.path(), &make_def_no_hooks("mybot")).unwrap();
         assert!(
             tmp.path().join("mybot.md").exists(),
             "write_agent must create {{name}}.md"
         );
+    }
+
+    // ── include_project_config field tests ───────────────────────────────────
+
+    #[test]
+    fn parse_agent_content_include_project_config_true_round_trips() {
+        let content =
+            "---\nname: agent\ndescription: desc\ninclude_project_config: true\n---\n\nBody.\n";
+        let def = parse_agent_content(content).unwrap();
+        assert_eq!(def.name, "agent");
+        assert!(def.include_project_config, "include_project_config must be true");
+
+        let formatted = format_agent_file(&def);
+        assert!(
+            formatted.contains("include_project_config: true"),
+            "formatted output must contain 'include_project_config: true' when true"
+        );
+        let reparsed = parse_agent_content(&formatted).unwrap();
+        assert!(reparsed.include_project_config, "re-parsed value must be true");
+    }
+
+    #[test]
+    fn parse_agent_content_include_project_config_defaults_to_false() {
+        let content = "---\nname: agent\ndescription: desc\n---\n\nBody.\n";
+        let def = parse_agent_content(content).unwrap();
+        assert!(
+            !def.include_project_config,
+            "include_project_config must default to false when absent"
+        );
+    }
+
+    #[test]
+    fn format_agent_file_omits_include_project_config_when_false() {
+        let def = make_def_no_hooks("agent");
+        let formatted = format_agent_file(&def);
+        assert!(
+            !formatted.contains("include_project_config"),
+            "formatted output must NOT contain 'include_project_config' when false, got: {formatted}"
+        );
+    }
+
+    // ── load_project_config tests ────────────────────────────────────────────
+
+    #[test]
+    fn load_project_config_returns_none_when_claude_md_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = load_project_config(tmp.path());
+        assert!(result.is_none(), "must return None when CLAUDE.md is absent");
+    }
+
+    #[test]
+    fn load_project_config_returns_claude_md_content_with_no_imports() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude_content = "# Project Config\n\nSome instructions here.\n";
+        std::fs::write(tmp.path().join("CLAUDE.md"), claude_content).unwrap();
+
+        let result = load_project_config(tmp.path()).unwrap();
+        assert_eq!(result, claude_content, "result must equal CLAUDE.md content when no @-imports");
+    }
+
+    #[test]
+    fn load_project_config_resolves_at_imports_mid_line() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        std::fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        std::fs::write(tmp.path().join("docs/style.md"), "Style guide content.\n").unwrap();
+
+        let claude_content = "See @docs/style.md here for style.\n";
+        std::fs::write(tmp.path().join("CLAUDE.md"), claude_content).unwrap();
+
+        let result = load_project_config(tmp.path()).unwrap();
+        assert!(result.contains("See @docs/style.md here for style."));
+        assert!(result.contains("Style guide content."));
+        let claude_pos = result.find("See @docs/style.md").unwrap();
+        let import_pos = result.find("Style guide content.").unwrap();
+        assert!(claude_pos < import_pos);
+    }
+
+    #[test]
+    fn load_project_config_deduplicates_at_imports() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        std::fs::write(tmp.path().join("shared.md"), "Shared content.\n").unwrap();
+
+        let claude_content = "First mention @shared.md\nSecond mention @shared.md\n";
+        std::fs::write(tmp.path().join("CLAUDE.md"), claude_content).unwrap();
+
+        let result = load_project_config(tmp.path()).unwrap();
+        let count = result.matches("Shared content.").count();
+        assert_eq!(count, 1, "imported file content must appear exactly once (deduped), got {count}");
+    }
+
+    #[test]
+    fn load_project_config_warns_on_missing_import_returns_partial() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        std::fs::write(tmp.path().join("real.md"), "Real content.\n").unwrap();
+        let claude_content = "See @real.md and @absent-file.md\n";
+        std::fs::write(tmp.path().join("CLAUDE.md"), claude_content).unwrap();
+
+        let result = load_project_config(tmp.path());
+        assert!(result.is_some());
+
+        let content = result.unwrap();
+        assert!(content.contains("Real content."));
+        let real_count = content.matches("Real content.").count();
+        assert_eq!(real_count, 1);
+    }
+
+    #[test]
+    fn load_project_config_resolves_multiple_distinct_imports_in_order() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        std::fs::write(tmp.path().join("first.md"), "First file.\n").unwrap();
+        std::fs::write(tmp.path().join("second.md"), "Second file.\n").unwrap();
+
+        let claude_content = "@first.md\n@second.md\n";
+        std::fs::write(tmp.path().join("CLAUDE.md"), claude_content).unwrap();
+
+        let result = load_project_config(tmp.path()).unwrap();
+        let first_pos = result.find("First file.").unwrap();
+        let second_pos = result.find("Second file.").unwrap();
+        assert!(first_pos < second_pos);
+    }
+
+    // ── load_project_hooks tests (GH #33) ────────────────────────────────────
+
+    /// Returns default (all-empty) when .claude/settings.json is absent.
+    #[test]
+    fn load_project_hooks_returns_default_when_file_absent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let hooks = load_project_hooks(tmp.path());
+        assert!(hooks.pre_tool_use.is_empty(), "pre_tool_use must be empty");
+        assert!(hooks.post_tool_use.is_empty(), "post_tool_use must be empty");
+        assert!(hooks.stop.is_empty(), "stop must be empty");
+    }
+
+    /// Parses PreToolUse entries from .claude/settings.json correctly.
+    #[test]
+    fn load_project_hooks_parses_pre_tool_use() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+        std::fs::write(
+            tmp.path().join(".claude/settings.json"),
+            r#"{
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {"type": "command", "command": "/pre.sh", "timeout": 300}
+                            ]
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let hooks = load_project_hooks(tmp.path());
+        assert_eq!(hooks.pre_tool_use.len(), 1, "expected 1 PreToolUse entry");
+        assert_eq!(hooks.pre_tool_use[0].matcher.as_deref(), Some("Bash"));
+        assert_eq!(hooks.pre_tool_use[0].hooks.len(), 1);
+        assert_eq!(hooks.pre_tool_use[0].hooks[0].command, "/pre.sh");
+        assert_eq!(hooks.pre_tool_use[0].hooks[0].timeout, 300);
+        assert!(hooks.post_tool_use.is_empty());
+        assert!(hooks.stop.is_empty());
+    }
+
+    /// Parses PostToolUse entries correctly; timeout defaults to 60 when absent.
+    #[test]
+    fn load_project_hooks_parses_post_tool_use_with_default_timeout() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+        std::fs::write(
+            tmp.path().join(".claude/settings.json"),
+            r#"{
+                "hooks": {
+                    "PostToolUse": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                {"type": "command", "command": "/post.sh"}
+                            ]
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let hooks = load_project_hooks(tmp.path());
+        assert_eq!(hooks.post_tool_use.len(), 1, "expected 1 PostToolUse entry");
+        assert_eq!(hooks.post_tool_use[0].matcher.as_deref(), Some(".*"));
+        assert_eq!(hooks.post_tool_use[0].hooks[0].command, "/post.sh");
+        assert_eq!(hooks.post_tool_use[0].hooks[0].timeout, 60, "default timeout must be 60");
+    }
+
+    /// Parses Stop entries (no matcher field) correctly.
+    #[test]
+    fn load_project_hooks_parses_stop_entries() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+        std::fs::write(
+            tmp.path().join(".claude/settings.json"),
+            r#"{
+                "hooks": {
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {"type": "command", "command": "/stop.sh"}
+                            ]
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let hooks = load_project_hooks(tmp.path());
+        assert_eq!(hooks.stop.len(), 1, "expected 1 Stop entry");
+        assert!(hooks.stop[0].matcher.is_none(), "Stop entry must have no matcher");
+        assert_eq!(hooks.stop[0].hooks[0].command, "/stop.sh");
+    }
+
+    /// Returns default when JSON is syntactically invalid.
+    #[test]
+    fn load_project_hooks_returns_default_on_invalid_json() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+        std::fs::write(tmp.path().join(".claude/settings.json"), "not valid json { {").unwrap();
+
+        let hooks = load_project_hooks(tmp.path());
+        assert!(hooks.pre_tool_use.is_empty(), "must return default on parse error");
+    }
+
+    /// Returns default when JSON is valid but has no `hooks` key.
+    #[test]
+    fn load_project_hooks_returns_default_when_no_hooks_key() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+        std::fs::write(
+            tmp.path().join(".claude/settings.json"),
+            r#"{"someOtherKey": true}"#,
+        )
+        .unwrap();
+
+        let hooks = load_project_hooks(tmp.path());
+        assert!(hooks.pre_tool_use.is_empty(), "must return default when no hooks key");
+        assert!(hooks.post_tool_use.is_empty());
+        assert!(hooks.stop.is_empty());
+    }
+
+    // ── merge_hooks tests (GH #33) ────────────────────────────────────────────
+
+    /// Agent entries appear in output unchanged.
+    #[test]
+    fn merge_hooks_agent_entries_preserved() {
+        let agent = AgentHooks {
+            pre_tool_use: vec![HookEntry {
+                matcher: Some("bash".to_string()),
+                hooks: vec![HookCommand { command: "/agent-pre.sh".to_string(), timeout: 10 }],
+            }],
+            ..AgentHooks::default()
+        };
+        let project = AgentHooks::default();
+
+        let merged = merge_hooks(agent, project);
+        assert_eq!(merged.pre_tool_use.len(), 1);
+        assert_eq!(merged.pre_tool_use[0].matcher.as_deref(), Some("bash"));
+        assert_eq!(merged.pre_tool_use[0].hooks[0].command, "/agent-pre.sh");
+    }
+
+    /// Project entries with new matchers are appended after agent entries.
+    #[test]
+    fn merge_hooks_project_entries_with_new_matchers_are_appended() {
+        let agent = AgentHooks {
+            pre_tool_use: vec![HookEntry {
+                matcher: Some("bash".to_string()),
+                hooks: vec![HookCommand { command: "/agent-pre.sh".to_string(), timeout: 10 }],
+            }],
+            ..AgentHooks::default()
+        };
+        let project = AgentHooks {
+            pre_tool_use: vec![HookEntry {
+                matcher: Some("read".to_string()),
+                hooks: vec![HookCommand { command: "/proj-pre.sh".to_string(), timeout: 60 }],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let merged = merge_hooks(agent, project);
+        assert_eq!(merged.pre_tool_use.len(), 2, "expected 2 entries: agent + project");
+        // Agent entry first
+        assert_eq!(merged.pre_tool_use[0].matcher.as_deref(), Some("bash"));
+        assert_eq!(merged.pre_tool_use[0].hooks[0].command, "/agent-pre.sh");
+        // Project entry appended
+        assert_eq!(merged.pre_tool_use[1].matcher.as_deref(), Some("read"));
+        assert_eq!(merged.pre_tool_use[1].hooks[0].command, "/proj-pre.sh");
+    }
+
+    /// Project entries with the same matcher as an agent entry are dropped.
+    #[test]
+    fn merge_hooks_project_entries_with_duplicate_matchers_are_dropped() {
+        let agent = AgentHooks {
+            post_tool_use: vec![HookEntry {
+                matcher: Some(".*".to_string()),
+                hooks: vec![HookCommand { command: "/agent-post.sh".to_string(), timeout: 10 }],
+            }],
+            ..AgentHooks::default()
+        };
+        let project = AgentHooks {
+            post_tool_use: vec![HookEntry {
+                matcher: Some(".*".to_string()),
+                hooks: vec![HookCommand { command: "/proj-post.sh".to_string(), timeout: 60 }],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let merged = merge_hooks(agent, project);
+        assert_eq!(merged.post_tool_use.len(), 1, "duplicate project entry must be dropped");
+        assert_eq!(merged.post_tool_use[0].hooks[0].command, "/agent-post.sh");
+    }
+
+    /// Stop hooks (None matcher): project stop entries appended when agent has none.
+    #[test]
+    fn merge_hooks_stop_project_entries_appended_when_agent_empty() {
+        let agent = AgentHooks::default();
+        let project = AgentHooks {
+            stop: vec![HookEntry {
+                matcher: None,
+                hooks: vec![HookCommand { command: "/proj-stop.sh".to_string(), timeout: 60 }],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let merged = merge_hooks(agent, project);
+        assert_eq!(merged.stop.len(), 1, "project stop entry must be appended when agent has none");
+        assert_eq!(merged.stop[0].hooks[0].command, "/proj-stop.sh");
+    }
+
+    /// Stop hooks: project entries dropped when agent already has a None-matcher stop entry.
+    #[test]
+    fn merge_hooks_stop_project_entries_dropped_when_agent_has_none_matcher() {
+        let agent = AgentHooks {
+            stop: vec![HookEntry {
+                matcher: None,
+                hooks: vec![HookCommand { command: "/agent-stop.sh".to_string(), timeout: 10 }],
+            }],
+            ..AgentHooks::default()
+        };
+        let project = AgentHooks {
+            stop: vec![HookEntry {
+                matcher: None,
+                hooks: vec![HookCommand { command: "/proj-stop.sh".to_string(), timeout: 60 }],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let merged = merge_hooks(agent, project);
+        assert_eq!(merged.stop.len(), 1, "duplicate None-matcher stop entries must be dropped");
+        assert_eq!(merged.stop[0].hooks[0].command, "/agent-stop.sh");
+    }
+
+    /// merge_hooks with empty agent and empty project returns empty.
+    #[test]
+    fn merge_hooks_both_empty_returns_empty() {
+        let merged = merge_hooks(AgentHooks::default(), AgentHooks::default());
+        assert!(merged.pre_tool_use.is_empty());
+        assert!(merged.post_tool_use.is_empty());
+        assert!(merged.stop.is_empty());
+    }
+
+    // ── Hook parsing tests (GH #33) ──────────────────────────────────────────
+
+    /// Missing `hooks:` field in frontmatter → `AgentHooks::default()` (all empty vecs).
+    #[test]
+    fn parse_agent_content_missing_hooks_defaults_to_empty() {
+        let content = "---\nname: agent\ndescription: desc\n---\n\nBody.\n";
+        let def = parse_agent_content(content).unwrap();
+        assert!(def.hooks.pre_tool_use.is_empty(), "pre_tool_use must be empty");
+        assert!(def.hooks.post_tool_use.is_empty(), "post_tool_use must be empty");
+        assert!(def.hooks.stop.is_empty(), "stop must be empty");
+    }
+
+    /// PreToolUse hook with matcher parses correctly.
+    #[test]
+    fn parse_agent_content_pre_tool_use_with_matcher() {
+        let content = "\
+---
+name: agent
+description: desc
+hooks:
+  PreToolUse:
+    - matcher: \"bash\"
+      hooks:
+        - type: command
+          command: /path/to/script.sh
+          timeout: 10
+---
+
+Body.
+";
+        let def = parse_agent_content(content).unwrap();
+        assert_eq!(def.hooks.pre_tool_use.len(), 1);
+        let entry = &def.hooks.pre_tool_use[0];
+        assert_eq!(entry.matcher.as_deref(), Some("bash"));
+        assert_eq!(entry.hooks.len(), 1);
+        assert_eq!(entry.hooks[0].command, "/path/to/script.sh");
+        assert_eq!(entry.hooks[0].timeout, 10);
+    }
+
+    /// PostToolUse hook with matcher parses correctly.
+    #[test]
+    fn parse_agent_content_post_tool_use_with_matcher() {
+        let content = "\
+---
+name: agent
+description: desc
+hooks:
+  PostToolUse:
+    - matcher: \".*\"
+      hooks:
+        - type: command
+          command: /path/to/script.sh
+---
+
+Body.
+";
+        let def = parse_agent_content(content).unwrap();
+        assert_eq!(def.hooks.post_tool_use.len(), 1);
+        let entry = &def.hooks.post_tool_use[0];
+        assert_eq!(entry.matcher.as_deref(), Some(".*"));
+        assert_eq!(entry.hooks.len(), 1);
+        assert_eq!(entry.hooks[0].command, "/path/to/script.sh");
+        assert_eq!(entry.hooks[0].timeout, 60, "default timeout must be 60");
+    }
+
+    /// Stop hook without matcher parses correctly.
+    #[test]
+    fn parse_agent_content_stop_hook_without_matcher() {
+        let content = "\
+---
+name: agent
+description: desc
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: /path/to/script.sh
+          timeout: 30
+---
+
+Body.
+";
+        let def = parse_agent_content(content).unwrap();
+        assert_eq!(def.hooks.stop.len(), 1);
+        let entry = &def.hooks.stop[0];
+        assert!(entry.matcher.is_none(), "Stop hook matcher must be None");
+        assert_eq!(entry.hooks.len(), 1);
+        assert_eq!(entry.hooks[0].command, "/path/to/script.sh");
+        assert_eq!(entry.hooks[0].timeout, 30);
+    }
+
+    /// Hooks round-trip through parse → format → parse.
+    #[test]
+    fn hooks_frontmatter_round_trips() {
+        let content = "\
+---
+name: agent
+description: desc
+hooks:
+  PreToolUse:
+    - matcher: \"bash\"
+      hooks:
+        - type: command
+          command: /path/to/script.sh
+          timeout: 10
+  PostToolUse:
+    - matcher: \".*\"
+      hooks:
+        - type: command
+          command: /other/script.sh
+  Stop:
+    - hooks:
+        - type: command
+          command: /stop/script.sh
+          timeout: 30
+---
+
+Body.
+";
+        let def = parse_agent_content(content).unwrap();
+        let formatted = format_agent_file(&def);
+        let reparsed = parse_agent_content(&formatted).unwrap();
+
+        // PreToolUse
+        assert_eq!(reparsed.hooks.pre_tool_use.len(), 1);
+        assert_eq!(reparsed.hooks.pre_tool_use[0].matcher.as_deref(), Some("bash"));
+        assert_eq!(reparsed.hooks.pre_tool_use[0].hooks[0].command, "/path/to/script.sh");
+        assert_eq!(reparsed.hooks.pre_tool_use[0].hooks[0].timeout, 10);
+
+        // PostToolUse
+        assert_eq!(reparsed.hooks.post_tool_use.len(), 1);
+        assert_eq!(reparsed.hooks.post_tool_use[0].matcher.as_deref(), Some(".*"));
+        assert_eq!(reparsed.hooks.post_tool_use[0].hooks[0].command, "/other/script.sh");
+        assert_eq!(reparsed.hooks.post_tool_use[0].hooks[0].timeout, 60);
+
+        // Stop
+        assert_eq!(reparsed.hooks.stop.len(), 1);
+        assert!(reparsed.hooks.stop[0].matcher.is_none());
+        assert_eq!(reparsed.hooks.stop[0].hooks[0].command, "/stop/script.sh");
+        assert_eq!(reparsed.hooks.stop[0].hooks[0].timeout, 30);
+    }
+
+    /// format_agent_file omits the `hooks:` section entirely when hooks are empty.
+    #[test]
+    fn format_agent_file_omits_hooks_when_empty() {
+        let def = make_def_no_hooks("agent");
+        let formatted = format_agent_file(&def);
+        assert!(
+            !formatted.contains("hooks:"),
+            "formatted output must NOT contain 'hooks:' when hooks are empty, got:\n{formatted}"
+        );
+    }
+
+    /// A full agent file with all three hook types serializes and parses back correctly.
+    #[test]
+    fn write_then_load_agent_with_hooks_round_trips() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let def = AgentDef {
+            name: "hooked".to_string(),
+            description: "agent with hooks".to_string(),
+            body: "body text".to_string(),
+            include_project_config: false,
+            hooks: AgentHooks {
+                pre_tool_use: vec![HookEntry {
+                    matcher: Some("bash".to_string()),
+                    hooks: vec![HookCommand { command: "/pre.sh".to_string(), timeout: 5 }],
+                }],
+                post_tool_use: vec![HookEntry {
+                    matcher: Some(".*".to_string()),
+                    hooks: vec![HookCommand { command: "/post.sh".to_string(), timeout: 60 }],
+                }],
+                stop: vec![HookEntry {
+                    matcher: None,
+                    hooks: vec![HookCommand { command: "/stop.sh".to_string(), timeout: 20 }],
+                }],
+            },
+        };
+
+        write_agent(tmp.path(), &def).unwrap();
+        let loaded = load_agent(tmp.path(), "hooked").unwrap();
+
+        assert_eq!(loaded.hooks.pre_tool_use.len(), 1);
+        assert_eq!(loaded.hooks.pre_tool_use[0].matcher.as_deref(), Some("bash"));
+        assert_eq!(loaded.hooks.pre_tool_use[0].hooks[0].command, "/pre.sh");
+        assert_eq!(loaded.hooks.pre_tool_use[0].hooks[0].timeout, 5);
+
+        assert_eq!(loaded.hooks.post_tool_use.len(), 1);
+        assert_eq!(loaded.hooks.post_tool_use[0].matcher.as_deref(), Some(".*"));
+        assert_eq!(loaded.hooks.post_tool_use[0].hooks[0].command, "/post.sh");
+        assert_eq!(loaded.hooks.post_tool_use[0].hooks[0].timeout, 60);
+
+        assert_eq!(loaded.hooks.stop.len(), 1);
+        assert!(loaded.hooks.stop[0].matcher.is_none());
+        assert_eq!(loaded.hooks.stop[0].hooks[0].command, "/stop.sh");
+        assert_eq!(loaded.hooks.stop[0].hooks[0].timeout, 20);
     }
 }

--- a/crates/arch-tests/architecture.spec.md
+++ b/crates/arch-tests/architecture.spec.md
@@ -2,7 +2,7 @@
 targets:
   - Cargo.toml
   - crates/*/Cargo.toml
-verified: 2026-04-24T14:02:58Z
+verified: 2026-04-25T11:19:49Z
 ---
 
 # Architecture Spec

--- a/crates/cli/cli-commands.spec.md
+++ b/crates/cli/cli-commands.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/cli/src/**/*.rs
   - crates/cli/Cargo.toml
-verified: 2026-04-25T10:02:12Z
+verified: 2026-04-25T11:19:59Z
 ---
 
 # CLI Commands Spec

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -768,6 +768,8 @@ async fn main() {
                     name: name.clone(),
                     description: description.unwrap_or_default(),
                     body: body.unwrap_or_default(),
+                    include_project_config: false,
+                    hooks: agents::AgentHooks::default(),
                 };
                 if let Err(e) = agents::write_agent(&dir, &def) {
                     eprintln!("Error writing agent file: {e}");

--- a/crates/db/data-model.spec.md
+++ b/crates/db/data-model.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/db/Cargo.toml
   - crates/types/src/**/*.rs
-verified: 2026-04-25T10:02:12Z
+verified: 2026-04-25T11:20:03Z
 ---
 
 # Data Model Spec

--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
+regex = "1"
 
 [dev-dependencies]
 mockall = "0.12"

--- a/crates/harness/agent-harness.spec.md
+++ b/crates/harness/agent-harness.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/harness/Cargo.toml
   - crates/anthropic/src/**/*.rs
   - crates/tools/src/**/*.rs
-verified: 2026-04-25T10:02:12Z
+verified: 2026-04-25T11:19:49Z
 ---
 
 # Agent Harness Spec

--- a/crates/harness/agent-sessions.spec.md
+++ b/crates/harness/agent-sessions.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
-verified: 2026-04-25T10:02:12Z
+verified: 2026-04-25T11:19:59Z
 ---
 
 # Agent Sessions Spec

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -1,6 +1,8 @@
+use agents::{AgentHooks, HookCommand, HookEntry};
 use anthropic::{AnthropicClient, MessageRequest, MessageResponse};
 use async_trait::async_trait;
 use chrono::Utc;
+use regex::Regex;
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
 use types::{ContentBlock, ContentBlockDelta, Role, Session, SessionEvent, SessionStatus, Turn};
@@ -15,6 +17,154 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+// ── Hook execution ────────────────────────────────────────────────────────────
+
+/// Run a single hook command with JSON on stdin.
+/// Returns `(exit_code, stdout, stderr)`.
+/// Kills the process and returns exit_code=1 on timeout.
+async fn run_hook(cmd: &HookCommand, stdin_json: &str) -> (i32, String, String) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::process::Command;
+    use tokio::time::{sleep, Duration};
+
+    let mut child = match Command::new("sh")
+        .arg("-c")
+        .arg(&cmd.command)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("failed to spawn hook command '{}': {e}", cmd.command);
+            return (1, String::new(), format!("failed to spawn: {e}"));
+        }
+    };
+
+    // Write stdin and close the pipe
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(stdin_json.as_bytes()).await;
+    }
+
+    // Take stdout/stderr handles for reading
+    let mut stdout_handle = child.stdout.take();
+    let mut stderr_handle = child.stderr.take();
+
+    // Read stdout and stderr concurrently with a timeout on the entire operation
+    let duration = Duration::from_secs(cmd.timeout);
+    tokio::select! {
+        result = async {
+            let mut stdout_buf = Vec::new();
+            let mut stderr_buf = Vec::new();
+            if let Some(ref mut h) = stdout_handle {
+                let _ = h.read_to_end(&mut stdout_buf).await;
+            }
+            if let Some(ref mut h) = stderr_handle {
+                let _ = h.read_to_end(&mut stderr_buf).await;
+            }
+            let status = child.wait().await;
+            (status, stdout_buf, stderr_buf)
+        } => {
+            let (status, stdout_buf, stderr_buf) = result;
+            let exit_code = status.ok().and_then(|s| s.code()).unwrap_or(1);
+            let stdout = String::from_utf8_lossy(&stdout_buf).into_owned();
+            let stderr = String::from_utf8_lossy(&stderr_buf).into_owned();
+            (exit_code, stdout, stderr)
+        }
+        _ = sleep(duration) => {
+            tracing::warn!("hook command '{}' timed out after {}s", cmd.command, cmd.timeout);
+            let _ = child.kill().await;
+            (1, String::new(), format!("hook timed out after {}s", cmd.timeout))
+        }
+    }
+}
+
+/// Find all `HookEntry`s whose matcher regex matches `tool_name`.
+fn matching_hook_entries<'a>(entries: &'a [HookEntry], tool_name: &str) -> Vec<&'a HookEntry> {
+    entries
+        .iter()
+        .filter(|e| {
+            e.matcher
+                .as_deref()
+                .map(|pat| Regex::new(pat).map(|re| re.is_match(tool_name)).unwrap_or(false))
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Run PreToolUse hooks for `tool_name`.
+/// Returns `Some(blocked_message)` if any hook exits non-zero (tool should be skipped),
+/// or `None` if all hooks pass.
+async fn run_pre_tool_use_hooks(
+    hooks: &AgentHooks,
+    tool_name: &str,
+    tool_input: &serde_json::Value,
+) -> Option<String> {
+    let stdin = serde_json::json!({
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+    });
+    let stdin_str = stdin.to_string();
+
+    for entry in matching_hook_entries(&hooks.pre_tool_use, tool_name) {
+        for cmd in &entry.hooks {
+            let (exit_code, _stdout, stderr) = run_hook(cmd, &stdin_str).await;
+            if exit_code != 0 {
+                return Some(if stderr.is_empty() {
+                    format!("Hook blocked tool '{tool_name}' (exit {exit_code})")
+                } else {
+                    stderr
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Run PostToolUse hooks for `tool_name`. Exit code is always ignored.
+async fn run_post_tool_use_hooks(
+    hooks: &AgentHooks,
+    tool_name: &str,
+    tool_input: &serde_json::Value,
+    tool_result: &str,
+) {
+    let stdin = serde_json::json!({
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+        "tool_result": tool_result,
+    });
+    let stdin_str = stdin.to_string();
+
+    for entry in matching_hook_entries(&hooks.post_tool_use, tool_name) {
+        for cmd in &entry.hooks {
+            run_hook(cmd, &stdin_str).await;
+        }
+    }
+}
+
+/// Run Stop hooks.
+/// Returns `Some(injected_message)` if any hook exits non-zero (the message should be
+/// injected into the conversation to continue the loop), or `None` to allow completion.
+async fn run_stop_hooks(hooks: &AgentHooks, session_id: Uuid) -> Option<String> {
+    let stdin = serde_json::json!({ "session_id": session_id.to_string() });
+    let stdin_str = stdin.to_string();
+
+    for entry in &hooks.stop {
+        for cmd in &entry.hooks {
+            let (exit_code, stdout, _stderr) = run_hook(cmd, &stdin_str).await;
+            if exit_code != 0 {
+                return Some(if stdout.is_empty() {
+                    format!("Stop hook exited with code {exit_code}")
+                } else {
+                    stdout
+                });
+            }
+        }
+    }
+    None
+}
 
 pub struct StubClient;
 
@@ -110,8 +260,9 @@ async fn run_tool_dispatch_loop(
     client: &Arc<dyn AnthropicClient>,
     db: &Arc<dyn db::Db>,
     event_tx: &broadcast::Sender<SessionEvent>,
+    hooks: &AgentHooks,
     mut messages: Vec<(Role, Vec<ContentBlock>)>,
-) -> Result<()> {
+) -> Result<Option<String>> {
     let tool_definitions: Vec<types::ToolDefinition> =
         config.tools.iter().map(|t| t.definition()).collect();
 
@@ -123,8 +274,25 @@ async fn run_tool_dispatch_loop(
             let dir = agents::agents_dir()?;
             agents::load_agent(&dir, name)
         })
-        .map(|def| def.body)
-        .filter(|s| !s.is_empty());
+        .and_then(|def| {
+            let agent_body = def.body;
+            if def.include_project_config {
+                // Try to find the git root via agents_dir (agents_dir = git_root/.ns2/agents)
+                let project = agents::agents_dir()
+                    .as_deref()
+                    .and_then(|d| d.parent())
+                    .and_then(|d| d.parent())
+                    .and_then(agents::load_project_config)
+                    .unwrap_or_default();
+                if project.is_empty() {
+                    if agent_body.is_empty() { None } else { Some(agent_body) }
+                } else {
+                    Some(format!("{agent_body}\n\n{project}"))
+                }
+            } else {
+                if agent_body.is_empty() { None } else { Some(agent_body) }
+            }
+        });
 
     loop {
         let request = MessageRequest {
@@ -169,7 +337,13 @@ async fn run_tool_dispatch_loop(
 
         match response.stop_reason.as_str() {
             "tool_use" => { /* dispatch tools below */ }
-            "end_turn" => break,
+            "end_turn" => {
+                // Run Stop hooks; if any exit non-zero, return their stdout as an injected message
+                if let Some(injected) = run_stop_hooks(hooks, config.session.id).await {
+                    return Ok(Some(injected));
+                }
+                break;
+            }
             "max_tokens" => {
                 let _ = event_tx.send(SessionEvent::Error {
                     message: "session hit max_tokens limit".to_string(),
@@ -190,12 +364,24 @@ async fn run_tool_dispatch_loop(
 
         for block in &response.content {
             if let ContentBlock::ToolUse { id, name, input } = block {
-                let result = match config.tools.iter().find(|t| t.definition().name == *name) {
-                    Some(tool) => match tool.execute(input.clone()).await {
-                        Ok(output) => output,
-                        Err(e) => format!("Error: {e}"),
-                    },
-                    None => format!("Error: unknown tool '{name}'"),
+                // Run PreToolUse hooks
+                let result = if let Some(blocked) =
+                    run_pre_tool_use_hooks(hooks, name, input).await
+                {
+                    // Hook blocked the tool — return hook stderr as the tool result
+                    blocked
+                } else {
+                    // Run the actual tool
+                    let tool_output = match config.tools.iter().find(|t| t.definition().name == *name) {
+                        Some(tool) => match tool.execute(input.clone()).await {
+                            Ok(output) => output,
+                            Err(e) => format!("Error: {e}"),
+                        },
+                        None => format!("Error: unknown tool '{name}'"),
+                    };
+                    // Run PostToolUse hooks (exit code ignored)
+                    run_post_tool_use_hooks(hooks, name, input, &tool_output).await;
+                    tool_output
                 };
                 tool_result_blocks.push(ContentBlock::ToolResult {
                     tool_use_id: id.clone(),
@@ -231,7 +417,7 @@ async fn run_tool_dispatch_loop(
         messages.push((Role::User, tool_result_blocks));
     }
 
-    Ok(())
+    Ok(None)
 }
 
 pub async fn run(
@@ -241,6 +427,39 @@ pub async fn run(
     event_tx: broadcast::Sender<SessionEvent>,
     mut msg_rx: mpsc::Receiver<String>,
 ) -> Result<()> {
+    // Load hooks from the agent definition (once, at harness start).
+    // When include_project_config is true, also load project hooks from
+    // .claude/settings.json and merge them (agent hooks take precedence).
+    let hooks = {
+        let agent_def = config
+            .session
+            .agent
+            .as_deref()
+            .and_then(|name| {
+                let dir = agents::agents_dir()?;
+                agents::load_agent(&dir, name)
+            });
+
+        match agent_def {
+            None => AgentHooks::default(),
+            Some(def) => {
+                let agent_hooks = def.hooks;
+                if def.include_project_config {
+                    // Derive git root from agents_dir (.ns2/agents → .ns2 → git_root)
+                    let project_hooks = agents::agents_dir()
+                        .as_deref()
+                        .and_then(|d| d.parent())
+                        .and_then(|d| d.parent())
+                        .map(agents::load_project_hooks)
+                        .unwrap_or_default();
+                    agents::merge_hooks(agent_hooks, project_hooks)
+                } else {
+                    agent_hooks
+                }
+            }
+        }
+    };
+
     loop {
         // Wait for the next user message. When the sender is dropped, recv() returns None → exit.
         let message = match msg_rx.recv().await {
@@ -257,8 +476,34 @@ pub async fn run(
         // Load full conversation history from DB (including the message we just stored)
         let history = load_history(&db, config.session.id).await?;
 
-        // Run the tool dispatch loop
-        run_tool_dispatch_loop(&config, &client, &db, &event_tx, history).await?;
+        // Run the tool dispatch loop. It returns Some(injected_message) when a Stop
+        // hook blocks completion and injects a message for the next turn.
+        let mut current_history = history;
+        loop {
+            match run_tool_dispatch_loop(
+                &config,
+                &client,
+                &db,
+                &event_tx,
+                &hooks,
+                current_history,
+            )
+            .await?
+            {
+                None => break, // normal completion
+                Some(injected) => {
+                    // Stop hook rejected; inject the message and continue
+                    persist_user_message(
+                        &db,
+                        config.session.id,
+                        &injected,
+                        &event_tx,
+                    )
+                    .await?;
+                    current_history = load_history(&db, config.session.id).await?;
+                }
+            }
+        }
 
         // Mark session completed and emit done event
         db.update_session_status(config.session.id, SessionStatus::Completed).await?;
@@ -1762,6 +2007,8 @@ mod tests {
             name: agent_name.to_string(),
             description: "test agent".to_string(),
             body: "You are a test harness agent with a non-empty body.".to_string(),
+            include_project_config: false,
+            hooks: agents::AgentHooks::default(),
         };
         agents::write_agent(&dir, &def).unwrap();
 
@@ -1817,6 +2064,8 @@ mod tests {
             name: agent_name.to_string(),
             description: "test agent with no body".to_string(),
             body: String::new(), // empty body
+            include_project_config: false,
+            hooks: agents::AgentHooks::default(),
         };
         agents::write_agent(&dir, &def).unwrap();
 
@@ -1852,6 +2101,752 @@ mod tests {
         assert!(
             client_ref.captured().is_none(),
             "empty agent body must NOT become the system prompt (system must be None)"
+        );
+    }
+
+    /// When `include_project_config: true`, the CLAUDE.md content is appended to the
+    /// agent body in the system prompt, separated by `\n\n`.
+    /// Skips when not inside a git repo (e.g. cargo-mutants temp dir).
+    #[tokio::test]
+    async fn test_include_project_config_true_appends_claude_md_to_system_prompt() {
+        // Skip when not inside a git repo
+        let dir = match agents::agents_dir() {
+            Some(d) => d,
+            None => return,
+        };
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let agent_name = "harness_test_include_project_config";
+        let agent_body = "You are a coding agent.";
+        let def = agents::AgentDef {
+            name: agent_name.to_string(),
+            description: "test agent with include_project_config".to_string(),
+            body: agent_body.to_string(),
+            include_project_config: true,
+            hooks: agents::AgentHooks::default(),
+        };
+        agents::write_agent(&dir, &def).unwrap();
+
+        let session = types::Session {
+            id: Uuid::new_v4(),
+            name: "test".into(),
+            status: types::SessionStatus::Running,
+            agent: Some(agent_name.to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let mock_db = permissive_mock_db();
+
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "claude-opus-4-5".into(),
+            tools: vec![],
+        };
+
+        // Derive the git root from agents_dir (agents_dir = git_root/.ns2/agents)
+        // We go up two levels: .ns2/agents -> .ns2 -> git_root
+        let git_root = dir.parent().and_then(|p| p.parent());
+        let project_content = git_root.and_then(|r| agents::load_project_config(r));
+
+        let client = Arc::new(SystemCapturingClient::new());
+        let client_ref = Arc::clone(&client);
+        let db = Arc::new(mock_db);
+        let (event_tx, _rx) = broadcast::channel(64);
+        let (msg_tx, msg_rx) = mpsc::channel(16);
+        msg_tx.send("hello".into()).await.unwrap();
+        drop(msg_tx);
+
+        let result = run(config, client, db, event_tx, msg_rx).await;
+
+        // Cleanup
+        let _ = std::fs::remove_file(dir.join(format!("{agent_name}.md")));
+
+        result.unwrap();
+
+        let captured = client_ref.captured();
+        assert!(captured.is_some(), "system prompt must be Some when agent body is non-empty");
+
+        let system = captured.unwrap();
+        assert!(
+            system.starts_with(agent_body),
+            "system prompt must start with agent body, got: {:?}",
+            &system[..system.len().min(80)]
+        );
+
+        // If CLAUDE.md exists (it does in this repo), it must be appended
+        if let Some(project) = project_content {
+            if !project.is_empty() {
+                assert!(
+                    system.contains(&project),
+                    "system prompt must contain project config when include_project_config=true"
+                );
+                let expected = format!("{agent_body}\n\n{project}");
+                assert_eq!(
+                    system, expected,
+                    "system prompt must be agent_body + \\n\\n + project config"
+                );
+            }
+        }
+    }
+
+    /// When `include_project_config: false` (default), the system prompt equals
+    /// only the agent body — CLAUDE.md content is NOT appended.
+    /// Skips when not inside a git repo.
+    #[tokio::test]
+    async fn test_include_project_config_false_leaves_system_prompt_unchanged() {
+        let dir = match agents::agents_dir() {
+            Some(d) => d,
+            None => return,
+        };
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let agent_name = "harness_test_no_project_config";
+        let agent_body = "You are a plain agent without project config.";
+        let def = agents::AgentDef {
+            name: agent_name.to_string(),
+            description: "test agent without include_project_config".to_string(),
+            body: agent_body.to_string(),
+            include_project_config: false,
+            hooks: agents::AgentHooks::default(),
+        };
+        agents::write_agent(&dir, &def).unwrap();
+
+        let session = types::Session {
+            id: Uuid::new_v4(),
+            name: "test".into(),
+            status: types::SessionStatus::Running,
+            agent: Some(agent_name.to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let mock_db = permissive_mock_db();
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "claude-opus-4-5".into(),
+            tools: vec![],
+        };
+        let client = Arc::new(SystemCapturingClient::new());
+        let client_ref = Arc::clone(&client);
+        let db = Arc::new(mock_db);
+        let (event_tx, _rx) = broadcast::channel(64);
+        let (msg_tx, msg_rx) = mpsc::channel(16);
+        msg_tx.send("hello".into()).await.unwrap();
+        drop(msg_tx);
+
+        let result = run(config, client, db, event_tx, msg_rx).await;
+
+        // Cleanup
+        let _ = std::fs::remove_file(dir.join(format!("{agent_name}.md")));
+
+        result.unwrap();
+
+        let captured = client_ref.captured();
+        assert!(captured.is_some(), "system prompt must be Some when agent body is non-empty");
+        assert_eq!(
+            captured.as_deref(),
+            Some(agent_body),
+            "system prompt must equal exactly the agent body when include_project_config=false"
+        );
+    }
+
+    // ── Hook dispatch tests (GH #33) ─────────────────────────────────────────
+
+    // Helper: build a HookCommand using a shell snippet.
+    fn hook_cmd(script: &str, timeout: u64) -> agents::HookCommand {
+        agents::HookCommand { command: script.to_string(), timeout }
+    }
+
+    /// PreToolUse hook exits 0 → tool runs normally.
+    #[tokio::test]
+    async fn test_pre_tool_use_hook_exit_0_allows_tool() {
+        use agents::{AgentHooks, HookEntry};
+
+        let hooks = AgentHooks {
+            pre_tool_use: vec![HookEntry {
+                matcher: Some("read".to_string()),
+                hooks: vec![hook_cmd("exit 0", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        // Verify directly via run_pre_tool_use_hooks
+        let result =
+            run_pre_tool_use_hooks(&hooks, "read", &serde_json::json!({"path": "/tmp/f"})).await;
+        assert!(result.is_none(), "exit 0 hook must not block the tool, got: {result:?}");
+    }
+
+    /// PreToolUse hook exits 1 → tool is blocked; hook stderr is returned.
+    #[tokio::test]
+    async fn test_pre_tool_use_hook_exit_1_blocks_tool_returns_stderr() {
+        use agents::{AgentHooks, HookEntry};
+
+        let hooks = AgentHooks {
+            pre_tool_use: vec![HookEntry {
+                matcher: Some("bash".to_string()),
+                hooks: vec![hook_cmd("echo 'blocked by policy' >&2; exit 1", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let result =
+            run_pre_tool_use_hooks(&hooks, "bash", &serde_json::json!({})).await;
+        assert!(result.is_some(), "exit 1 hook must block the tool");
+        let msg = result.unwrap();
+        assert!(
+            msg.contains("blocked by policy"),
+            "blocked message must contain hook stderr, got: {msg:?}"
+        );
+    }
+
+    /// PreToolUse hook with matcher "bash" does NOT match tool "read".
+    #[tokio::test]
+    async fn test_pre_tool_use_hook_matcher_does_not_match_different_tool() {
+        use agents::{AgentHooks, HookEntry};
+
+        let hooks = AgentHooks {
+            pre_tool_use: vec![HookEntry {
+                matcher: Some("bash".to_string()),
+                hooks: vec![hook_cmd("exit 1", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        // "read" should not be matched by "bash"
+        let result =
+            run_pre_tool_use_hooks(&hooks, "read", &serde_json::json!({})).await;
+        assert!(result.is_none(), "hook for 'bash' must not match tool 'read'");
+    }
+
+    /// PostToolUse hook runs after tool; non-zero exit is ignored (no error propagated).
+    #[tokio::test]
+    async fn test_post_tool_use_hook_non_zero_exit_is_ignored() {
+        use agents::{AgentHooks, HookEntry};
+
+        let hooks = AgentHooks {
+            post_tool_use: vec![HookEntry {
+                matcher: Some(".*".to_string()),
+                hooks: vec![hook_cmd("exit 42", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        // Should complete without any error
+        run_post_tool_use_hooks(&hooks, "bash", &serde_json::json!({}), "result").await;
+        // If we get here, the non-zero exit was ignored as expected.
+    }
+
+    /// Stop hook exits 0 → session completes normally (run_stop_hooks returns None).
+    #[tokio::test]
+    async fn test_stop_hook_exit_0_allows_completion() {
+        use agents::{AgentHooks, HookEntry};
+
+        let hooks = AgentHooks {
+            stop: vec![HookEntry {
+                matcher: None,
+                hooks: vec![hook_cmd("exit 0", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let result = run_stop_hooks(&hooks, Uuid::new_v4()).await;
+        assert!(result.is_none(), "exit 0 stop hook must allow completion, got: {result:?}");
+    }
+
+    /// Stop hook exits 1 → injects stdout as user message (run_stop_hooks returns Some).
+    #[tokio::test]
+    async fn test_stop_hook_exit_1_injects_stdout_as_user_message() {
+        use agents::{AgentHooks, HookEntry};
+
+        let hooks = AgentHooks {
+            stop: vec![HookEntry {
+                matcher: None,
+                hooks: vec![hook_cmd("echo 'please continue'; exit 1", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let result = run_stop_hooks(&hooks, Uuid::new_v4()).await;
+        assert!(result.is_some(), "exit 1 stop hook must inject a message");
+        let msg = result.unwrap();
+        assert!(
+            msg.contains("please continue"),
+            "injected message must contain hook stdout, got: {msg:?}"
+        );
+    }
+
+    /// Hook timeout kills command and treats as exit 1 (times out after `timeout` seconds).
+    #[tokio::test]
+    async fn test_hook_timeout_kills_command_and_returns_exit_1() {
+        // Use a very short timeout (1s) and a command that sleeps longer (5s)
+        let cmd = hook_cmd("sleep 5", 1);
+        let (exit_code, _stdout, stderr) = run_hook(&cmd, "{}").await;
+        assert_eq!(exit_code, 1, "timed-out hook must return exit_code=1");
+        assert!(
+            stderr.contains("timed out"),
+            "stderr must mention timeout, got: {stderr:?}"
+        );
+    }
+
+    /// Integration: PreToolUse hook exit 0 lets the tool run; result is the tool's output.
+    #[tokio::test]
+    async fn test_integration_pre_tool_use_exit_0_tool_runs_normally() {
+        use agents::{AgentHooks, HookEntry};
+        use std::sync::Mutex;
+
+        // Track what's stored as ToolResult
+        let results_store: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(vec![]));
+        let results_store_c = Arc::clone(&results_store);
+
+        let mut mock_db = MockTestDb::new();
+        mock_db.expect_create_turn().returning(|_| Ok(()));
+        mock_db.expect_create_content_block().returning(move |_, _, _, block| {
+            if let ContentBlock::ToolResult { content, .. } = block {
+                results_store_c.lock().unwrap().push(content.clone());
+            }
+            Ok(())
+        });
+        mock_db.expect_update_session_status().returning(|_, _| Ok(()));
+        mock_db.expect_list_turns().returning(|_| Ok(vec![]));
+        mock_db.expect_list_content_blocks().returning(|_| Ok(vec![]));
+
+        let hooks = AgentHooks {
+            pre_tool_use: vec![HookEntry {
+                matcher: Some("read".to_string()),
+                hooks: vec![hook_cmd("exit 0", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let session = make_session();
+        let (event_tx, _rx) = broadcast::channel(64);
+
+        // Run the tool dispatch loop directly with hooks
+        let history = vec![(
+            Role::User,
+            vec![ContentBlock::Text { text: "go".into() }],
+        )];
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "test".into(),
+            tools: vec![Arc::new(AlwaysOkTool)],
+        };
+        let client: Arc<dyn AnthropicClient> = Arc::new(ToolUseClient::new());
+        let db: Arc<dyn db::Db> = Arc::new(mock_db);
+
+        let result = run_tool_dispatch_loop(&config, &client, &db, &event_tx, &hooks, history)
+            .await
+            .unwrap();
+        assert!(result.is_none(), "should complete normally");
+
+        let results = results_store.lock().unwrap();
+        assert_eq!(results.len(), 1, "expected one tool result");
+        assert_eq!(results[0], "file content here", "tool should have run normally");
+    }
+
+    /// Integration: PreToolUse hook exit 1 blocks tool; hook stderr becomes tool result.
+    #[tokio::test]
+    async fn test_integration_pre_tool_use_exit_1_blocks_tool() {
+        use agents::{AgentHooks, HookEntry};
+        use std::sync::Mutex;
+
+        let results_store: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(vec![]));
+        let results_store_c = Arc::clone(&results_store);
+
+        let mut mock_db = MockTestDb::new();
+        mock_db.expect_create_turn().returning(|_| Ok(()));
+        mock_db.expect_create_content_block().returning(move |_, _, _, block| {
+            if let ContentBlock::ToolResult { content, .. } = block {
+                results_store_c.lock().unwrap().push(content.clone());
+            }
+            Ok(())
+        });
+        mock_db.expect_update_session_status().returning(|_, _| Ok(()));
+        mock_db.expect_list_turns().returning(|_| Ok(vec![]));
+        mock_db.expect_list_content_blocks().returning(|_| Ok(vec![]));
+
+        let hooks = AgentHooks {
+            pre_tool_use: vec![HookEntry {
+                matcher: Some("read".to_string()),
+                hooks: vec![hook_cmd("echo 'tool blocked by hook' >&2; exit 1", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let session = make_session();
+        let (event_tx, _rx) = broadcast::channel(64);
+
+        let history = vec![(
+            Role::User,
+            vec![ContentBlock::Text { text: "go".into() }],
+        )];
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "test".into(),
+            tools: vec![Arc::new(AlwaysOkTool)],
+        };
+        let client: Arc<dyn AnthropicClient> = Arc::new(ToolUseClient::new());
+        let db: Arc<dyn db::Db> = Arc::new(mock_db);
+
+        run_tool_dispatch_loop(&config, &client, &db, &event_tx, &hooks, history)
+            .await
+            .unwrap();
+
+        let results = results_store.lock().unwrap();
+        assert_eq!(results.len(), 1, "expected one tool result (the blocked message)");
+        assert!(
+            results[0].contains("tool blocked by hook"),
+            "tool result must be hook stderr when blocked, got: {:?}",
+            results[0]
+        );
+    }
+
+    /// Integration: PostToolUse hook runs after tool; non-zero exit does not alter tool result.
+    #[tokio::test]
+    async fn test_integration_post_tool_use_hook_does_not_alter_result() {
+        use agents::{AgentHooks, HookEntry};
+        use std::sync::Mutex;
+
+        let results_store: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(vec![]));
+        let results_store_c = Arc::clone(&results_store);
+
+        let mut mock_db = MockTestDb::new();
+        mock_db.expect_create_turn().returning(|_| Ok(()));
+        mock_db.expect_create_content_block().returning(move |_, _, _, block| {
+            if let ContentBlock::ToolResult { content, .. } = block {
+                results_store_c.lock().unwrap().push(content.clone());
+            }
+            Ok(())
+        });
+        mock_db.expect_update_session_status().returning(|_, _| Ok(()));
+        mock_db.expect_list_turns().returning(|_| Ok(vec![]));
+        mock_db.expect_list_content_blocks().returning(|_| Ok(vec![]));
+
+        let hooks = AgentHooks {
+            post_tool_use: vec![HookEntry {
+                matcher: Some(".*".to_string()),
+                // Non-zero exit — must not alter the tool result
+                hooks: vec![hook_cmd("exit 99", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let session = make_session();
+        let (event_tx, _rx) = broadcast::channel(64);
+
+        let history = vec![(
+            Role::User,
+            vec![ContentBlock::Text { text: "go".into() }],
+        )];
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "test".into(),
+            tools: vec![Arc::new(AlwaysOkTool)],
+        };
+        let client: Arc<dyn AnthropicClient> = Arc::new(ToolUseClient::new());
+        let db: Arc<dyn db::Db> = Arc::new(mock_db);
+
+        run_tool_dispatch_loop(&config, &client, &db, &event_tx, &hooks, history)
+            .await
+            .unwrap();
+
+        let results = results_store.lock().unwrap();
+        assert_eq!(results.len(), 1, "expected one tool result");
+        assert_eq!(
+            results[0], "file content here",
+            "PostToolUse hook must not alter the tool result"
+        );
+    }
+
+    /// Integration: Stop hook exit 0 lets session complete without injecting a message.
+    #[tokio::test]
+    async fn test_integration_stop_hook_exit_0_lets_session_complete() {
+        use agents::{AgentHooks, HookEntry};
+
+        let hooks = AgentHooks {
+            stop: vec![HookEntry {
+                matcher: None,
+                hooks: vec![hook_cmd("exit 0", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let session = make_session();
+        let (event_tx, _rx) = broadcast::channel(64);
+
+        let history = vec![(
+            Role::User,
+            vec![ContentBlock::Text { text: "hi".into() }],
+        )];
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "test".into(),
+            tools: vec![],
+        };
+        // StubClient returns end_turn
+        let client: Arc<dyn AnthropicClient> = Arc::new(StubClient);
+        let mock_db = permissive_mock_db();
+        let db: Arc<dyn db::Db> = Arc::new(mock_db);
+
+        let result = run_tool_dispatch_loop(&config, &client, &db, &event_tx, &hooks, history)
+            .await
+            .unwrap();
+        assert!(result.is_none(), "stop hook exit 0 must return None (normal completion)");
+    }
+
+    /// Integration: Stop hook exit 1 injects stdout as user message (returns Some).
+    #[tokio::test]
+    async fn test_integration_stop_hook_exit_1_injects_user_message() {
+        use agents::{AgentHooks, HookEntry};
+
+        let hooks = AgentHooks {
+            stop: vec![HookEntry {
+                matcher: None,
+                hooks: vec![hook_cmd("echo 'do more work'; exit 1", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let session = make_session();
+        let (event_tx, _rx) = broadcast::channel(64);
+
+        let history = vec![(
+            Role::User,
+            vec![ContentBlock::Text { text: "hi".into() }],
+        )];
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "test".into(),
+            tools: vec![],
+        };
+        let client: Arc<dyn AnthropicClient> = Arc::new(StubClient);
+        let mock_db = permissive_mock_db();
+        let db: Arc<dyn db::Db> = Arc::new(mock_db);
+
+        let result = run_tool_dispatch_loop(&config, &client, &db, &event_tx, &hooks, history)
+            .await
+            .unwrap();
+        assert!(result.is_some(), "stop hook exit 1 must inject a user message");
+        let injected = result.unwrap();
+        assert!(
+            injected.contains("do more work"),
+            "injected message must contain hook stdout, got: {injected:?}"
+        );
+    }
+
+    // ── GH#33 project hook inheritance tests ─────────────────────────────────
+
+    // A process-wide lock to prevent concurrent tests from racing over .claude/settings.json.
+    fn settings_json_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    /// When `include_project_config: true` and `.claude/settings.json` has a PostToolUse
+    /// hook, the project hook runs during a tool-dispatching session (the log file is written).
+    ///
+    /// Skips when not inside a git repo (agents_dir() returns None).
+    #[tokio::test]
+    async fn test_include_project_config_true_runs_project_hook() {
+        let dir = match agents::agents_dir() {
+            Some(d) => d,
+            None => return,
+        };
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Derive git root from agents_dir (.ns2/agents → .ns2 → git_root)
+        let git_root = match dir.parent().and_then(|p| p.parent()) {
+            Some(r) => r.to_path_buf(),
+            None => return,
+        };
+
+        // Write a temp sentinel file the hook will touch
+        let log_file = std::env::temp_dir().join(format!(
+            "ns2_proj_hook_test_{}.txt",
+            uuid::Uuid::new_v4()
+        ));
+        let log_path = log_file.to_string_lossy().to_string();
+
+        // Acquire lock to prevent concurrent access to .claude/settings.json
+        let _guard = settings_json_lock().lock().unwrap();
+
+        // Write .claude/settings.json with a PostToolUse hook
+        let claude_dir = git_root.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let settings_path = claude_dir.join("settings.json");
+        // Save any existing settings.json to restore later
+        let original_settings = std::fs::read_to_string(&settings_path).ok();
+        std::fs::write(
+            &settings_path,
+            format!(
+                r#"{{
+                    "hooks": {{
+                        "PostToolUse": [
+                            {{
+                                "matcher": ".*",
+                                "hooks": [
+                                    {{"type": "command", "command": "echo project-hook >> {log_path}", "timeout": 10}}
+                                ]
+                            }}
+                        ]
+                    }}
+                }}"#
+            ),
+        ).unwrap();
+
+        // Write the agent with include_project_config: true and no agent-level hooks
+        let agent_name = "harness_test_project_hook_true";
+        let def = agents::AgentDef {
+            name: agent_name.to_string(),
+            description: "test agent for project hook inheritance".to_string(),
+            body: "You are a test agent.".to_string(),
+            include_project_config: true,
+            hooks: agents::AgentHooks::default(),
+        };
+        agents::write_agent(&dir, &def).unwrap();
+
+        let session = types::Session {
+            id: Uuid::new_v4(),
+            name: "test".into(),
+            status: types::SessionStatus::Running,
+            agent: Some(agent_name.to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let mock_db = permissive_mock_db();
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "test".into(),
+            tools: vec![Arc::new(AlwaysOkTool)],
+        };
+        let client = Arc::new(ToolUseClient::new());
+        let db = Arc::new(mock_db);
+        let (event_tx, _rx) = broadcast::channel(128);
+        let (msg_tx, msg_rx) = mpsc::channel(16);
+        msg_tx.send("read the file".into()).await.unwrap();
+        drop(msg_tx);
+
+        let result = run(config, client, db, event_tx, msg_rx).await;
+
+        // Cleanup agent and restore/remove settings.json (while still holding the lock)
+        let _ = std::fs::remove_file(dir.join(format!("{agent_name}.md")));
+        match original_settings {
+            Some(orig) => { let _ = std::fs::write(&settings_path, orig); }
+            None => { let _ = std::fs::remove_file(&settings_path); }
+        }
+        drop(_guard);
+
+        result.unwrap();
+
+        // The log file must exist and contain the hook output
+        let log_content = std::fs::read_to_string(&log_file)
+            .unwrap_or_default();
+        let _ = std::fs::remove_file(&log_file);
+        assert!(
+            log_content.contains("project-hook"),
+            "project PostToolUse hook must have run (log file contents: {log_content:?})"
+        );
+    }
+
+    /// When `include_project_config: false`, the project `.claude/settings.json` PostToolUse
+    /// hook must NOT run even if the file exists.
+    ///
+    /// Skips when not inside a git repo (agents_dir() returns None).
+    #[tokio::test]
+    async fn test_include_project_config_false_does_not_run_project_hook() {
+        let dir = match agents::agents_dir() {
+            Some(d) => d,
+            None => return,
+        };
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let git_root = match dir.parent().and_then(|p| p.parent()) {
+            Some(r) => r.to_path_buf(),
+            None => return,
+        };
+
+        // Write a temp sentinel file the hook would touch if it ran
+        let log_file = std::env::temp_dir().join(format!(
+            "ns2_proj_hook_false_test_{}.txt",
+            uuid::Uuid::new_v4()
+        ));
+        let log_path = log_file.to_string_lossy().to_string();
+
+        // Acquire lock to prevent concurrent access to .claude/settings.json
+        let _guard = settings_json_lock().lock().unwrap();
+
+        // Write .claude/settings.json with a PostToolUse hook
+        let claude_dir = git_root.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let settings_path = claude_dir.join("settings.json");
+        let original_settings = std::fs::read_to_string(&settings_path).ok();
+        std::fs::write(
+            &settings_path,
+            format!(
+                r#"{{
+                    "hooks": {{
+                        "PostToolUse": [
+                            {{
+                                "matcher": ".*",
+                                "hooks": [
+                                    {{"type": "command", "command": "echo project-hook >> {log_path}", "timeout": 10}}
+                                ]
+                            }}
+                        ]
+                    }}
+                }}"#
+            ),
+        ).unwrap();
+
+        // Write the agent with include_project_config: FALSE
+        let agent_name = "harness_test_project_hook_false";
+        let def = agents::AgentDef {
+            name: agent_name.to_string(),
+            description: "test agent without project hook inheritance".to_string(),
+            body: "You are a test agent.".to_string(),
+            include_project_config: false,
+            hooks: agents::AgentHooks::default(),
+        };
+        agents::write_agent(&dir, &def).unwrap();
+
+        let session = types::Session {
+            id: Uuid::new_v4(),
+            name: "test".into(),
+            status: types::SessionStatus::Running,
+            agent: Some(agent_name.to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let mock_db = permissive_mock_db();
+        let config = HarnessConfig {
+            session: session.clone(),
+            model: "test".into(),
+            tools: vec![Arc::new(AlwaysOkTool)],
+        };
+        let client = Arc::new(ToolUseClient::new());
+        let db = Arc::new(mock_db);
+        let (event_tx, _rx) = broadcast::channel(128);
+        let (msg_tx, msg_rx) = mpsc::channel(16);
+        msg_tx.send("read the file".into()).await.unwrap();
+        drop(msg_tx);
+
+        let result = run(config, client, db, event_tx, msg_rx).await;
+
+        // Cleanup (while still holding the lock)
+        let _ = std::fs::remove_file(dir.join(format!("{agent_name}.md")));
+        match original_settings {
+            Some(orig) => { let _ = std::fs::write(&settings_path, orig); }
+            None => { let _ = std::fs::remove_file(&settings_path); }
+        }
+        drop(_guard);
+
+        result.unwrap();
+
+        // The log file must NOT exist (project hook must not have run)
+        let log_content = std::fs::read_to_string(&log_file).unwrap_or_default();
+        let _ = std::fs::remove_file(&log_file);
+        assert!(
+            !log_content.contains("project-hook"),
+            "project hook must NOT run when include_project_config=false (log: {log_content:?})"
         );
     }
 }

--- a/crates/server/src/issue-lifecycle.spec.md
+++ b/crates/server/src/issue-lifecycle.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
   - crates/cli/src/**/*.rs
-verified: 2026-04-25T10:02:12Z
+verified: 2026-04-25T11:20:03Z
 ---
 
 # Issue Lifecycle Spec

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -2352,10 +2352,13 @@ mod tests {
     async fn test_issue_auto_completes_when_session_succeeds() {
         let (app, state) = test_app_with_state().await;
 
+        // Use a non-existent agent name so the harness does not load any agent
+        // definition from disk (which would pull in include_project_config and
+        // real project hooks that depend on the working-tree state).
         let create_resp = app
             .clone()
             .oneshot(issue_req("POST", "/issues", serde_json::json!({
-                "title": "Auto complete test", "body": "body", "assignee": "swe"
+                "title": "Auto complete test", "body": "body", "assignee": "test-agent-no-disk-def"
             })))
             .await
             .unwrap();

--- a/crates/server/src/session-lifecycle.spec.md
+++ b/crates/server/src/session-lifecycle.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/harness/src/**/*.rs
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
-verified: 2026-04-25T10:02:12Z
+verified: 2026-04-25T11:20:03Z
 ---
 
 # Session Lifecycle Spec

--- a/product-flows/01-server-lifecycle.spec.md
+++ b/product-flows/01-server-lifecycle.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 01: Server Lifecycle

--- a/product-flows/02-session-create-and-list.spec.md
+++ b/product-flows/02-session-create-and-list.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 02: Session Create and List

--- a/product-flows/03-bash-tool.spec.md
+++ b/product-flows/03-bash-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 03: Bash Tool

--- a/product-flows/04-hello-world-real.spec.md
+++ b/product-flows/04-hello-world-real.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/anthropic/src/**/*.rs
   - crates/server/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 04: Hello World (Real Claude API)

--- a/product-flows/05-server-not-running-errors.spec.md
+++ b/product-flows/05-server-not-running-errors.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 05: Error Handling When Server Is Down

--- a/product-flows/06-read-tool.spec.md
+++ b/product-flows/06-read-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 06: Read Tool

--- a/product-flows/07-multi-tool.spec.md
+++ b/product-flows/07-multi-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 07: Multi-Tool (Write + Read)

--- a/product-flows/08-multi-turn.spec.md
+++ b/product-flows/08-multi-turn.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/db/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 08: Multi-Turn Conversation

--- a/product-flows/09-agent-commands.spec.md
+++ b/product-flows/09-agent-commands.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/agents/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 09: Agent Commands

--- a/product-flows/10-spec-new.spec.md
+++ b/product-flows/10-spec-new.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/specs/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 10: Spec New

--- a/product-flows/11-spec-sync.spec.md
+++ b/product-flows/11-spec-sync.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/specs/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 11: Spec Sync

--- a/product-flows/12-spec-verify.spec.md
+++ b/product-flows/12-spec-verify.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/specs/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 12: Spec Verify

--- a/product-flows/13-issue-lifecycle.spec.md
+++ b/product-flows/13-issue-lifecycle.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 13: Issue Lifecycle

--- a/product-flows/14-issue-list-filter.spec.md
+++ b/product-flows/14-issue-list-filter.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/cli/src/main.rs
   - crates/db/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 14: Issue List and Filtering

--- a/product-flows/15-issue-relationships.spec.md
+++ b/product-flows/15-issue-relationships.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 15: Issue Relationships

--- a/product-flows/16-issue-error-cases.spec.md
+++ b/product-flows/16-issue-error-cases.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/cli/src/main.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 16: Issue Error Cases

--- a/product-flows/17-session-wait.spec.md
+++ b/product-flows/17-session-wait.spec.md
@@ -1,7 +1,7 @@
 ---
 targets:
   - crates/cli/src/main.rs
-verified: 2026-04-25T10:02:12Z
+verified: 2026-04-25T11:20:04Z
 ---
 
 # Flow 17: Session Wait

--- a/product-flows/18-stateless-session-resume.spec.md
+++ b/product-flows/18-stateless-session-resume.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 18: Stateless Session Resume

--- a/product-flows/19-orphan-recovery-and-reopen.spec.md
+++ b/product-flows/19-orphan-recovery-and-reopen.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
   - crates/cli/src/**/*.rs
-verified: 2026-04-25T10:02:12Z
+verified: 2026-04-25T11:20:04Z
 ---
 
 # Flow 19: Server Restart Orphan Recovery and Issue Reopen

--- a/product-flows/20-auto-complete-posts-comment.spec.md
+++ b/product-flows/20-auto-complete-posts-comment.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-25T10:03:20Z
+verified: 2026-04-25T11:26:14Z
 ---
 
 # Flow 20: Auto-Complete Posts Final Turn as Comment

--- a/product-flows/21-project-config-inheritance.spec.md
+++ b/product-flows/21-project-config-inheritance.spec.md
@@ -1,0 +1,180 @@
+---
+targets:
+  - crates/agents/src/**/*.rs
+  - crates/harness/src/**/*.rs
+verified: 2026-04-25T11:19:57Z
+---
+
+# Flow 21: Project Config Inheritance (CLAUDE.md Loading)
+
+When an agent definition has `include_project_config: true` in its frontmatter, the harness
+loads `CLAUDE.md` from the repository root and appends its content (plus any `@`-imported files)
+to the agent's system prompt before starting the session.
+
+`@`-imports may be embedded anywhere in a line (e.g. `See @docs/style.md for details`).
+Invalid imports produce a warning on stderr but do not abort the session.
+
+## Prerequisites
+
+No API key required. The server is started without `ANTHROPIC_API_KEY` so the stub client is
+used — sessions complete immediately with a canned response. What we verify is the system prompt
+content captured from requests sent to the stub.
+
+## Fixture Setup
+
+```bash
+docker exec ns2-flow-21 bash /fixtures/init.sh
+docker exec ns2-flow-21 bash /fixtures/start-server.sh
+```
+
+## Steps
+
+### Step 1: Create a CLAUDE.md with an embedded @-import
+
+```bash
+docker exec ns2-flow-21 bash -c 'cat > /repo/CLAUDE.md <<'"'"'EOF'"'"'
+# Project Config
+
+This is the project guide. See @docs/style.md for style rules.
+
+## Commands
+cargo test
+EOF'
+```
+
+```bash
+docker exec ns2-flow-21 bash -c 'mkdir -p /repo/docs && cat > /repo/docs/style.md <<'"'"'EOF'"'"'
+# Style Guide
+
+Use snake_case everywhere.
+EOF'
+```
+
+Expected: files written without error.
+
+### Step 2: Create an agent with `include_project_config: true`
+
+```bash
+docker exec ns2-flow-21 bash -c 'mkdir -p /repo/.ns2/agents && cat > /repo/.ns2/agents/project-agent.md <<'"'"'EOF'"'"'
+---
+name: project-agent
+description: Agent that loads CLAUDE.md into its system prompt
+include_project_config: true
+---
+
+You are a helpful assistant.
+EOF'
+```
+
+Expected: file written without error.
+
+### Step 3: Create an agent without `include_project_config` (defaults to false)
+
+```bash
+docker exec ns2-flow-21 bash -c 'cat > /repo/.ns2/agents/plain-agent.md <<'"'"'EOF'"'"'
+---
+name: plain-agent
+description: Agent that does NOT load CLAUDE.md
+---
+
+You are a plain assistant.
+EOF'
+```
+
+Expected: file written without error.
+
+### Step 4: Start a session with `project-agent` and capture the system prompt
+
+```bash
+docker exec ns2-flow-21 bash -c 'cd /repo && ns2 session new --agent project-agent --message "hello" > /tmp/sess_project.txt && cat /tmp/sess_project.txt'
+```
+
+Expected: a UUID is printed to stdout.
+
+```bash
+docker exec ns2-flow-21 bash -c 'ns2 session tail --id "$(cat /tmp/sess_project.txt)"'
+```
+
+Expected: output contains `[done]` (stub client completes immediately).
+
+### Step 5: Verify the system prompt included CLAUDE.md content
+
+```bash
+docker exec ns2-flow-21 bash -c 'ns2 session tail --id "$(cat /tmp/sess_project.txt)" 2>&1 | grep -q "done" && echo "completed"'
+```
+
+Inspect the captured request body written by the test harness to confirm the system prompt
+contains both the agent body and the CLAUDE.md content:
+
+```bash
+docker exec ns2-flow-21 bash -c 'cat /tmp/captured-system.txt'
+```
+
+Expected: `/tmp/captured-system.txt` contains `You are a helpful assistant.` AND
+`This is the project guide.` AND `Use snake_case everywhere.`
+(the agent body is prepended; CLAUDE.md body and its @-imported content follow).
+
+### Step 6: Start a session with `plain-agent` and verify CLAUDE.md is NOT included
+
+```bash
+docker exec ns2-flow-21 bash -c 'cd /repo && ns2 session new --agent plain-agent --message "hello" > /tmp/sess_plain.txt && ns2 session tail --id "$(cat /tmp/sess_plain.txt)"'
+```
+
+Expected: output contains `[done]`.
+
+```bash
+docker exec ns2-flow-21 bash -c 'cat /tmp/captured-system.txt'
+```
+
+Expected: `/tmp/captured-system.txt` contains `You are a plain assistant.` but does NOT
+contain `This is the project guide.`.
+
+### Step 7: Verify @-import embedded in a line is resolved
+
+```bash
+docker exec ns2-flow-21 bash -c 'cat /tmp/captured-system.txt | grep -c "Use snake_case"'
+```
+
+Expected: output is `1` — the style guide was imported exactly once even though the `@`-import
+appeared mid-line (`See @docs/style.md for style rules.`).
+
+### Step 8: Invalid @-import warns but does not abort
+
+```bash
+docker exec ns2-flow-21 bash -c 'cat >> /repo/CLAUDE.md <<'"'"'EOF'"'"'
+
+Also see @nonexistent/file.md for more info.
+EOF'
+```
+
+```bash
+docker exec ns2-flow-21 bash -c 'cd /repo && ns2 session new --agent project-agent --message "hello" 2>/tmp/sess_warn_err.txt > /tmp/sess_warn.txt && ns2 session tail --id "$(cat /tmp/sess_warn.txt)"'
+```
+
+Expected: session still completes (`[done]` in output). `cat /tmp/sess_warn_err.txt` contains a
+warning mentioning `nonexistent/file.md` (or similar) — written to stderr, not aborting the
+session.
+
+```bash
+docker exec ns2-flow-21 bash -c 'grep -i "warn\|import\|nonexistent" /tmp/sess_warn_err.txt'
+```
+
+Expected: at least one line matching the grep — a human-readable warning about the missing import.
+
+## Acceptance Criteria
+
+- [ ] `AgentDef` gains an `include_project_config: bool` field (defaults to `false` when absent from frontmatter)
+- [ ] `parse_agent_content` parses `include_project_config: true/false` from frontmatter
+- [ ] `format_agent_file` serializes `include_project_config` when `true` (omits the field when `false`)
+- [ ] When `include_project_config` is `true`, the harness loads `CLAUDE.md` from the git root before building the system prompt
+- [ ] The final system prompt is: `<agent body>\n\n<CLAUDE.md content>\n\n<imported file content>` (agent body first)
+- [ ] `@path/to/file.md` references anywhere in a line in CLAUDE.md are resolved relative to git root and their content appended
+- [ ] Each imported file is included at most once (dedup by path)
+- [ ] If an `@`-imported file does not exist, a warning is emitted to stderr and the session continues
+- [ ] If `CLAUDE.md` itself does not exist, a warning is emitted to stderr and the session continues with only the agent body
+- [ ] A session with `include_project_config: false` (or absent) sends no CLAUDE.md content in system prompt
+- [ ] Existing `AgentDef` parse/format round-trips remain valid (no regression)
+
+## Cleanup
+
+Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/22-session-hooks.spec.md
+++ b/product-flows/22-session-hooks.spec.md
@@ -1,0 +1,287 @@
+---
+targets:
+  - crates/agents/src/**/*.rs
+  - crates/harness/src/**/*.rs
+verified: 2026-04-25T11:19:57Z
+---
+
+# Flow 22: Session Lifecycle Hooks (PreToolUse / PostToolUse / Stop)
+
+Agent definitions may declare lifecycle hooks that the harness runs at specific points:
+
+- **PreToolUse** — before each tool call; can block the tool by exiting non-zero
+- **PostToolUse** — after each tool call (informational; exit code is ignored)
+- **Stop** — when the agent turn loop ends (after `stop_reason == "end_turn"`); can block
+  completion by exiting non-zero and providing a message back to the model
+
+When an agent has `include_project_config: true`, it also inherits any hooks defined in
+`.claude/settings.json` at the project root. Agent-level hooks take precedence over
+project-level hooks for the same event type and matcher.
+
+Hook schema matches Claude Code's schema: each hook entry has `type: "command"`, `command`,
+optional `timeout` (seconds), optional `statusMessage`. The harness passes a JSON payload via
+stdin to each hook command.
+
+## Prerequisites
+
+No API key required. The server is started without `ANTHROPIC_API_KEY` so the stub client is
+used. The stub always returns `stop_reason: "end_turn"`.
+
+## Fixture Setup
+
+```bash
+docker exec ns2-flow-22 bash /fixtures/init.sh
+docker exec ns2-flow-22 bash /fixtures/start-server.sh
+```
+
+## Steps
+
+### Step 1: Create a PreToolUse hook that logs tool calls
+
+```bash
+docker exec ns2-flow-22 bash -c 'mkdir -p /repo/scripts && cat > /repo/scripts/log-tool.sh <<'"'"'EOF'"'"'
+#!/usr/bin/env bash
+INPUT=$(cat)
+TOOL=$(printf "%s" "$INPUT" | jq -r ".tool_name // \"unknown\"")
+echo "pre-tool: $TOOL" >> /tmp/hook-log.txt
+exit 0
+EOF
+chmod +x /repo/scripts/log-tool.sh'
+```
+
+Expected: script written and made executable.
+
+### Step 2: Create an agent with a PreToolUse hook
+
+```bash
+docker exec ns2-flow-22 bash -c 'mkdir -p /repo/.ns2/agents && cat > /repo/.ns2/agents/hooked-agent.md <<'"'"'EOF'"'"'
+---
+name: hooked-agent
+description: Agent with PreToolUse and PostToolUse hooks
+hooks:
+  PreToolUse:
+    - matcher: ".*"
+      hooks:
+        - type: command
+          command: /repo/scripts/log-tool.sh
+          timeout: 10
+---
+
+You are a helpful assistant. Use the bash tool to run: echo hooked
+EOF'
+```
+
+Expected: file written without error.
+
+### Step 3: Start a session with `hooked-agent`
+
+```bash
+docker exec ns2-flow-22 bash -c 'cd /repo && ns2 session new --agent hooked-agent --message "run the bash tool" > /tmp/sess_hook.txt && cat /tmp/sess_hook.txt'
+```
+
+Expected: a UUID is printed.
+
+```bash
+docker exec ns2-flow-22 bash -c 'ns2 session tail --id "$(cat /tmp/sess_hook.txt)"'
+```
+
+Expected: output contains `[done]`.
+
+### Step 4: Verify PreToolUse hook was invoked
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat /tmp/hook-log.txt'
+```
+
+Expected: at least one line beginning with `pre-tool:`.
+
+### Step 5: Create a PreToolUse hook that blocks a tool
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat > /repo/scripts/block-tool.sh <<'"'"'EOF'"'"'
+#!/usr/bin/env bash
+INPUT=$(cat)
+TOOL=$(printf "%s" "$INPUT" | jq -r ".tool_name // \"\"")
+if [ "$TOOL" = "bash" ]; then
+    echo "Bash tool is blocked by policy." >&2
+    exit 2
+fi
+exit 0
+EOF
+chmod +x /repo/scripts/block-tool.sh'
+```
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat > /repo/.ns2/agents/blocked-agent.md <<'"'"'EOF'"'"'
+---
+name: blocked-agent
+description: Agent whose bash tool is blocked
+hooks:
+  PreToolUse:
+    - matcher: "bash"
+      hooks:
+        - type: command
+          command: /repo/scripts/block-tool.sh
+          timeout: 10
+---
+
+You are a helpful assistant.
+EOF'
+```
+
+Expected: agent written without error.
+
+### Step 6: Verify a blocked PreToolUse hook causes the harness to skip the tool
+
+```bash
+docker exec ns2-flow-22 bash -c 'cd /repo && ns2 session new --agent blocked-agent --message "run bash: echo hello" > /tmp/sess_blocked.txt && ns2 session tail --id "$(cat /tmp/sess_blocked.txt)"'
+```
+
+Expected: output contains `[done]` (session completes). The tool result fed back to the model
+contains the hook's blocking message (`Bash tool is blocked by policy.`) rather than running the
+actual command.
+
+### Step 7: Create a Stop hook that always allows stopping
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat > /repo/scripts/stop-allow.sh <<'"'"'EOF'"'"'
+#!/usr/bin/env bash
+echo "stop hook ran" >> /tmp/stop-log.txt
+exit 0
+EOF
+chmod +x /repo/scripts/stop-allow.sh'
+```
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat > /repo/.ns2/agents/stop-agent.md <<'"'"'EOF'"'"'
+---
+name: stop-agent
+description: Agent with a Stop hook that allows stopping
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: /repo/scripts/stop-allow.sh
+          timeout: 10
+---
+
+You are a helpful assistant.
+EOF'
+```
+
+```bash
+docker exec ns2-flow-22 bash -c 'cd /repo && ns2 session new --agent stop-agent --message "hello" > /tmp/sess_stop.txt && ns2 session tail --id "$(cat /tmp/sess_stop.txt)"'
+```
+
+Expected: `[done]` in output.
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat /tmp/stop-log.txt'
+```
+
+Expected: contains `stop hook ran`.
+
+### Step 8: Project-level hooks are inherited when `include_project_config: true`
+
+```bash
+docker exec ns2-flow-22 bash -c 'mkdir -p /repo/.claude/hooks && cat > /repo/.claude/hooks/proj-hook.sh <<'"'"'EOF'"'"'
+#!/usr/bin/env bash
+echo "project-hook ran" >> /tmp/proj-hook-log.txt
+exit 0
+EOF
+chmod +x /repo/.claude/hooks/proj-hook.sh'
+```
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat > /repo/.claude/settings.json <<'"'"'EOF'"'"'
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {"type": "command", "command": "/repo/.claude/hooks/proj-hook.sh", "timeout": 10}
+        ]
+      }
+    ]
+  }
+}
+EOF'
+```
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat > /repo/.ns2/agents/proj-config-agent.md <<'"'"'EOF'"'"'
+---
+name: proj-config-agent
+description: Agent that inherits project-level hooks
+include_project_config: true
+---
+
+You are a helpful assistant. Use the bash tool to run: echo inherited
+EOF'
+```
+
+```bash
+docker exec ns2-flow-22 bash -c 'cd /repo && ns2 session new --agent proj-config-agent --message "run bash tool" > /tmp/sess_proj.txt && ns2 session tail --id "$(cat /tmp/sess_proj.txt)"'
+```
+
+Expected: `[done]` in output.
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat /tmp/proj-hook-log.txt'
+```
+
+Expected: contains `project-hook ran` — confirming the project-level PostToolUse hook was
+inherited.
+
+### Step 9: Agent-level hooks take precedence over project-level hooks for the same event+matcher
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat > /repo/.ns2/agents/override-agent.md <<'"'"'EOF'"'"'
+---
+name: override-agent
+description: Agent whose hooks override project hooks for the same event
+include_project_config: true
+hooks:
+  PostToolUse:
+    - matcher: ".*"
+      hooks:
+        - type: command
+          command: /repo/scripts/log-tool.sh
+          timeout: 10
+---
+
+You are a helpful assistant. Use bash tool: echo override
+EOF'
+```
+
+```bash
+docker exec ns2-flow-22 bash -c 'rm -f /tmp/proj-hook-log.txt /tmp/hook-log.txt && cd /repo && ns2 session new --agent override-agent --message "run bash" > /tmp/sess_ov.txt && ns2 session tail --id "$(cat /tmp/sess_ov.txt)"'
+```
+
+Expected: `[done]`.
+
+```bash
+docker exec ns2-flow-22 bash -c 'cat /tmp/hook-log.txt && echo "proj log:"; cat /tmp/proj-hook-log.txt 2>/dev/null || echo "(absent)"'
+```
+
+Expected: `/tmp/hook-log.txt` contains `pre-tool:`; `/tmp/proj-hook-log.txt` is absent or empty
+(agent-level PostToolUse replaced the project-level one for the same matcher).
+
+## Acceptance Criteria
+
+- [ ] `AgentDef` supports a `hooks` field in frontmatter; missing field means no hooks
+- [ ] Hooks are parsed from YAML frontmatter following the schema: `hooks: { EventType: [ { matcher, hooks: [ { type, command, timeout? } ] } ] }`
+- [ ] Stop hooks have no `matcher` field (they apply unconditionally)
+- [ ] **PreToolUse**: harness runs the hook command before each tool call; if exit code ≥ 1, the tool is skipped and hook stderr is returned as the tool result
+- [ ] **PostToolUse**: harness runs the hook command after each tool call; exit code is always ignored
+- [ ] **Stop**: harness runs the hook after `stop_reason == "end_turn"`; if exit code ≥ 1, hook stdout is injected as a new user message and the turn loop continues
+- [ ] Hook stdin receives a JSON payload: `{"tool_name": "...", "tool_input": {...}}` for tool hooks; `{"session_id": "..."}` for Stop hooks
+- [ ] When `include_project_config: true`, hooks from `.claude/settings.json` are loaded and merged; agent-level hooks for the same event type and matcher take precedence
+- [ ] `.claude/settings.json` absence is not an error
+- [ ] Hook timeout defaults to 60 seconds if not specified; commands that exceed timeout are killed and treated as if they returned exit code 1
+- [ ] All hook invocations are non-blocking from the test suite's perspective (harness awaits them serially within a turn)
+
+## Cleanup
+
+Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.

--- a/product-flows/23-stop-hook-commit-guard.spec.md
+++ b/product-flows/23-stop-hook-commit-guard.spec.md
@@ -1,0 +1,161 @@
+---
+targets:
+  - crates/agents/src/**/*.rs
+  - crates/harness/src/**/*.rs
+  - .ns2/agents/**/*.md
+  - .claude/hooks/stop-commit-guard.sh
+verified: 2026-04-25T11:24:12Z
+---
+
+# Flow 23: Stop Hook — Commit Guard
+
+A project-level Stop hook checks `git status` after every agent turn loop ends. If there are
+untracked, unstaged, or uncommitted changes, the hook exits non-zero and tells the model to
+commit its work before stopping.
+
+All agents in `.ns2/agents/` have `include_project_config: true` so they inherit this hook
+automatically.
+
+## Prerequisites
+
+No API key required. The server is started without `ANTHROPIC_API_KEY` so the stub client is
+used. What we verify is hook wiring and git-status logic — not model output.
+
+## Fixture Setup
+
+```bash
+docker exec ns2-flow-23 bash /fixtures/init.sh
+docker exec ns2-flow-23 bash /fixtures/start-server.sh
+```
+
+## Steps
+
+### Step 1: Verify all agents in .ns2/agents/ declare `include_project_config: true`
+
+```bash
+docker exec ns2-flow-23 bash -c 'cd /repo && for f in .ns2/agents/*.md; do echo "$f:"; grep "include_project_config" "$f" || echo "  MISSING"; done'
+```
+
+Expected: every agent file prints a line containing `include_project_config: true`. No file
+prints `MISSING`.
+
+### Step 2: Verify the project stop-hook script exists and is executable
+
+```bash
+docker exec ns2-flow-23 bash -c 'test -x /repo/.claude/hooks/stop-commit-guard.sh && echo "ok"'
+```
+
+Expected: `ok`.
+
+### Step 3: Verify the stop hook is registered in .claude/settings.json
+
+```bash
+docker exec ns2-flow-23 bash -c 'cat /repo/.claude/settings.json | jq ".hooks.Stop"'
+```
+
+Expected: JSON array with at least one entry whose `command` contains `stop-commit-guard.sh`.
+
+### Step 4: Clean working tree — stop hook allows stopping
+
+```bash
+docker exec ns2-flow-23 bash -c 'cd /repo && git status --short'
+```
+
+Expected: no output (clean tree).
+
+```bash
+docker exec ns2-flow-23 bash -c '/repo/.claude/hooks/stop-commit-guard.sh <<'"'"'EOF'"'"'
+{"session_id": "test-session"}
+EOF
+echo "exit: $?"'
+```
+
+Expected: `exit: 0`. Hook exits cleanly when tree is clean.
+
+### Step 5: Dirty working tree — stop hook blocks and prints guidance
+
+```bash
+docker exec ns2-flow-23 bash -c 'echo "dirty" > /repo/dirty-file.txt'
+```
+
+```bash
+docker exec ns2-flow-23 bash -c '/repo/.claude/hooks/stop-commit-guard.sh <<'"'"'EOF'"'"'
+{"session_id": "test-session"}
+EOF
+echo "exit: $?"'
+```
+
+Expected: `exit: 1` (or any non-zero code). Output contains a message instructing the agent to
+commit changes — something like `You have uncommitted changes. Please commit your work before
+stopping.` (exact wording may vary).
+
+```bash
+docker exec ns2-flow-23 bash -c 'rm /repo/dirty-file.txt'
+```
+
+### Step 6: Staged but uncommitted changes — stop hook blocks
+
+```bash
+docker exec ns2-flow-23 bash -c 'cd /repo && echo "staged" > staged-file.txt && git add staged-file.txt'
+```
+
+```bash
+docker exec ns2-flow-23 bash -c '/repo/.claude/hooks/stop-commit-guard.sh <<'"'"'EOF'"'"'
+{"session_id": "test-session"}
+EOF
+echo "exit: $?"'
+```
+
+Expected: `exit: 1`. Hook prints a message about uncommitted/staged changes.
+
+```bash
+docker exec ns2-flow-23 bash -c 'cd /repo && git rm --cached staged-file.txt && rm staged-file.txt'
+```
+
+### Step 7: Session with an agent — harness invokes stop hook
+
+```bash
+docker exec ns2-flow-23 bash -c 'echo "unsaved" > /repo/unsaved.txt'
+```
+
+```bash
+docker exec ns2-flow-23 bash -c 'cd /repo && ns2 session new --agent swe --message "say hello" > /tmp/sess_stop23.txt && cat /tmp/sess_stop23.txt'
+```
+
+Expected: UUID printed.
+
+```bash
+docker exec ns2-flow-23 bash -c 'ns2 session tail --id "$(cat /tmp/sess_stop23.txt)" 2>&1 | tail -5'
+```
+
+Expected: output contains a message from the hook (`uncommitted changes` or similar) injected as
+a follow-up user message, causing the agent to continue its loop. The session does NOT reach
+`[done]` in the first turn.
+
+```bash
+docker exec ns2-flow-23 bash -c 'rm /repo/unsaved.txt'
+```
+
+### Step 8: After cleanup, agent eventually stops cleanly
+
+```bash
+docker exec ns2-flow-23 bash -c 'ns2 session tail --id "$(cat /tmp/sess_stop23.txt)"'
+```
+
+Expected: output eventually contains `[done]` after the working tree becomes clean (either the
+stub model loop exhausts or the tree is already clean by the time the next stop fires).
+
+## Acceptance Criteria
+
+- [ ] `.claude/hooks/stop-commit-guard.sh` exists, is executable, reads JSON from stdin, and runs `git status --short` in `CLAUDE_PROJECT_DIR` (or the repo root)
+- [ ] Hook exits 0 when `git status --short` produces no output (clean tree)
+- [ ] Hook exits non-zero and prints a commit instruction message when there are any untracked, unstaged, or staged-but-uncommitted changes
+- [ ] `.claude/settings.json` includes a `Stop` hook entry pointing to `stop-commit-guard.sh`
+- [ ] Every file in `.ns2/agents/` has `include_project_config: true` in its frontmatter
+- [ ] The harness invokes Stop hooks after `stop_reason == "end_turn"`; a non-zero exit causes the hook's stdout to be sent as a new user message and the loop continues
+- [ ] A clean working tree allows the Stop hook to pass and the session to reach `completed`
+- [ ] The commit guard hook works correctly when `CLAUDE_PROJECT_DIR` is set (mirrors the env var convention from Claude Code)
+
+## Cleanup
+
+Do not run any cleanup commands. The smoke-test skill tears down containers after all flows complete and may inspect state first.


### PR DESCRIPTION
## Summary

- **GH #32 - Project config inheritance**: `AgentDef` gains `include_project_config: bool`; when true, the harness loads `CLAUDE.md` from the git root into the system prompt and resolves `@`-imports (embedded mid-line, deduped, warning on missing imports)
- **GH #33 - Session lifecycle hooks**: Three hook types — `PreToolUse` (matcher regex, can block tool execution), `PostToolUse` (exit code ignored), `Stop` (non-zero exit injects stdout as a user message to continue the loop). When an agent uses `include_project_config`, project-level hooks from `.claude/settings.json` are merged in (agent hooks take precedence)
- **GH #34 - Commit guard stop hook**: `.claude/hooks/stop-commit-guard.sh` blocks agent completion when the working tree is dirty; all five agents now have `include_project_config: true` so they inherit the hook automatically

## Key implementation details

- Hook schema matches Claude Code's schema (`PreToolUse`, `PostToolUse`, `Stop` with optional matcher regex and command array)
- `load_project_config` resolves `@path/to/file` references anywhere in a line, deduplicates imports, warns on missing files without aborting
- `load_project_hooks` reads `.claude/settings.json` and merges hooks; project entries with duplicate matchers are dropped (agent hooks win)
- New product-flow specs: 21 (project config inheritance), 22 (session hooks), 23 (stop hook / commit guard)
- All existing stale specs verified against updated implementation

## Test plan

- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (245 tests total including 47 new agents tests and 39 harness tests)
- [ ] `cargo llvm-cov` 96.29% total line coverage (≥85%)
- [ ] `ns2 spec sync` shows no errors
- [ ] Smoke test flow 21: CLAUDE.md loaded into system prompt, @-imports resolved mid-line, missing imports produce warning without aborting
- [ ] `stop-commit-guard.sh` exits 0 on clean tree, exits 1 with guidance on dirty tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)