### PR TITLE
fix: route handlers and spawn_harness_sync bypass IssueService

### DIFF
--- a/crates/issues/src/lib.rs
+++ b/crates/issues/src/lib.rs
@@ -3,6 +3,49 @@ use chrono::Utc;
 use types::{Issue, IssueComment, IssueStatus, Session, SessionStatus};
 use uuid::Uuid;
 
+pub fn slugify(title: &str) -> String {
+    let lower = title.to_lowercase();
+    let mut result = String::new();
+    let mut in_sep = false;
+    for ch in lower.chars() {
+        if ch.is_alphanumeric() {
+            result.push(ch);
+            in_sep = false;
+        } else if !in_sep {
+            result.push('-');
+            in_sep = true;
+        }
+    }
+    result.trim_matches('-').to_string()
+}
+
+pub fn generate_issue_id() -> String {
+    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+    let id = Uuid::new_v4();
+    let bytes = id.as_bytes();
+    (0..4)
+        .map(|i| ALPHABET[(bytes[i] as usize) % ALPHABET.len()] as char)
+        .collect()
+}
+
+pub struct CreateIssueInput {
+    pub title: String,
+    pub body: String,
+    pub assignee: Option<String>,
+    pub parent_id: Option<String>,
+    pub blocked_on: Vec<String>,
+    pub branch: Option<String>,
+}
+
+pub struct EditIssueInput {
+    pub title: Option<String>,
+    pub body: Option<String>,
+    pub assignee: Option<Option<String>>,
+    pub parent_id: Option<Option<String>>,
+    pub blocked_on: Option<Vec<String>>,
+    pub branch: Option<String>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("db error: {0}")]
@@ -31,6 +74,105 @@ impl IssueService {
 
     pub fn db(&self) -> &Arc<dyn db::Db> {
         &self.db
+    }
+
+    pub async fn create_issue(&self, input: CreateIssueInput) -> Result<Issue> {
+        let now = Utc::now();
+        let id = generate_issue_id();
+        let branch = if let Some(b) = input.branch {
+            b
+        } else if let Some(ref parent_id) = input.parent_id {
+            match self.db.get_issue(parent_id.clone()).await {
+                Ok(parent) => parent.branch,
+                Err(_) => format!("{}-{}", id, slugify(&input.title)),
+            }
+        } else {
+            format!("{}-{}", id, slugify(&input.title))
+        };
+        let issue = Issue {
+            id,
+            title: input.title,
+            body: input.body,
+            status: IssueStatus::Open,
+            branch,
+            assignee: input.assignee,
+            session_id: None,
+            parent_id: input.parent_id,
+            blocked_on: input.blocked_on,
+            comments: vec![],
+            created_at: now,
+            updated_at: now,
+        };
+        self.db.create_issue(&issue).await?;
+        Ok(issue)
+    }
+
+    pub async fn edit_issue(&self, id: String, input: EditIssueInput) -> Result<Issue> {
+        let mut issue = self.db.get_issue(id).await?;
+        if let Some(title) = input.title {
+            issue.title = title;
+        }
+        if let Some(body) = input.body {
+            issue.body = body;
+        }
+        if let Some(assignee_opt) = input.assignee {
+            issue.assignee = assignee_opt;
+        }
+        if let Some(parent_opt) = input.parent_id {
+            issue.parent_id = parent_opt;
+        }
+        if let Some(blocked_on) = input.blocked_on {
+            issue.blocked_on = blocked_on;
+        }
+        if let Some(branch) = input.branch {
+            issue.branch = branch;
+        }
+        issue.updated_at = Utc::now();
+        self.db.update_issue(&issue).await?;
+        Ok(issue)
+    }
+
+    pub async fn add_comment(&self, id: String, author: String, body: String) -> Result<Issue> {
+        let mut issue = self.db.get_issue(id).await?;
+        issue.comments.push(IssueComment {
+            author,
+            created_at: Utc::now(),
+            body,
+        });
+        issue.updated_at = Utc::now();
+        self.db.update_issue(&issue).await?;
+        Ok(issue)
+    }
+
+    pub async fn finish_issue(&self, id: &str, summary: Option<String>) -> Result<()> {
+        let mut issue = self.db.get_issue(id.to_string()).await?;
+        if let Some(text) = summary {
+            if !text.is_empty() {
+                let author = issue.assignee.clone().unwrap_or_else(|| "agent".to_string());
+                issue.comments.push(IssueComment {
+                    author,
+                    created_at: Utc::now(),
+                    body: text,
+                });
+            }
+        }
+        issue.status = IssueStatus::Completed;
+        issue.updated_at = Utc::now();
+        self.db.update_issue(&issue).await?;
+        Ok(())
+    }
+
+    pub async fn fail_issue(&self, id: &str, error_message: String) -> Result<()> {
+        let mut issue = self.db.get_issue(id.to_string()).await?;
+        issue.comments.push(IssueComment {
+            author: "system".to_string(),
+            created_at: Utc::now(),
+            body: error_message,
+        });
+        issue.status = IssueStatus::Failed;
+        issue.updated_at = Utc::now();
+        self.db.update_issue(&issue).await?;
+        Ok(())
     }
 
     pub async fn start_issue(&self, id: String) -> Result<StartIssueOutcome> {
@@ -563,5 +705,256 @@ mod tests {
         assert_eq!(fetched_issue.comments.len(), 1);
         assert_eq!(fetched_issue.comments[0].author, "system");
         assert_eq!(fetched_issue.comments[0].body, "session lost on server restart");
+    }
+
+    // --- create_issue ---
+
+    #[tokio::test]
+    async fn create_issue_returns_open_issue_with_generated_id() {
+        let db = Arc::new(MemoryDb::new());
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        let issue = svc.create_issue(CreateIssueInput {
+            title: "Fix the bug".into(),
+            body: "Details".into(),
+            assignee: None,
+            parent_id: None,
+            blocked_on: vec![],
+            branch: None,
+        }).await.unwrap();
+
+        assert_eq!(issue.status, IssueStatus::Open);
+        assert_eq!(issue.id.len(), 4);
+        assert!(issue.branch.contains("fix-the-bug"));
+
+        let persisted = db.get_issue(issue.id.clone()).await.unwrap();
+        assert_eq!(persisted.title, "Fix the bug");
+    }
+
+    #[tokio::test]
+    async fn create_issue_uses_explicit_branch() {
+        let db = Arc::new(MemoryDb::new());
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        let issue = svc.create_issue(CreateIssueInput {
+            title: "My task".into(),
+            body: "B".into(),
+            assignee: None,
+            parent_id: None,
+            blocked_on: vec![],
+            branch: Some("my-explicit-branch".into()),
+        }).await.unwrap();
+
+        assert_eq!(issue.branch, "my-explicit-branch");
+    }
+
+    #[tokio::test]
+    async fn create_issue_inherits_parent_branch() {
+        let db = Arc::new(MemoryDb::new());
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        let parent = svc.create_issue(CreateIssueInput {
+            title: "Parent".into(),
+            body: "B".into(),
+            assignee: None,
+            parent_id: None,
+            blocked_on: vec![],
+            branch: Some("parent-branch".into()),
+        }).await.unwrap();
+
+        let child = svc.create_issue(CreateIssueInput {
+            title: "Child".into(),
+            body: "B".into(),
+            assignee: None,
+            parent_id: Some(parent.id.clone()),
+            blocked_on: vec![],
+            branch: None,
+        }).await.unwrap();
+
+        assert_eq!(child.branch, "parent-branch");
+    }
+
+    // --- edit_issue ---
+
+    #[tokio::test]
+    async fn edit_issue_updates_fields() {
+        let db = Arc::new(MemoryDb::new());
+        let issue = open_issue("ab12");
+        db.create_issue(&issue).await.unwrap();
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        let updated = svc.edit_issue("ab12".into(), EditIssueInput {
+            title: Some("New title".into()),
+            body: None,
+            assignee: None,
+            parent_id: None,
+            blocked_on: None,
+            branch: None,
+        }).await.unwrap();
+
+        assert_eq!(updated.title, "New title");
+        assert_eq!(updated.body, "Test body");
+    }
+
+    #[tokio::test]
+    async fn edit_issue_clears_parent_with_explicit_none() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.parent_id = Some("parent1".into());
+        db.create_issue(&issue).await.unwrap();
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        let updated = svc.edit_issue("ab12".into(), EditIssueInput {
+            title: None,
+            body: None,
+            assignee: None,
+            parent_id: Some(None),
+            blocked_on: None,
+            branch: None,
+        }).await.unwrap();
+
+        assert!(updated.parent_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn edit_issue_absent_field_leaves_unchanged() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.parent_id = Some("parent1".into());
+        db.create_issue(&issue).await.unwrap();
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        let updated = svc.edit_issue("ab12".into(), EditIssueInput {
+            title: Some("Renamed".into()),
+            body: None,
+            assignee: None,
+            parent_id: None,
+            blocked_on: None,
+            branch: None,
+        }).await.unwrap();
+
+        assert_eq!(updated.parent_id, Some("parent1".into()));
+    }
+
+    // --- add_comment ---
+
+    #[tokio::test]
+    async fn add_comment_appends_to_issue() {
+        let db = Arc::new(MemoryDb::new());
+        let issue = open_issue("ab12");
+        db.create_issue(&issue).await.unwrap();
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        let updated = svc.add_comment("ab12".into(), "user".into(), "Great issue".into()).await.unwrap();
+
+        assert_eq!(updated.comments.len(), 1);
+        assert_eq!(updated.comments[0].author, "user");
+        assert_eq!(updated.comments[0].body, "Great issue");
+
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(persisted.comments.len(), 1);
+    }
+
+    // --- finish_issue ---
+
+    #[tokio::test]
+    async fn finish_issue_marks_completed_with_summary_comment() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Running;
+        issue.assignee = Some("swe".into());
+        db.create_issue(&issue).await.unwrap();
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        svc.finish_issue("ab12", Some("Done! All tests pass.".into())).await.unwrap();
+
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(persisted.status, IssueStatus::Completed);
+        assert_eq!(persisted.comments.len(), 1);
+        assert_eq!(persisted.comments[0].author, "swe");
+        assert_eq!(persisted.comments[0].body, "Done! All tests pass.");
+    }
+
+    #[tokio::test]
+    async fn finish_issue_no_summary_adds_no_comment() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Running;
+        db.create_issue(&issue).await.unwrap();
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        svc.finish_issue("ab12", None).await.unwrap();
+
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(persisted.status, IssueStatus::Completed);
+        assert_eq!(persisted.comments.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn finish_issue_empty_summary_adds_no_comment() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Running;
+        db.create_issue(&issue).await.unwrap();
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        svc.finish_issue("ab12", Some(String::new())).await.unwrap();
+
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(persisted.status, IssueStatus::Completed);
+        assert_eq!(persisted.comments.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn finish_issue_uses_agent_author_when_no_assignee() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Running;
+        issue.assignee = None;
+        db.create_issue(&issue).await.unwrap();
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        svc.finish_issue("ab12", Some("summary".into())).await.unwrap();
+
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(persisted.comments[0].author, "agent");
+    }
+
+    // --- fail_issue ---
+
+    #[tokio::test]
+    async fn fail_issue_marks_failed_with_system_comment() {
+        let db = Arc::new(MemoryDb::new());
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::Running;
+        db.create_issue(&issue).await.unwrap();
+        let svc = make_service(Arc::clone(&db) as Arc<dyn db::Db>);
+
+        svc.fail_issue("ab12", "timeout exceeded".into()).await.unwrap();
+
+        let persisted = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(persisted.status, IssueStatus::Failed);
+        assert_eq!(persisted.comments.len(), 1);
+        assert_eq!(persisted.comments[0].author, "system");
+        assert_eq!(persisted.comments[0].body, "timeout exceeded");
+    }
+
+    // --- slugify ---
+
+    #[test]
+    fn slugify_simple_title() {
+        assert_eq!(slugify("Fix the bug"), "fix-the-bug");
+    }
+
+    #[test]
+    fn slugify_consecutive_specials_collapsed() {
+        assert_eq!(slugify("foo--bar"), "foo-bar");
+        assert_eq!(slugify("foo  bar"), "foo-bar");
+    }
+
+    #[test]
+    fn slugify_trims_leading_trailing_dashes() {
+        assert_eq!(slugify("  leading"), "leading");
+        assert_eq!(slugify("trailing  "), "trailing");
     }
 }

--- a/crates/server/src/routes/issue.rs
+++ b/crates/server/src/routes/issue.rs
@@ -3,10 +3,8 @@ use axum::{
     http::StatusCode,
     Json,
 };
-use chrono::Utc;
 use serde::{Deserialize, Deserializer};
-use types::{Issue, IssueComment, IssueStatus};
-use uuid::Uuid;
+use types::{Issue, IssueStatus};
 
 use crate::state::{spawn_harness_sync, AppState};
 use super::Error;
@@ -15,36 +13,12 @@ use super::Error;
 
 #[cfg(test)]
 pub(crate) fn generate_issue_id_for_test() -> String {
-    generate_issue_id()
+    issues::generate_issue_id()
 }
 
-fn generate_issue_id() -> String {
-    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
-    let id = Uuid::new_v4();
-    let bytes = id.as_bytes();
-    (0..4)
-        .map(|i| ALPHABET[(bytes[i] as usize) % ALPHABET.len()] as char)
-        .collect()
-}
-
-/// Convert a title string into a URL-safe slug.
-/// - Lowercase all characters
-/// - Replace any run of non-alphanumeric characters with a single `-`
-/// - Trim leading/trailing `-`
+#[cfg(test)]
 pub(crate) fn slugify(title: &str) -> String {
-    let lower = title.to_lowercase();
-    let mut result = String::new();
-    let mut in_sep = false;
-    for ch in lower.chars() {
-        if ch.is_alphanumeric() {
-            result.push(ch);
-            in_sep = false;
-        } else if !in_sep {
-            result.push('-');
-            in_sep = true;
-        }
-    }
-    result.trim_matches('-').to_string()
+    issues::slugify(title)
 }
 
 // Wraps a present JSON field (including null) in Some, leaving absent fields as None.
@@ -112,39 +86,14 @@ pub(crate) async fn create_issue(
     State(state): State<AppState>,
     Json(req): Json<CreateIssueRequest>,
 ) -> std::result::Result<(StatusCode, Json<Issue>), Error> {
-    let now = Utc::now();
-    let id = generate_issue_id();
-
-    // Compute the branch:
-    // 1. Explicit branch in request → use as-is
-    // 2. parent_id provided → inherit parent's branch
-    // 3. Otherwise → generate slug from "<id>-<slugified-title>"
-    let branch = if let Some(b) = req.branch {
-        b
-    } else if let Some(ref parent_id) = req.parent_id {
-        match state.db.get_issue(parent_id.clone()).await {
-            Ok(parent) => parent.branch,
-            Err(_) => format!("{}-{}", id, slugify(&req.title)),
-        }
-    } else {
-        format!("{}-{}", id, slugify(&req.title))
-    };
-
-    let issue = Issue {
-        id,
+    let issue = state.issue_service.create_issue(issues::CreateIssueInput {
         title: req.title,
         body: req.body,
-        status: IssueStatus::Open,
-        branch,
         assignee: req.assignee,
-        session_id: None,
         parent_id: req.parent_id,
         blocked_on: req.blocked_on.unwrap_or_default(),
-        comments: vec![],
-        created_at: now,
-        updated_at: now,
-    };
-    state.db.create_issue(&issue).await?;
+        branch: req.branch,
+    }).await?;
     Ok((StatusCode::CREATED, Json(issue)))
 }
 
@@ -180,27 +129,14 @@ pub(crate) async fn edit_issue(
     Path(id): Path<String>,
     Json(req): Json<EditIssueRequest>,
 ) -> std::result::Result<Json<Issue>, Error> {
-    let mut issue = state.db.get_issue(id.clone()).await?;
-    if let Some(title) = req.title {
-        issue.title = title;
-    }
-    if let Some(body) = req.body {
-        issue.body = body;
-    }
-    if let Some(assignee_opt) = req.assignee {
-        issue.assignee = assignee_opt;
-    }
-    if let Some(parent_opt) = req.parent_id {
-        issue.parent_id = parent_opt;
-    }
-    if let Some(blocked_on) = req.blocked_on {
-        issue.blocked_on = blocked_on;
-    }
-    if let Some(branch) = req.branch {
-        issue.branch = branch;
-    }
-    issue.updated_at = Utc::now();
-    state.db.update_issue(&issue).await?;
+    let issue = state.issue_service.edit_issue(id, issues::EditIssueInput {
+        title: req.title,
+        body: req.body,
+        assignee: req.assignee,
+        parent_id: req.parent_id,
+        blocked_on: req.blocked_on,
+        branch: req.branch,
+    }).await?;
     Ok(Json(issue))
 }
 
@@ -209,14 +145,7 @@ pub(crate) async fn add_comment(
     Path(id): Path<String>,
     Json(req): Json<AddCommentRequest>,
 ) -> std::result::Result<Json<Issue>, Error> {
-    let mut issue = state.db.get_issue(id.clone()).await?;
-    issue.comments.push(IssueComment {
-        author: req.author,
-        created_at: Utc::now(),
-        body: req.body,
-    });
-    issue.updated_at = Utc::now();
-    state.db.update_issue(&issue).await?;
+    let issue = state.issue_service.add_comment(id, req.author, req.body).await?;
     Ok(Json(issue))
 }
 

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -1,9 +1,8 @@
-use chrono::Utc;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use types::{IssueComment, IssueStatus, Session, SessionEvent, SessionStatus};
+use types::{Session, SessionEvent, SessionStatus};
 use uuid::Uuid;
 
 /// Central application state shared across all request handlers.
@@ -46,6 +45,7 @@ pub(crate) fn spawn_harness_sync(
     let msg_senders_map = Arc::clone(&state.msg_senders);
     let spawning_set = Arc::clone(&state.spawning);
     let db = Arc::clone(&state.db);
+    let issue_service = state.issue_service.clone();
     let client = Arc::clone(&state.client);
     let session_clone = session.clone();
     let event_tx = tx.clone();
@@ -64,7 +64,7 @@ pub(crate) fn spawn_harness_sync(
 
     let issue_watcher = issue_id.map(|id| {
         let mut rx = tx.subscribe();
-        let db_watch = Arc::clone(&db);
+        let svc = issue_service;
         tokio::spawn(async move {
             let mut current_turn_text = String::new();
             let mut last_turn_text = String::new();
@@ -81,35 +81,12 @@ pub(crate) fn spawn_harness_sync(
                         last_turn_text = std::mem::take(&mut current_turn_text);
                     }
                     SessionEvent::SessionDone { .. } => {
-                        if let Ok(mut issue) = db_watch.get_issue(id.clone()).await {
-                            if !last_turn_text.is_empty() {
-                                let author = issue
-                                    .assignee
-                                    .clone()
-                                    .unwrap_or_else(|| "agent".to_string());
-                                issue.comments.push(IssueComment {
-                                    author,
-                                    created_at: Utc::now(),
-                                    body: last_turn_text.clone(),
-                                });
-                            }
-                            issue.status = IssueStatus::Completed;
-                            issue.updated_at = Utc::now();
-                            let _ = db_watch.update_issue(&issue).await;
-                        }
+                        let summary = if last_turn_text.is_empty() { None } else { Some(last_turn_text) };
+                        let _ = svc.finish_issue(&id, summary).await;
                         break;
                     }
                     SessionEvent::Error { message } => {
-                        if let Ok(mut issue) = db_watch.get_issue(id.clone()).await {
-                            issue.comments.push(IssueComment {
-                                author: "system".to_string(),
-                                created_at: Utc::now(),
-                                body: message.clone(),
-                            });
-                            issue.status = IssueStatus::Failed;
-                            issue.updated_at = Utc::now();
-                            let _ = db_watch.update_issue(&issue).await;
-                        }
+                        let _ = svc.fail_issue(&id, message).await;
                         break;
                     }
                     _ => {}


### PR DESCRIPTION
Fixes #70 and #71.

## Summary

- **Issue 70**: `create_issue`, `edit_issue`, and `add_comment` route handlers were building/mutating `Issue` structs inline and calling `state.db` directly. Moved all three operations into `IssueService` methods (`create_issue`, `edit_issue`, `add_comment`). Handlers are now one-liners that delegate and return.
- **Issue 71**: `spawn_harness_sync` contained a ~50-line embedded watcher that wrote `IssueStatus::Completed`/`Failed` directly to `db`. Replaced with two new `IssueService` methods (`finish_issue`, `fail_issue`) and the watcher calls those instead.
- Also moved `slugify` and `generate_issue_id` into the `issues` crate where they belong (branch computation and ID generation are issue lifecycle concerns).

## Test plan

- [ ] 15 new unit tests added to `issues` crate covering `create_issue`, `edit_issue`, `add_comment`, `finish_issue`, `fail_issue`, and `slugify`
- [ ] All existing server integration tests continue to pass (`cargo test`)
- [ ] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)