### PR TITLE
Extract issues crate — pure domain service for issue lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,6 +1263,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "issues"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "db",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "types",
+ "uuid",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2129,7 @@ dependencies = [
  "db",
  "futures",
  "harness",
+ "issues",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/workspace",
     "crates/agents",
     "crates/harness",
+    "crates/issues",
     "crates/server",
     "crates/tui",
     "crates/cli",

--- a/crates/anthropic/src/lib.rs
+++ b/crates/anthropic/src/lib.rs
@@ -346,3 +346,19 @@ impl AnthropicClient for Client {
         Ok(assembler.finish())
     }
 }
+
+/// A no-op [`AnthropicClient`] that returns a fixed stub response.
+/// Used when `ANTHROPIC_API_KEY` is not set.
+pub struct StubClient;
+
+#[async_trait::async_trait]
+impl AnthropicClient for StubClient {
+    async fn complete(&self, _request: MessageRequest) -> Result<MessageResponse> {
+        Ok(MessageResponse {
+            content: vec![types::ContentBlock::Text { text: "stub".into() }],
+            stop_reason: "end_turn".into(),
+            input_tokens: 1,
+            output_tokens: 1,
+        })
+    }
+}

--- a/crates/arch-tests/architecture.spec.md
+++ b/crates/arch-tests/architecture.spec.md
@@ -2,39 +2,73 @@
 targets:
   - Cargo.toml
   - crates/*/Cargo.toml
-verified: 2026-04-26T17:28:05Z
+verified: 2026-04-28T00:00:00Z
 ---
 
 # Architecture Spec
 
-## Overview
+## Design Principles
 
-The workspace is a flat set of crates, each owning one layer of the system. Dependencies are a directed, acyclic graph. Any crate should be able to be understood, tested, and replaced without reading the others.
+Flat set of crates, each owning one layer. Dependencies are a directed acyclic graph — any crate can be understood, tested, and replaced without reading the others.
 
-**Deep modules:** each crate exposes a narrow, well-defined public interface and hides its implementation complexity.
+**Do not add dependencies to a crate's `Cargo.toml` to work around an architectural boundary.** Adding a dep to the wrong crate is a violation, not a shortcut.
 
-**Do not add dependencies to a crate's `Cargo.toml` to work around an architectural boundary.** Adding a dependency to the wrong crate is an architectural violation, not a pragmatic shortcut. When in doubt, request input on how to proceed.
+When adding a substantial new unit of responsibilities or business logic, consider whether a new crate should be created instead of adding it to an existing one.
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    types
+    workspace
+
+    db --> types
+    anthropic --> types
+    tools --> types
+    agents --> workspace
+    specs --> workspace
+
+    harness --> db & anthropic & tools & agents & workspace
+
+    issues --> db
+
+    server --> issues & db & anthropic & tools & harness
+
+    tui --> types
+    cli --> agents & specs & workspace
+```
+
+Arrows point from dependent to dependency.
 
 ## Crates
 
-**`types`** — shared domain types with no dependencies: `Session`, `Turn`, `ContentBlock`, `SessionStatus`, SSE event envelopes, tool input/output shapes. Everything else depends on this; it depends on nothing.
+**`types`** — shared domain types: `Session`, `Turn`, `ContentBlock`, `Issue`, SSE events, tool shapes. No behavior.
 
-**`db`** — all SQLite access via sqlx. Owns the schema, migrations, and every query. Nothing outside this crate writes SQL. Exposes an async repository interface that the rest of the system talks to.
+**`db`** — SQLite access via sqlx. Owns schema, migrations, and every query.
+_Doesn't own: SQL written anywhere else._
 
-**`anthropic`** — HTTP client for the Anthropic Messages API. Owns streaming SSE parsing, assembles raw deltas into complete `ContentBlock`s, and surfaces a clean async interface. All knowledge of the wire format lives here.
+**`anthropic`** — HTTP client for the Anthropic Messages API. Streaming SSE parsing, request/response types.
 
-**`tools`** — defines the `Tool` trait and implements the standard tools: `bash`, `read`, `write`, `edit`. Each tool is self-contained. The harness depends on this crate; tools have no knowledge of sessions or turns.
+**`tools`** — `Tool` trait plus `bash`, `read`, `write`, `edit` implementations.
+_Doesn't own: session or turn state._
 
-**`workspace`** — git worktree management. Creates a worktree for a branch on demand; worktrees persist until explicitly removed via CLI (typically after merge). Purely a git operations crate — no knowledge of sessions. Also exposes `git_root()` — a utility that returns the repository root, used by `cli` for locating config files and data directories. All git interactions belong here.
+**`workspace`** — git worktree management and `git_root()` discovery.
 
-**`agents`** — agent definition files. Reads and writes `.ns2/agents/*.md` files, which define agent types via YAML frontmatter (`name`, `description`) and a system prompt body. Exposes a pure in-memory `AgentDef` type, parsing/formatting helpers, and directory-based list/load/write operations. Depends only on `workspace` for `git_root()` discovery. No knowledge of sessions, turns, or HTTP.
+**`agents`** — reads/writes `.ns2/agents/*.md` agent definition files.
 
-**`specs`** — spec file management. Reads and writes `.spec.md` files anywhere in the repo, which declare which source files a spec governs via YAML frontmatter (`targets`: glob patterns, `verified`: UTC timestamp). Exposes a pure in-memory `SpecDef` type, parsing/formatting helpers, recursive discovery (`list_specs`), and staleness checking (`stale_files`). Depends only on `workspace` for `git_root()` discovery. No knowledge of sessions, turns, or HTTP.
+**`specs`** — reads/writes `.spec.md` files; staleness checking.
 
-**`harness`** — the agent turn loop. Depends on `anthropic`, `tools`, `db`, `agents`, and `workspace`. Owns context window construction, system prompt loading (reads the agent definition for `session.agent` via the `agents` crate), tool dispatch, and worktree resolution (looks up the issue branch via `db`, then calls `workspace::ensure_worktree` to set the session cwd). Emits events to a tokio broadcast channel — it has no knowledge of HTTP or subscribers. One instance runs per active session as a tokio task.
+**`harness`** — agent turn loop. Context window construction, system prompt loading, tool dispatch, worktree resolution. Emits events to a broadcast channel; one instance per active session.
+_Doesn't own: issue lifecycle or state transitions — that's `issues`. No HTTP._
 
-**`server`** — axum HTTP server. Exposes routes for session management, issue management, SSE streaming, and worktree management: creating session records, listing sessions, queuing user messages; creating, listing, editing, and completing issues; linking issues to agent sessions via `issue start`; listing, creating, and deleting git worktrees via `ns2 worktree`. Multiple sessions may run concurrently on the same branch — worktree isolation replaces the old single-session-per-branch guard. Owns its own initialization: reads `ANTHROPIC_API_KEY` from the environment, constructs the `anthropic::Client`, and instantiates the standard tools (`ReadTool`, `BashTool`, `WriteTool`, `EditTool`). `ServerConfig` covers only transport-level concerns (port, db path, model). Spawns harness tasks for new sessions but doesn't reach into the turn loop — the harness runs independently once started. Subscribes to harness broadcast channels and fans events out to SSE clients.
+**`issues`** — pure issue domain service. Owns the state machine (open → running → completed/failed/cancelled), `start_issue`, `complete_issue`, `reopen_issue`, `orphan_sweep`. Exposes `IssueService` and `StartIssueOutcome`.
+_Doesn't own: HTTP routing, harness spawning, or session maps — those belong in `server`._
+**Dependencies:** `types`, `db`.
 
-**`tui`** — ratatui terminal UI. Connects to the server via SSE and renders sessions. Thin client: all state comes from the server, nothing is computed locally.
+**`server`** — axum HTTP server. Routes, SSE fan-out, `ServerConfig`, session maps, harness spawning. Constructs the Anthropic client, standard tools, and `spawn_harness_sync`. Delegates issue lifecycle to `IssueService` but owns all harness lifecycle.
+_Doesn't own: issue business logic — delegate to `issues`._
 
-**`cli`** — the `ns2` binary. Depends on `workspace` for git root discovery, `agents` for agent management commands, and `specs` for spec file commands. Must not directly depend on `anthropic`, `harness`, or `tools` — initialization of the Anthropic client and standard tools is the server's responsibility. On launch, checks if a server is already running (via a PID file or a probe to localhost). If not, starts one in the background. Then launches the TUI connected to the orchestrator session. Wires crates together; contains no logic of its own.
+**`tui`** — ratatui terminal UI. Connects to the server via SSE. Thin client: all state comes from the server.
+
+**`cli`** — the `ns2` binary. Wires crates; contains no logic of its own.
+_Doesn't own: Anthropic client init or harness instantiation — that's `server`'s job._

--- a/crates/arch-tests/tests/architecture.rs
+++ b/crates/arch-tests/tests/architecture.rs
@@ -147,6 +147,15 @@ fn tui_is_thin_client_with_no_internal_deps() {
     }
 }
 
+/// `issues` owns issue lifecycle — must not depend on server, tui, or cli.
+#[test]
+fn issues_has_no_server_or_client_deps() {
+    let graph = build_dep_graph();
+    for forbidden in &["server", "tui", "cli"] {
+        assert_no_dep(&graph, "issues", forbidden);
+    }
+}
+
 /// `server` must not depend on tui or cli (it is consumed by cli, not the other way around).
 #[test]
 fn server_does_not_depend_on_tui_or_cli() {
@@ -476,6 +485,16 @@ fn direct_dep_edges_match_spec() {
     assert_no_direct_dep(&graph, "harness", "server");
     assert_no_direct_dep(&graph, "harness", "tui");
     assert_no_direct_dep(&graph, "harness", "cli");
+
+    // issues -> no harness/HTTP layer and no tool layer
+    assert_no_direct_dep(&graph, "issues", "harness");
+    assert_no_direct_dep(&graph, "issues", "anthropic");
+    assert_no_direct_dep(&graph, "issues", "tools");
+    assert_no_direct_dep(&graph, "issues", "workspace");
+    assert_no_direct_dep(&graph, "issues", "agents");
+    assert_no_direct_dep(&graph, "issues", "server");
+    assert_no_direct_dep(&graph, "issues", "tui");
+    assert_no_direct_dep(&graph, "issues", "cli");
 
     // server -> no client layer
     assert_no_direct_dep(&graph, "server", "tui");

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -1,5 +1,6 @@
 use agents::{AgentHooks, HookCommand, HookEntry};
 use anthropic::{AnthropicClient, MessageRequest, MessageResponse};
+#[cfg(test)]
 use async_trait::async_trait;
 use chrono::Utc;
 use regex::Regex;
@@ -321,21 +322,7 @@ pub(crate) async fn resolve_session_cwd_with_root(
     workspace::ensure_worktree(&git_root, &worktree_path, &branch).await
 }
 
-pub struct StubClient;
-
-#[async_trait]
-impl AnthropicClient for StubClient {
-    async fn complete(&self, _request: MessageRequest) -> anthropic::Result<MessageResponse> {
-        Ok(MessageResponse {
-            content: vec![ContentBlock::Text {
-                text: "Hello! I'm a stub assistant.".into(),
-            }],
-            stop_reason: "end_turn".into(),
-            input_tokens: 10,
-            output_tokens: 8,
-        })
-    }
-}
+pub use anthropic::StubClient;
 
 pub struct HarnessConfig {
     pub session: Session,

--- a/crates/issues/Cargo.toml
+++ b/crates/issues/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "issues"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+types = { path = "../types" }
+db = { path = "../db" }
+tokio = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }

--- a/crates/issues/src/lib.rs
+++ b/crates/issues/src/lib.rs
@@ -1,0 +1,567 @@
+use std::sync::Arc;
+use chrono::Utc;
+use types::{Issue, IssueComment, IssueStatus, Session, SessionStatus};
+use uuid::Uuid;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("db error: {0}")]
+    Db(#[from] db::Error),
+    #[error("bad request: {0}")]
+    BadRequest(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub struct StartIssueOutcome {
+    pub issue: Issue,
+    pub session: Session,
+    pub initial_message: String,
+}
+
+#[derive(Clone)]
+pub struct IssueService {
+    db: Arc<dyn db::Db>,
+}
+
+impl IssueService {
+    pub fn new(db: Arc<dyn db::Db>) -> Self {
+        Self { db }
+    }
+
+    pub fn db(&self) -> &Arc<dyn db::Db> {
+        &self.db
+    }
+
+    pub async fn start_issue(&self, id: String) -> Result<StartIssueOutcome> {
+        let mut issue = self.db.get_issue(id.clone()).await?;
+
+        if issue.assignee.is_none() {
+            return Err(Error::BadRequest("issue has no assignee; set one with `issue edit --assignee <agent>`".into()));
+        }
+        if issue.status != IssueStatus::Open {
+            return Err(Error::BadRequest(format!("issue is already {}", issue.status)));
+        }
+
+        let now = Utc::now();
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: format!("issue-{}", issue.id),
+            status: SessionStatus::Created,
+            agent: issue.assignee.clone(),
+            created_at: now,
+            updated_at: now,
+        };
+        self.db.create_session(&session).await?;
+
+        issue.session_id = Some(session.id);
+        issue.status = IssueStatus::Running;
+        issue.updated_at = Utc::now();
+        self.db.update_issue(&issue).await?;
+
+        let mut initial_message = format!("{}\n\n{}", issue.title, issue.body);
+        if !issue.comments.is_empty() {
+            initial_message.push_str("\n\n---\n# Issue History\n");
+            for comment in &issue.comments {
+                initial_message.push_str(&format!(
+                    "\n**{}** ({}): {}\n",
+                    comment.author,
+                    comment.created_at.format("%Y-%m-%d %H:%M UTC"),
+                    comment.body
+                ));
+            }
+        }
+
+        Ok(StartIssueOutcome { issue, session, initial_message })
+    }
+
+    pub async fn complete_issue(&self, id: String, comment: String) -> Result<Issue> {
+        let mut issue = self.db.get_issue(id.clone()).await?;
+        if matches!(issue.status, IssueStatus::Completed | IssueStatus::Failed) {
+            return Err(Error::BadRequest(format!("issue is already {}", issue.status)));
+        }
+        issue.comments.push(IssueComment {
+            author: "user".into(),
+            created_at: Utc::now(),
+            body: comment,
+        });
+        issue.status = IssueStatus::Completed;
+        issue.updated_at = Utc::now();
+        self.db.update_issue(&issue).await?;
+        Ok(issue)
+    }
+
+    pub async fn reopen_issue(&self, id: String, comment: Option<String>) -> Result<Issue> {
+        let mut issue = self.db.get_issue(id.clone()).await?;
+
+        // Only `failed` and `completed` can be reopened
+        let keep_session_id = match issue.status {
+            IssueStatus::Failed => false,   // clear session_id → fresh session on next start
+            IssueStatus::Completed => true, // keep session_id → resume history on next start
+            _ => {
+                return Err(Error::BadRequest(format!(
+                    "cannot reopen issue {id}: only failed or completed issues can be reopened (current status: {})",
+                    issue.status
+                )));
+            }
+        };
+
+        // Optionally append a user comment before the status transition
+        if let Some(comment_text) = comment {
+            if !comment_text.is_empty() {
+                issue.comments.push(IssueComment {
+                    author: "user".into(),
+                    created_at: Utc::now(),
+                    body: comment_text,
+                });
+            }
+        }
+
+        issue.status = IssueStatus::Open;
+        if !keep_session_id {
+            issue.session_id = None;
+        }
+        issue.updated_at = Utc::now();
+        self.db.update_issue(&issue).await?;
+        Ok(issue)
+    }
+
+    /// Orphan sweep: run at startup before accepting any connections.
+    ///
+    /// Finds all sessions stuck in `running` state (no live harness after restart),
+    /// marks them `failed`, and for any linked issue does the same while appending a
+    /// system comment so the issue history is self-explanatory.
+    ///
+    /// Errors are logged and swallowed — a sweep failure must not crash the server.
+    pub async fn orphan_sweep(&self) {
+        let orphans = match self.db.list_sessions(Some(SessionStatus::Running)).await {
+            Ok(sessions) => sessions,
+            Err(e) => {
+                eprintln!("[orphan_sweep] failed to list running sessions: {e}");
+                return;
+            }
+        };
+
+        for session in orphans {
+            // 1. Mark the session failed.
+            if let Err(e) = self.db.update_session_status(session.id, SessionStatus::Failed).await {
+                eprintln!("[orphan_sweep] failed to update session {} to failed: {e}", session.id);
+                // Continue — try the rest.
+            }
+
+            // 2. Find any issue linked to this session and recover it too.
+            let issues = match self.db.list_issues_by_session_id(session.id).await {
+                Ok(issues) => issues,
+                Err(e) => {
+                    eprintln!(
+                        "[orphan_sweep] failed to list issues for session {}: {e}",
+                        session.id
+                    );
+                    continue;
+                }
+            };
+
+            for mut issue in issues {
+                issue.comments.push(IssueComment {
+                    author: "system".into(),
+                    body: "session lost on server restart".into(),
+                    created_at: Utc::now(),
+                });
+                issue.status = types::IssueStatus::Failed;
+                issue.updated_at = Utc::now();
+
+                if let Err(e) = self.db.update_issue(&issue).await {
+                    eprintln!(
+                        "[orphan_sweep] failed to update issue {} to failed: {e}",
+                        issue.id
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use db::{IssueDb, SessionDb};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use types::{ContentBlock, Role, Turn};
+
+    // --- MemoryDb ---
+
+    struct MemoryDb {
+        sessions: Mutex<HashMap<Uuid, Session>>,
+        issues: Mutex<HashMap<String, Issue>>,
+    }
+
+    impl MemoryDb {
+        fn new() -> Self {
+            Self {
+                sessions: Mutex::new(HashMap::new()),
+                issues: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl db::Db for MemoryDb {}
+
+    #[async_trait]
+    impl db::SessionDb for MemoryDb {
+        async fn create_session(&self, session: &Session) -> db::Result<()> {
+            self.sessions.lock().unwrap().insert(session.id, session.clone());
+            Ok(())
+        }
+
+        async fn get_session(&self, id: Uuid) -> db::Result<Session> {
+            self.sessions
+                .lock()
+                .unwrap()
+                .get(&id)
+                .cloned()
+                .ok_or(db::Error::NotFound)
+        }
+
+        async fn list_sessions(&self, status: Option<SessionStatus>) -> db::Result<Vec<Session>> {
+            let sessions = self.sessions.lock().unwrap();
+            let result = sessions
+                .values()
+                .filter(|s| status.as_ref().is_none_or(|st| &s.status == st))
+                .cloned()
+                .collect();
+            Ok(result)
+        }
+
+        async fn update_session_status(&self, id: Uuid, status: SessionStatus) -> db::Result<()> {
+            let mut sessions = self.sessions.lock().unwrap();
+            let session = sessions.get_mut(&id).ok_or(db::Error::NotFound)?;
+            session.status = status;
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl db::TurnDb for MemoryDb {
+        async fn create_turn(&self, _turn: &Turn) -> db::Result<()> {
+            Ok(())
+        }
+
+        async fn list_turns(&self, _session_id: Uuid) -> db::Result<Vec<Turn>> {
+            Ok(vec![])
+        }
+    }
+
+    #[async_trait]
+    impl db::ContentBlockDb for MemoryDb {
+        async fn create_content_block(
+            &self,
+            _turn_id: Uuid,
+            _block_index: i64,
+            _role: &Role,
+            _block: &ContentBlock,
+        ) -> db::Result<()> {
+            Ok(())
+        }
+
+        async fn list_content_blocks(&self, _turn_id: Uuid) -> db::Result<Vec<(Role, ContentBlock)>> {
+            Ok(vec![])
+        }
+
+        async fn get_last_text_for_session(&self, _session_id: Uuid) -> db::Result<Option<String>> {
+            Ok(None)
+        }
+    }
+
+    #[async_trait]
+    impl db::IssueDb for MemoryDb {
+        async fn create_issue(&self, issue: &Issue) -> db::Result<()> {
+            self.issues.lock().unwrap().insert(issue.id.clone(), issue.clone());
+            Ok(())
+        }
+
+        async fn get_issue(&self, id: String) -> db::Result<Issue> {
+            self.issues
+                .lock()
+                .unwrap()
+                .get(&id)
+                .cloned()
+                .ok_or(db::Error::NotFound)
+        }
+
+        async fn list_issues(
+            &self,
+            _status: Option<IssueStatus>,
+            _assignee: Option<String>,
+            _parent_id: Option<String>,
+        ) -> db::Result<Vec<Issue>> {
+            Ok(self.issues.lock().unwrap().values().cloned().collect())
+        }
+
+        async fn list_issues_by_session_id(&self, session_id: Uuid) -> db::Result<Vec<Issue>> {
+            let issues = self.issues.lock().unwrap();
+            let result = issues
+                .values()
+                .filter(|i| i.session_id == Some(session_id))
+                .cloned()
+                .collect();
+            Ok(result)
+        }
+
+        async fn update_issue(&self, issue: &Issue) -> db::Result<()> {
+            let mut issues = self.issues.lock().unwrap();
+            if !issues.contains_key(&issue.id) {
+                return Err(db::Error::NotFound);
+            }
+            issues.insert(issue.id.clone(), issue.clone());
+            Ok(())
+        }
+    }
+
+    // --- Helpers ---
+
+    fn make_service(db: Arc<dyn db::Db>) -> IssueService {
+        IssueService::new(db)
+    }
+
+    fn open_issue(id: &str) -> Issue {
+        let now = Utc::now();
+        Issue {
+            id: id.into(),
+            title: "Test issue".into(),
+            body: "Test body".into(),
+            status: IssueStatus::Open,
+            branch: String::new(),
+            assignee: Some("swe".into()),
+            session_id: None,
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    // --- Tests ---
+
+    #[tokio::test]
+    async fn start_issue_transitions_open_to_running() {
+        let db = Arc::new(MemoryDb::new());
+        let issue = open_issue("ab12");
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let outcome = svc.start_issue("ab12".into()).await.unwrap();
+
+        assert_eq!(outcome.issue.status, IssueStatus::Running);
+        assert!(outcome.issue.session_id.is_some());
+
+        // Verify persisted in db
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(persisted.status, IssueStatus::Running);
+        assert!(persisted.session_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn start_issue_requires_assignee() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.assignee = None;
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc.start_issue("ab12".into()).await;
+
+        assert!(matches!(result, Err(Error::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn start_issue_requires_open_status() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Running;
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc.start_issue("ab12".into()).await;
+
+        assert!(matches!(result, Err(Error::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn complete_issue_adds_comment_and_marks_completed() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Running;
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc.complete_issue("ab12".into(), "Looks good".into()).await.unwrap();
+
+        assert_eq!(result.status, IssueStatus::Completed);
+        assert_eq!(result.comments.len(), 1);
+        assert_eq!(result.comments[0].author, "user");
+        assert_eq!(result.comments[0].body, "Looks good");
+
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(persisted.status, IssueStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn complete_issue_fails_if_already_completed() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Completed;
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc.complete_issue("ab12".into(), "again".into()).await;
+
+        assert!(matches!(result, Err(Error::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn complete_issue_fails_if_already_failed() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Failed;
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc.complete_issue("ab12".into(), "again".into()).await;
+
+        assert!(matches!(result, Err(Error::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn reopen_failed_issue_clears_session_id() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Failed;
+        issue.session_id = Some(Uuid::new_v4());
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc.reopen_issue("ab12".into(), None).await.unwrap();
+
+        assert_eq!(result.status, IssueStatus::Open);
+        assert!(result.session_id.is_none());
+
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert!(persisted.session_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn reopen_completed_issue_keeps_session_id() {
+        let db = Arc::new(MemoryDb::new());
+        let session_id = Uuid::new_v4();
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Completed;
+        issue.session_id = Some(session_id);
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc.reopen_issue("ab12".into(), None).await.unwrap();
+
+        assert_eq!(result.status, IssueStatus::Open);
+        assert_eq!(result.session_id, Some(session_id));
+
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(persisted.session_id, Some(session_id));
+    }
+
+    #[tokio::test]
+    async fn reopen_open_issue_fails() {
+        let db = Arc::new(MemoryDb::new());
+        let issue = open_issue("ab12");
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc.reopen_issue("ab12".into(), None).await;
+
+        assert!(matches!(result, Err(Error::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn reopen_running_issue_fails() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Running;
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc.reopen_issue("ab12".into(), None).await;
+
+        assert!(matches!(result, Err(Error::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn reopen_with_comment_appends_comment() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Failed;
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        let result = svc
+            .reopen_issue("ab12".into(), Some("please try again".into()))
+            .await
+            .unwrap();
+
+        assert_eq!(result.status, IssueStatus::Open);
+        assert_eq!(result.comments.len(), 1);
+        assert_eq!(result.comments[0].author, "user");
+        assert_eq!(result.comments[0].body, "please try again");
+    }
+
+    #[tokio::test]
+    async fn orphan_sweep_marks_running_session_failed() {
+        let db = Arc::new(MemoryDb::new());
+        let now = Utc::now();
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "orphan-session".into(),
+            status: SessionStatus::Running,
+            agent: None,
+            created_at: now,
+            updated_at: now,
+        };
+        db.create_session(&session).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        svc.orphan_sweep().await;
+
+        let fetched = db.get_session(session.id).await.unwrap();
+        assert_eq!(fetched.status, SessionStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn orphan_sweep_marks_linked_issue_failed_with_comment() {
+        let db = Arc::new(MemoryDb::new());
+        let now = Utc::now();
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "orphan-session".into(),
+            status: SessionStatus::Running,
+            agent: None,
+            created_at: now,
+            updated_at: now,
+        };
+        db.create_session(&session).await.unwrap();
+
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Running;
+        issue.session_id = Some(session.id);
+        db.create_issue(&issue).await.unwrap();
+
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+        svc.orphan_sweep().await;
+
+        let fetched_issue = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(fetched_issue.status, IssueStatus::Failed);
+        assert_eq!(fetched_issue.comments.len(), 1);
+        assert_eq!(fetched_issue.comments[0].author, "system");
+        assert_eq!(fetched_issue.comments[0].body, "session lost on server restart");
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -9,6 +9,7 @@ db = { path = "../db" }
 harness = { path = "../harness" }
 anthropic = { path = "../anthropic" }
 tools = { path = "../tools" }
+issues = { path = "../issues" }
 axum = { version = "0.7", features = ["json"] }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -32,6 +32,15 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+impl From<issues::Error> for Error {
+    fn from(e: issues::Error) -> Self {
+        match e {
+            issues::Error::Db(db_err) => Error::Db(db_err),
+            issues::Error::BadRequest(msg) => Error::BadRequest(msg),
+        }
+    }
+}
+
 impl IntoResponse for Error {
     fn into_response(self) -> axum::response::Response {
         let (status, message) = match &self {
@@ -55,9 +64,9 @@ pub struct ServerConfig {
 #[derive(Clone)]
 struct AppState {
     db: Arc<dyn db::Db>,
+    issue_service: issues::IssueService,
     sessions: Arc<tokio::sync::Mutex<HashMap<Uuid, tokio::sync::broadcast::Sender<SessionEvent>>>>,
     msg_senders: Arc<tokio::sync::Mutex<HashMap<Uuid, tokio::sync::mpsc::Sender<String>>>>,
-    /// Tracks session IDs for which a harness spawn is in flight (not yet inserted into msg_senders).
     spawning: Arc<tokio::sync::Mutex<HashSet<Uuid>>>,
     client: Arc<dyn anthropic::AnthropicClient>,
     tools: Vec<Arc<dyn tools::Tool>>,
@@ -95,42 +104,6 @@ async fn health() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
 }
 
-async fn create_session(
-    State(state): State<AppState>,
-    Json(req): Json<CreateSessionRequest>,
-) -> std::result::Result<(StatusCode, Json<Session>), Error> {
-    let now = Utc::now();
-    let has_message = req
-        .initial_message
-        .as_deref()
-        .map(|m| !m.is_empty())
-        .unwrap_or(false);
-
-    let initial_message = req.initial_message.unwrap_or_default();
-
-    let session = Session {
-        id: Uuid::new_v4(),
-        name: req.name.unwrap_or_else(|| "unnamed".to_string()),
-        status: SessionStatus::Created,
-        agent: req.agent,
-        created_at: now,
-        updated_at: now,
-    };
-    state.db.create_session(&session).await?;
-
-    if has_message {
-        let msg_tx = spawn_harness_sync(&state, session.clone(), None);
-        msg_tx.send(initial_message).await.ok();
-    }
-
-    Ok((StatusCode::CREATED, Json(session)))
-}
-
-/// Spawn a harness task for the given session.
-///
-/// Inserts both the broadcast sender AND the msg sender into their maps atomically
-/// (under a single combined lock acquisition) *before* returning. This prevents a
-/// second concurrent call from racing to spawn a second harness for the same session.
 fn spawn_harness_sync(
     state: &AppState,
     session: Session,
@@ -159,13 +132,9 @@ fn spawn_harness_sync(
 
     let session_id = session_clone.id;
 
-    // If this session is linked to an issue, subscribe to the event channel now so we can
-    // watch for SessionDone and SessionError events and propagate them to the issue status.
-    // The harness is designed to stay alive waiting for more messages, so we cannot rely on
-    // harness::run returning — instead we react to individual turn completions.
     let issue_watcher = issue_id.map(|id| {
         let mut rx = tx.subscribe();
-        let db_watch = Arc::clone(&state.db);
+        let db_watch = Arc::clone(&db);
         tokio::spawn(async move {
             let mut current_turn_text = String::new();
             let mut last_turn_text = String::new();
@@ -183,7 +152,6 @@ fn spawn_harness_sync(
                     }
                     SessionEvent::SessionDone { .. } => {
                         if let Ok(mut issue) = db_watch.get_issue(id.clone()).await {
-                            // Post agent's final turn as comment before marking completed
                             if !last_turn_text.is_empty() {
                                 let author = issue.assignee.clone()
                                     .unwrap_or_else(|| "agent".to_string());
@@ -219,7 +187,6 @@ fn spawn_harness_sync(
     });
 
     tokio::spawn(async move {
-        // Insert into maps atomically before yielding back to callers.
         {
             let mut smap = msg_senders_map.lock().await;
             let mut map = sessions_map.lock().await;
@@ -237,7 +204,6 @@ fn spawn_harness_sync(
             let _ = db_clone.update_session_status(session_id, SessionStatus::Failed).await;
         }
 
-        // Remove from maps when harness exits (msg_rx closed → all senders dropped)
         {
             let mut map = sessions_map.lock().await;
             map.remove(&session_id);
@@ -247,16 +213,43 @@ fn spawn_harness_sync(
             smap.remove(&session_id);
         }
 
-        // Note: we do NOT abort the watcher here because it may still be processing
-        // the final SessionDone or Error event from the broadcast channel. The watcher
-        // exits naturally once it handles a terminal event (its while-loop breaks on
-        // SessionDone and Error), or when the broadcast channel closes (all tx senders
-        // are dropped after this task ends), causing rx.recv() to return Err.
         drop(issue_watcher);
     });
 
     msg_tx_ret
 }
+
+async fn create_session(
+    State(state): State<AppState>,
+    Json(req): Json<CreateSessionRequest>,
+) -> std::result::Result<(StatusCode, Json<Session>), Error> {
+    let now = Utc::now();
+    let has_message = req
+        .initial_message
+        .as_deref()
+        .map(|m| !m.is_empty())
+        .unwrap_or(false);
+
+    let initial_message = req.initial_message.unwrap_or_default();
+
+    let session = Session {
+        id: Uuid::new_v4(),
+        name: req.name.unwrap_or_else(|| "unnamed".to_string()),
+        status: SessionStatus::Created,
+        agent: req.agent,
+        created_at: now,
+        updated_at: now,
+    };
+    state.db.create_session(&session).await?;
+
+    if has_message {
+        let msg_tx = spawn_harness_sync(&state, session.clone(), None);
+        msg_tx.send(initial_message).await.ok();
+    }
+
+    Ok((StatusCode::CREATED, Json(session)))
+}
+
 
 async fn list_sessions(
     State(state): State<AppState>,
@@ -468,59 +461,6 @@ async fn update_session_status(
     Ok(Json(session))
 }
 
-/// Orphan sweep: run at startup before accepting any connections.
-///
-/// Finds all sessions stuck in `running` state (no live harness after restart),
-/// marks them `failed`, and for any linked issue does the same while appending a
-/// system comment so the issue history is self-explanatory.
-///
-/// Errors are logged and swallowed — a sweep failure must not crash the server.
-pub(crate) async fn orphan_sweep(db: &Arc<dyn db::Db>) {
-    let orphans = match db.list_sessions(Some(SessionStatus::Running)).await {
-        Ok(sessions) => sessions,
-        Err(e) => {
-            eprintln!("[orphan_sweep] failed to list running sessions: {e}");
-            return;
-        }
-    };
-
-    for session in orphans {
-        // 1. Mark the session failed.
-        if let Err(e) = db.update_session_status(session.id, SessionStatus::Failed).await {
-            eprintln!("[orphan_sweep] failed to update session {} to failed: {e}", session.id);
-            // Continue — try the rest.
-        }
-
-        // 2. Find any issue linked to this session and recover it too.
-        let issues = match db.list_issues_by_session_id(session.id).await {
-            Ok(issues) => issues,
-            Err(e) => {
-                eprintln!(
-                    "[orphan_sweep] failed to list issues for session {}: {e}",
-                    session.id
-                );
-                continue;
-            }
-        };
-
-        for mut issue in issues {
-            issue.comments.push(IssueComment {
-                author: "system".into(),
-                body: "session lost on server restart".into(),
-                created_at: Utc::now(),
-            });
-            issue.status = types::IssueStatus::Failed;
-            issue.updated_at = Utc::now();
-
-            if let Err(e) = db.update_issue(&issue).await {
-                eprintln!(
-                    "[orphan_sweep] failed to update issue {} to failed: {e}",
-                    issue.id
-                );
-            }
-        }
-    }
-}
 
 fn generate_issue_id() -> String {
     const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
@@ -719,49 +659,10 @@ async fn start_issue(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> std::result::Result<Json<Issue>, Error> {
-    let mut issue = state.db.get_issue(id.clone()).await?;
-
-    if issue.assignee.is_none() {
-        return Err(Error::BadRequest("issue has no assignee; set one with `issue edit --assignee <agent>`".into()));
-    }
-    if issue.status != IssueStatus::Open {
-        return Err(Error::BadRequest(format!("issue is already {}", issue.status)));
-    }
-
-    let now = Utc::now();
-    let session = Session {
-        id: Uuid::new_v4(),
-        name: format!("issue-{}", issue.id),
-        status: SessionStatus::Created,
-        agent: issue.assignee.clone(),
-        created_at: now,
-        updated_at: now,
-    };
-    state.db.create_session(&session).await?;
-
-    // Update issue to Running before spawning the harness so the DB write cannot
-    // race with the harness auto-completing the issue on a fast (stub) client.
-    issue.session_id = Some(session.id);
-    issue.status = IssueStatus::Running;
-    issue.updated_at = Utc::now();
-    state.db.update_issue(&issue).await?;
-
-    let mut initial_message = format!("{}\n\n{}", issue.title, issue.body);
-    if !issue.comments.is_empty() {
-        initial_message.push_str("\n\n---\n# Issue History\n");
-        for comment in &issue.comments {
-            initial_message.push_str(&format!(
-                "\n**{}** ({}): {}\n",
-                comment.author,
-                comment.created_at.format("%Y-%m-%d %H:%M UTC"),
-                comment.body
-            ));
-        }
-    }
-    let msg_tx = spawn_harness_sync(&state, session.clone(), Some(issue.id.clone()));
-    msg_tx.send(initial_message).await.ok();
-
-    Ok(Json(issue))
+    let outcome = state.issue_service.start_issue(id).await?;
+    let msg_tx = spawn_harness_sync(&state, outcome.session, Some(outcome.issue.id.clone()));
+    msg_tx.send(outcome.initial_message).await.ok();
+    Ok(Json(outcome.issue))
 }
 
 async fn complete_issue(
@@ -769,18 +670,7 @@ async fn complete_issue(
     Path(id): Path<String>,
     Json(req): Json<CompleteIssueRequest>,
 ) -> std::result::Result<Json<Issue>, Error> {
-    let mut issue = state.db.get_issue(id.clone()).await?;
-    if matches!(issue.status, IssueStatus::Completed | IssueStatus::Failed) {
-        return Err(Error::BadRequest(format!("issue is already {}", issue.status)));
-    }
-    issue.comments.push(IssueComment {
-        author: "user".into(),
-        created_at: Utc::now(),
-        body: req.comment,
-    });
-    issue.status = IssueStatus::Completed;
-    issue.updated_at = Utc::now();
-    state.db.update_issue(&issue).await?;
+    let issue = state.issue_service.complete_issue(id, req.comment).await?;
     Ok(Json(issue))
 }
 
@@ -789,39 +679,8 @@ async fn reopen_issue(
     Path(id): Path<String>,
     body: Option<Json<ReopenIssueRequest>>,
 ) -> std::result::Result<Json<Issue>, Error> {
-    let mut issue = state.db.get_issue(id.clone()).await?;
-
-    // Only `failed` and `completed` can be reopened
-    let keep_session_id = match issue.status {
-        IssueStatus::Failed => false,   // clear session_id → fresh session on next start
-        IssueStatus::Completed => true, // keep session_id → resume history on next start
-        _ => {
-            return Err(Error::BadRequest(format!(
-                "cannot reopen issue {id}: only failed or completed issues can be reopened (current status: {})",
-                issue.status
-            )));
-        }
-    };
-
-    // Optionally append a user comment before the status transition
-    if let Some(Json(req)) = body {
-        if let Some(comment_text) = req.comment {
-            if !comment_text.is_empty() {
-                issue.comments.push(IssueComment {
-                    author: "user".into(),
-                    created_at: Utc::now(),
-                    body: comment_text,
-                });
-            }
-        }
-    }
-
-    issue.status = IssueStatus::Open;
-    if !keep_session_id {
-        issue.session_id = None;
-    }
-    issue.updated_at = Utc::now();
-    state.db.update_issue(&issue).await?;
+    let comment = body.and_then(|Json(req)| req.comment);
+    let issue = state.issue_service.reopen_issue(id, comment).await?;
     Ok(Json(issue))
 }
 
@@ -874,7 +733,7 @@ pub async fn run(config: ServerConfig) -> Result<()> {
         Some(key) => Arc::new(anthropic::Client::new(key)),
         None => {
             eprintln!("Warning: ANTHROPIC_API_KEY not set — using stub client (responses will be fake)");
-            Arc::new(harness::StubClient)
+            Arc::new(anthropic::StubClient)
         }
     };
     let tools: Vec<Arc<dyn tools::Tool>> = vec![
@@ -887,8 +746,11 @@ pub async fn run(config: ServerConfig) -> Result<()> {
     let db_path = config.data_dir.join("ns2.db");
     let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
     let db = SqliteDb::connect(&db_url).await?;
+    let db: Arc<dyn db::Db> = Arc::new(db);
+    let issue_service = issues::IssueService::new(Arc::clone(&db));
     let state = AppState {
-        db: Arc::new(db) as Arc<dyn db::Db>,
+        db,
+        issue_service,
         sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         msg_senders: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         spawning: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
@@ -898,7 +760,7 @@ pub async fn run(config: ServerConfig) -> Result<()> {
     };
 
     // Recover orphaned sessions before accepting any connections.
-    orphan_sweep(&state.db).await;
+    state.issue_service.orphan_sweep().await;
 
     let app = build_router(state);
 
@@ -960,33 +822,29 @@ mod tests {
         }
     }
 
-    async fn test_app() -> Router {
+    async fn test_state() -> AppState {
         let db = Arc::new(SqliteDb::connect("sqlite::memory:").await.unwrap()) as Arc<dyn db::Db>;
         let client = Arc::new(TestClient) as Arc<dyn anthropic::AnthropicClient>;
-        let state = AppState {
+        let issue_service = issues::IssueService::new(Arc::clone(&db));
+        AppState {
             db,
+            issue_service,
             sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             msg_senders: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             spawning: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
             client,
             tools: vec![],
             model: "claude-opus-4-5".into(),
-        };
+        }
+    }
+
+    async fn test_app() -> Router {
+        let state = test_state().await;
         build_router(state)
     }
 
     async fn test_app_with_state() -> (Router, AppState) {
-        let db = Arc::new(SqliteDb::connect("sqlite::memory:").await.unwrap()) as Arc<dyn db::Db>;
-        let client = Arc::new(TestClient) as Arc<dyn anthropic::AnthropicClient>;
-        let state = AppState {
-            db,
-            sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            msg_senders: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            spawning: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
-            client,
-            tools: vec![],
-            model: "claude-opus-4-5".into(),
-        };
+        let state = test_state().await;
         let app = build_router(state.clone());
         (app, state)
     }
@@ -2616,21 +2474,6 @@ mod tests {
 
     // ─── Orphan sweep tests ───────────────────────────────────────────────────
 
-    /// Helper: build an AppState with a fresh in-memory DB (no router).
-    async fn test_state() -> AppState {
-        let db = Arc::new(SqliteDb::connect("sqlite::memory:").await.unwrap()) as Arc<dyn db::Db>;
-        let client = Arc::new(TestClient) as Arc<dyn anthropic::AnthropicClient>;
-        AppState {
-            db,
-            sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            msg_senders: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            spawning: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
-            client,
-            tools: vec![],
-            model: "claude-opus-4-5".into(),
-        }
-    }
-
     /// A `running` session is swept to `failed` by `orphan_sweep`.
     #[tokio::test]
     async fn test_orphan_sweep_marks_running_session_failed() {
@@ -2646,7 +2489,7 @@ mod tests {
         };
         state.db.create_session(&session).await.unwrap();
 
-        orphan_sweep(&state.db).await;
+        state.issue_service.orphan_sweep().await;
 
         let fetched = state.db.get_session(session.id).await.unwrap();
         assert_eq!(
@@ -2688,7 +2531,7 @@ mod tests {
         };
         state.db.create_issue(&issue).await.unwrap();
 
-        orphan_sweep(&state.db).await;
+        state.issue_service.orphan_sweep().await;
 
         // Issue must be failed
         let fetched_issue = state.db.get_issue("ab12".into()).await.unwrap();
@@ -2739,7 +2582,7 @@ mod tests {
             state.db.create_session(&session).await.unwrap();
         }
 
-        orphan_sweep(&state.db).await;
+        state.issue_service.orphan_sweep().await;
 
         // Each session must retain its original status — the sweep touches only `running`.
         for (id, original_status) in &session_ids {
@@ -2769,7 +2612,7 @@ mod tests {
         state.db.create_session(&session).await.unwrap();
 
         // Must not panic or return an error
-        orphan_sweep(&state.db).await;
+        state.issue_service.orphan_sweep().await;
 
         let fetched = state.db.get_session(session.id).await.unwrap();
         assert_eq!(
@@ -3060,8 +2903,10 @@ mod tests {
         let captured = Arc::new(Mutex::new(Vec::<String>::new()));
         let db = Arc::new(SqliteDb::connect("sqlite::memory:").await.unwrap()) as Arc<dyn db::Db>;
         let client = Arc::new(CapturingClient { captured: Arc::clone(&captured) }) as Arc<dyn anthropic::AnthropicClient>;
+        let issue_service = issues::IssueService::new(Arc::clone(&db));
         let state = AppState {
             db,
+            issue_service,
             sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             msg_senders: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             spawning: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
@@ -3156,8 +3001,10 @@ mod tests {
         let captured = Arc::new(Mutex::new(Vec::<String>::new()));
         let db = Arc::new(SqliteDb::connect("sqlite::memory:").await.unwrap()) as Arc<dyn db::Db>;
         let client = Arc::new(CapturingClient { captured: Arc::clone(&captured) }) as Arc<dyn anthropic::AnthropicClient>;
+        let issue_service = issues::IssueService::new(Arc::clone(&db));
         let state = AppState {
-            db: Arc::clone(&db),
+            db,
+            issue_service,
             sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             msg_senders: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             spawning: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
@@ -3369,8 +3216,10 @@ mod tests {
 
         let db = Arc::new(SqliteDb::connect("sqlite::memory:").await.unwrap()) as Arc<dyn db::Db>;
         let client = Arc::new(ErrorClient) as Arc<dyn anthropic::AnthropicClient>;
+        let issue_service = issues::IssueService::new(Arc::clone(&db));
         let state = AppState {
             db,
+            issue_service,
             sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             msg_senders: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             spawning: Arc::new(tokio::sync::Mutex::new(HashSet::new())),


### PR DESCRIPTION
## Summary

- Creates \`crates/issues\` with \`IssueService\` as a pure domain service: owns the issue state machine (\`start_issue\`, \`complete_issue\`, \`reopen_issue\`, \`orphan_sweep\`) with only \`db\` as a dependency
- \`server\` retains \`spawn_harness_sync\` and session maps — bare sessions have no business going through an issue service
- Moves \`StubClient\` from \`harness\` to \`anthropic\` where it belongs (it's a fake \`AnthropicClient\`, not a harness concept)
- Arch tests updated with explicit \`assert_no_direct_dep\` constraints locking \`issues\` out of \`harness\`, \`anthropic\`, \`tools\`, \`workspace\`, \`agents\`
- Architecture spec rewritten with a Mermaid DAG and leaner per-crate descriptions

## Test plan

- [ ] \`cargo test\` passes (all existing tests green)
- [ ] \`cargo test -p arch-tests\` passes including the new \`issues_has_no_server_or_client_deps\` constraint
- [ ] \`cargo clippy -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)