### PR TITLE
Extract spawn_harness_sync out of state.rs

### DIFF
--- a/crates/server/src/harness_spawn.rs
+++ b/crates/server/src/harness_spawn.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+use types::{SessionEvent, SessionStatus};
+
+use crate::state::AppState;
+
+/// Spawn a harness task for the given session and return the mpsc sender that
+/// can be used to deliver messages to it.
+///
+/// This function registers the broadcast sender and mpsc sender in `AppState`
+/// once the task starts, and removes them when the task finishes.
+pub(crate) fn spawn_harness_sync(
+    state: &AppState,
+    session: types::Session,
+    issue_id: Option<String>,
+) -> tokio::sync::mpsc::Sender<String> {
+    let (tx, _rx) = tokio::sync::broadcast::channel::<SessionEvent>(256);
+    let (msg_tx, msg_rx) = tokio::sync::mpsc::channel::<String>(16);
+
+    let sessions_map = Arc::clone(&state.sessions);
+    let msg_senders_map = Arc::clone(&state.msg_senders);
+    let spawning_set = Arc::clone(&state.spawning);
+    let db = Arc::clone(&state.db);
+    let issue_service = state.issue_service.clone();
+    let client = Arc::clone(&state.client);
+    let session_clone = session.clone();
+    let event_tx = tx.clone();
+    let msg_tx_ret = msg_tx.clone();
+    let tools = state.tools.clone();
+    let model = state.model.clone();
+
+    let config = harness::HarnessConfig {
+        session: session_clone.clone(),
+        model,
+        tools,
+        git_root: None,
+    };
+
+    let session_id = session_clone.id;
+
+    let issue_watcher = issue_id.map(|id| {
+        let mut rx = tx.subscribe();
+        let svc = issue_service;
+        tokio::spawn(async move {
+            let mut current_turn_text = String::new();
+            let mut last_turn_text = String::new();
+
+            while let Ok(event) = rx.recv().await {
+                match event {
+                    SessionEvent::ContentBlockDelta {
+                        delta: types::ContentBlockDelta::TextDelta { text },
+                        ..
+                    } => {
+                        current_turn_text.push_str(&text);
+                    }
+                    SessionEvent::TurnDone { .. } if !current_turn_text.is_empty() => {
+                        last_turn_text = std::mem::take(&mut current_turn_text);
+                    }
+                    SessionEvent::SessionDone { .. } => {
+                        let summary = if last_turn_text.is_empty() { None } else { Some(last_turn_text) };
+                        let _ = svc.finish_issue(&id, summary).await;
+                        break;
+                    }
+                    SessionEvent::Error { message } => {
+                        let _ = svc.fail_issue(&id, message).await;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        })
+    });
+
+    tokio::spawn(async move {
+        {
+            let mut smap = msg_senders_map.lock().await;
+            let mut map = sessions_map.lock().await;
+            let mut spawning = spawning_set.lock().await;
+            map.insert(session_id, event_tx.clone());
+            smap.insert(session_id, msg_tx);
+            spawning.remove(&session_id);
+        }
+
+        let db_clone = Arc::clone(&db);
+        let event_tx_clone = event_tx.clone();
+
+        if let Err(e) = harness::run(config, client, db, event_tx.clone(), msg_rx).await {
+            let _ = event_tx_clone.send(SessionEvent::Error {
+                message: e.to_string(),
+            });
+            let _ = db_clone
+                .update_session_status(session_id, SessionStatus::Failed)
+                .await;
+        }
+
+        {
+            let mut map = sessions_map.lock().await;
+            map.remove(&session_id);
+        }
+        {
+            let mut smap = msg_senders_map.lock().await;
+            smap.remove(&session_id);
+        }
+
+        drop(issue_watcher);
+    });
+
+    msg_tx_ret
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,6 +4,7 @@ use std::{collections::{HashMap, HashSet}, path::PathBuf, sync::Arc};
 use tokio::net::TcpListener;
 
 mod state;
+mod harness_spawn;
 mod routes;
 
 pub use routes::{Error, Result};

--- a/crates/server/src/routes/issue.rs
+++ b/crates/server/src/routes/issue.rs
@@ -6,7 +6,8 @@ use axum::{
 use serde::{Deserialize, Deserializer};
 use types::{Issue, IssueStatus};
 
-use crate::state::{spawn_harness_sync, AppState};
+use crate::harness_spawn::spawn_harness_sync;
+use crate::state::AppState;
 use super::Error;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/crates/server/src/routes/session.rs
+++ b/crates/server/src/routes/session.rs
@@ -11,7 +11,8 @@ use tokio_stream::wrappers::BroadcastStream;
 use types::{Session, SessionEvent, SessionStatus};
 use uuid::Uuid;
 
-use crate::state::{spawn_harness_sync, AppState};
+use crate::harness_spawn::spawn_harness_sync;
+use crate::state::AppState;
 use super::Error;
 
 // ─── Request / Response types ─────────────────────────────────────────────────

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use types::{Session, SessionEvent, SessionStatus};
+use types::SessionEvent;
 use uuid::Uuid;
 
 /// Central application state shared across all request handlers.
@@ -26,108 +26,4 @@ pub(crate) struct AppState {
     pub(crate) client: Arc<dyn anthropic::AnthropicClient>,
     pub(crate) tools: Vec<Arc<dyn tools::Tool>>,
     pub(crate) model: String,
-}
-
-/// Spawn a harness task for the given session and return the mpsc sender that
-/// can be used to deliver messages to it.
-///
-/// This function registers the broadcast sender and mpsc sender in `AppState`
-/// once the task starts, and removes them when the task finishes.
-pub(crate) fn spawn_harness_sync(
-    state: &AppState,
-    session: Session,
-    issue_id: Option<String>,
-) -> tokio::sync::mpsc::Sender<String> {
-    let (tx, _rx) = tokio::sync::broadcast::channel::<SessionEvent>(256);
-    let (msg_tx, msg_rx) = tokio::sync::mpsc::channel::<String>(16);
-
-    let sessions_map = Arc::clone(&state.sessions);
-    let msg_senders_map = Arc::clone(&state.msg_senders);
-    let spawning_set = Arc::clone(&state.spawning);
-    let db = Arc::clone(&state.db);
-    let issue_service = state.issue_service.clone();
-    let client = Arc::clone(&state.client);
-    let session_clone = session.clone();
-    let event_tx = tx.clone();
-    let msg_tx_ret = msg_tx.clone();
-    let tools = state.tools.clone();
-    let model = state.model.clone();
-
-    let config = harness::HarnessConfig {
-        session: session_clone.clone(),
-        model,
-        tools,
-        git_root: None,
-    };
-
-    let session_id = session_clone.id;
-
-    let issue_watcher = issue_id.map(|id| {
-        let mut rx = tx.subscribe();
-        let svc = issue_service;
-        tokio::spawn(async move {
-            let mut current_turn_text = String::new();
-            let mut last_turn_text = String::new();
-
-            while let Ok(event) = rx.recv().await {
-                match event {
-                    SessionEvent::ContentBlockDelta {
-                        delta: types::ContentBlockDelta::TextDelta { text },
-                        ..
-                    } => {
-                        current_turn_text.push_str(&text);
-                    }
-                    SessionEvent::TurnDone { .. } if !current_turn_text.is_empty() => {
-                        last_turn_text = std::mem::take(&mut current_turn_text);
-                    }
-                    SessionEvent::SessionDone { .. } => {
-                        let summary = if last_turn_text.is_empty() { None } else { Some(last_turn_text) };
-                        let _ = svc.finish_issue(&id, summary).await;
-                        break;
-                    }
-                    SessionEvent::Error { message } => {
-                        let _ = svc.fail_issue(&id, message).await;
-                        break;
-                    }
-                    _ => {}
-                }
-            }
-        })
-    });
-
-    tokio::spawn(async move {
-        {
-            let mut smap = msg_senders_map.lock().await;
-            let mut map = sessions_map.lock().await;
-            let mut spawning = spawning_set.lock().await;
-            map.insert(session_id, event_tx.clone());
-            smap.insert(session_id, msg_tx);
-            spawning.remove(&session_id);
-        }
-
-        let db_clone = Arc::clone(&db);
-        let event_tx_clone = event_tx.clone();
-
-        if let Err(e) = harness::run(config, client, db, event_tx.clone(), msg_rx).await {
-            let _ = event_tx_clone.send(SessionEvent::Error {
-                message: e.to_string(),
-            });
-            let _ = db_clone
-                .update_session_status(session_id, SessionStatus::Failed)
-                .await;
-        }
-
-        {
-            let mut map = sessions_map.lock().await;
-            map.remove(&session_id);
-        }
-        {
-            let mut smap = msg_senders_map.lock().await;
-            smap.remove(&session_id);
-        }
-
-        drop(issue_watcher);
-    });
-
-    msg_tx_ret
 }


### PR DESCRIPTION
## Summary

- Moves `spawn_harness_sync` (and the issue-watcher it contains) from `state.rs` into a new `crates/server/src/harness_spawn.rs` module
- Leaves `state.rs` as a pure struct definition with no spawning logic
- Updates `routes/issue.rs` and `routes/session.rs` imports accordingly

Resolves the `check-state` complexity violation: `state.rs` scored 13 (threshold: 8) because it mixed struct ownership with async channel wiring, task spawning, and event-watching logic.

Closes #72.

## Test plan

- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test -p server` — all 86 tests pass
- [ ] `check-state` score on `state.rs` drops below threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)