### PR TITLE
fix(harness): stop hook exit 127 fails open

### DIFF
--- a/crates/harness/agent-harness.spec.md
+++ b/crates/harness/agent-harness.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/harness/Cargo.toml
   - crates/anthropic/src/**/*.rs
   - crates/tools/src/**/*.rs
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:35:54Z
 ---
 
 # Agent Harness Spec

--- a/crates/harness/agent-sessions.spec.md
+++ b/crates/harness/agent-sessions.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:35:54Z
 ---
 
 # Agent Sessions Spec

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -148,6 +148,11 @@ async fn run_post_tool_use_hooks(
 /// Run Stop hooks.
 /// Returns `Some(injected_message)` if any hook exits non-zero (the message should be
 /// injected into the conversation to continue the loop), or `None` to allow completion.
+///
+/// Exit code 127 (command not found) is treated as a configuration error and fails
+/// open — the hook is skipped and the session is allowed to complete normally.
+/// This prevents an infinite loop when a hook script cannot be found (e.g. because
+/// `$CLAUDE_PROJECT_DIR` is unset and the path cannot be resolved).
 async fn run_stop_hooks(hooks: &AgentHooks, session_id: Uuid) -> Option<String> {
     let stdin = serde_json::json!({ "session_id": session_id.to_string() });
     let stdin_str = stdin.to_string();
@@ -156,6 +161,15 @@ async fn run_stop_hooks(hooks: &AgentHooks, session_id: Uuid) -> Option<String> 
         for cmd in &entry.hooks {
             let (exit_code, stdout, _stderr) = run_hook(cmd, &stdin_str).await;
             if exit_code != 0 {
+                // Exit 127 = command not found: configuration error, not a deliberate
+                // block. Fail open so the agent is not trapped in an infinite loop.
+                if exit_code == 127 {
+                    tracing::warn!(
+                        "stop hook command not found (exit 127): '{}' — failing open",
+                        cmd.command
+                    );
+                    continue;
+                }
                 return Some(if stdout.is_empty() {
                     format!("Stop hook exited with code {exit_code}")
                 } else {

--- a/crates/server/src/session-lifecycle.spec.md
+++ b/crates/server/src/session-lifecycle.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/harness/src/**/*.rs
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:35:54Z
 ---
 
 # Session Lifecycle Spec

--- a/product-flows/03-bash-tool.spec.md
+++ b/product-flows/03-bash-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:36:35Z
 ---
 
 # Flow 03: Bash Tool

--- a/product-flows/04-hello-world-real.spec.md
+++ b/product-flows/04-hello-world-real.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/anthropic/src/**/*.rs
   - crates/server/src/**/*.rs
 severity: warning
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:36:35Z
 ---
 
 # Flow 04: Hello World (Real Claude API)

--- a/product-flows/06-read-tool.spec.md
+++ b/product-flows/06-read-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:36:35Z
 ---
 
 # Flow 06: Read Tool

--- a/product-flows/07-multi-tool.spec.md
+++ b/product-flows/07-multi-tool.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/tools/src/**/*.rs
   - crates/harness/src/**/*.rs
 severity: warning
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:36:35Z
 ---
 
 # Flow 07: Multi-Tool (Write + Read)

--- a/product-flows/08-multi-turn.spec.md
+++ b/product-flows/08-multi-turn.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/server/src/**/*.rs
   - crates/db/src/**/*.rs
 severity: warning
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:36:35Z
 ---
 
 # Flow 08: Multi-Turn Conversation

--- a/product-flows/18-stateless-session-resume.spec.md
+++ b/product-flows/18-stateless-session-resume.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:36:35Z
 ---
 
 # Flow 18: Stateless Session Resume

--- a/product-flows/21-project-config-inheritance.spec.md
+++ b/product-flows/21-project-config-inheritance.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/agents/src/**/*.rs
   - crates/harness/src/**/*.rs
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:35:54Z
 ---
 
 # Flow 21: Project Config Inheritance (CLAUDE.md Loading)

--- a/product-flows/22-session-hooks.spec.md
+++ b/product-flows/22-session-hooks.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/agents/src/**/*.rs
   - crates/harness/src/**/*.rs
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:35:54Z
 ---
 
 # Flow 22: Session Lifecycle Hooks (PreToolUse / PostToolUse / Stop)

--- a/product-flows/23-stop-hook-commit-guard.spec.md
+++ b/product-flows/23-stop-hook-commit-guard.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/harness/src/**/*.rs
   - .ns2/agents/**/*.md
   - .claude/hooks/stop-commit-guard.sh
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:35:54Z
 ---
 
 # Flow 23: Stop Hook — Commit Guard

--- a/product-flows/25-session-worktree-creation.spec.md
+++ b/product-flows/25-session-worktree-creation.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/harness/src/**/*.rs
   - crates/cli/src/main.rs
   - ns2.toml
-verified: 2026-04-25T21:22:22Z
+verified: 2026-04-26T10:35:54Z
 ---
 
 # Flow 25: Session Worktree Creation


### PR DESCRIPTION
## Summary

- Exit code 127 (command not found) in a stop hook is a configuration error, not a deliberate block
- Before this fix, a misconfigured hook command path would trap the agent in an infinite stop-hook loop
- Now: exit 127 is logged as a warning and the hook is skipped, allowing the session to complete normally

The test `test_stop_hook_exit_127_fails_open` (added in 19f4d4e) was failing CI on PR #40 because this implementation fix was left uncommitted on main.

## Test plan

- [ ] `cargo test -p harness` — `test_stop_hook_exit_127_fails_open` passes
- [ ] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)