### PR TITLE
Add ns2 issue show --id command (issue #58)

### DIFF
--- a/crates/cli/src/commands/issue.rs
+++ b/crates/cli/src/commands/issue.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use serde_json::json;
 use types::{Issue, IssueStatus};
 use crate::client::{handle_connection_error, print_error_response};
-use crate::render::{print_issue_row, render_issue_tree, IssueTreeNode};
+use crate::render::{format_issue_show, print_issue_row, render_issue_tree, IssueTreeNode};
 
 pub(crate) fn issue_is_terminal(status: &IssueStatus) -> bool {
     matches!(status, IssueStatus::Completed | IssueStatus::Failed)
@@ -283,6 +283,34 @@ pub(crate) async fn run_list(
         for issue in &issues {
             print_issue_row(issue);
         }
+    }
+}
+
+pub(crate) async fn run_show(server: &str, id: String, json: bool) {
+    let client = reqwest::Client::new();
+    let url = format!("{}/issues/{}", server, id);
+    let resp = client.get(&url).send().await.unwrap_or_else(|e| {
+        handle_connection_error(&e);
+    });
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        eprintln!("Error: issue not found: {id}");
+        std::process::exit(1);
+    }
+    if !resp.status().is_success() {
+        print_error_response(resp).await;
+    }
+    let issue: Issue = resp.json().await.unwrap_or_else(|e| {
+        eprintln!("Error parsing response: {e}");
+        std::process::exit(1);
+    });
+    if json {
+        let out = serde_json::to_string_pretty(&issue).unwrap_or_else(|e| {
+            eprintln!("Error serializing to JSON: {e}");
+            std::process::exit(1);
+        });
+        println!("{out}");
+    } else {
+        print!("{}", format_issue_show(&issue));
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -250,6 +250,13 @@ enum IssueAction {
         #[arg(long = "id", num_args = 1.., help = "Issue IDs to wait on. Repeat for multiple.")]
         ids: Vec<String>,
     },
+    #[command(about = "Show details of a single issue.", long_about = "Print full details of a single issue: title, body, status, assignee, branch, and comments.\n\nWith --json, output is machine-readable JSON suitable for scripting:\n  STATUS=$(ns2 issue show --id \"$id\" --json | jq -r .status)")]
+    Show {
+        #[arg(long, help = "The issue ID. Required.")]
+        id: String,
+        #[arg(long, help = "Output as JSON instead of human-readable format.")]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -372,6 +379,9 @@ async fn main() {
             IssueAction::Wait { ids } => {
                 commands::issue::run_wait(&cli.server, ids).await;
             }
+            IssueAction::Show { id, json } => {
+                commands::issue::run_show(&cli.server, id, json).await;
+            }
         },
         Command::Worktree { action } => match action {
             WorktreeAction::List => {
@@ -393,10 +403,10 @@ mod tests {
     use types::*;
     use uuid::Uuid;
     use crate::render::{
-        format_issue_row, format_session_event, format_sync_error, format_sync_warning,
-        issue_status_symbol, parse_sse_frames, render_issue_tree, render_session_line,
-        render_tree_line, session_status_symbol, spinner_char, truncate_str, IssueTreeNode,
-        SPINNER_FRAMES,
+        format_issue_row, format_issue_show, format_session_event, format_sync_error,
+        format_sync_warning, issue_status_symbol, parse_sse_frames, render_issue_tree,
+        render_session_line, render_tree_line, session_status_symbol, spinner_char, truncate_str,
+        IssueTreeNode, SPINNER_FRAMES,
     };
     use crate::commands::spec::verify_spec_paths;
     use crate::commands::issue::{issue_is_terminal, all_nodes_terminal};
@@ -938,6 +948,103 @@ mod tests {
             }
             _ => panic!("expected issue new command"),
         }
+    }
+
+    // --- issue show CLI parse tests ---
+
+    #[test]
+    fn issue_show_parses_id_flag() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "show", "--id", "ab12"]).unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Show { id, json } } => {
+                assert_eq!(id, "ab12");
+                assert!(!json);
+            }
+            _ => panic!("expected issue show command"),
+        }
+    }
+
+    #[test]
+    fn issue_show_parses_json_flag() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "show", "--id", "ab12", "--json"]).unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Show { id, json } } => {
+                assert_eq!(id, "ab12");
+                assert!(json);
+            }
+            _ => panic!("expected issue show command"),
+        }
+    }
+
+    #[test]
+    fn issue_show_missing_id_fails_to_parse() {
+        let result = Cli::try_parse_from(["ns2", "issue", "show"]);
+        assert!(result.is_err(), "show without --id should fail to parse");
+    }
+
+    // --- format_issue_show render tests ---
+
+    fn make_show_issue() -> Issue {
+        Issue {
+            id: "ab12".into(),
+            title: "My Title".into(),
+            body: "My body text".into(),
+            status: types::IssueStatus::Open,
+            branch: "feat/my-branch".into(),
+            assignee: Some("swe".into()),
+            session_id: None,
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::DateTime::parse_from_rfc3339("2024-01-15T10:30:00Z").unwrap().into(),
+            updated_at: chrono::DateTime::parse_from_rfc3339("2024-01-15T10:30:00Z").unwrap().into(),
+        }
+    }
+
+    #[test]
+    fn format_issue_show_contains_id_title_status_body() {
+        let issue = make_show_issue();
+        let out = format_issue_show(&issue);
+        assert!(out.contains("ab12"), "should contain id");
+        assert!(out.contains("My Title"), "should contain title");
+        assert!(out.contains("open"), "should contain status");
+        assert!(out.contains("My body text"), "should contain body");
+    }
+
+    #[test]
+    fn format_issue_show_contains_assignee_and_branch() {
+        let issue = make_show_issue();
+        let out = format_issue_show(&issue);
+        assert!(out.contains("swe"), "should contain assignee");
+        assert!(out.contains("feat/my-branch"), "should contain branch");
+    }
+
+    #[test]
+    fn format_issue_show_no_assignee_shows_dash() {
+        let mut issue = make_show_issue();
+        issue.assignee = None;
+        let out = format_issue_show(&issue);
+        assert!(out.contains("assignee:   -"), "no assignee should show dash");
+    }
+
+    #[test]
+    fn format_issue_show_displays_comments() {
+        let mut issue = make_show_issue();
+        issue.comments = vec![types::IssueComment {
+            author: "user".into(),
+            body: "This is a comment".into(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2024-01-15T11:00:00Z").unwrap().into(),
+        }];
+        let out = format_issue_show(&issue);
+        assert!(out.contains("This is a comment"), "should contain comment body");
+        assert!(out.contains("user"), "should contain comment author");
+    }
+
+    #[test]
+    fn format_issue_show_no_comments_omits_comments_section() {
+        let issue = make_show_issue();
+        let out = format_issue_show(&issue);
+        assert!(!out.contains("comments:"), "no comments should omit comments section");
     }
 
     #[test]

--- a/crates/cli/src/render.rs
+++ b/crates/cli/src/render.rs
@@ -49,6 +49,38 @@ pub(crate) fn print_issue_row(issue: &Issue) {
     println!("{}", format_issue_row(issue));
 }
 
+pub(crate) fn format_issue_show(issue: &Issue) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("id:         {}\n", issue.id));
+    out.push_str(&format!("title:      {}\n", issue.title));
+    out.push_str(&format!("status:     {}\n", issue.status));
+    out.push_str(&format!("assignee:   {}\n", issue.assignee.as_deref().unwrap_or("-")));
+    out.push_str(&format!("branch:     {}\n", issue.branch));
+    if let Some(pid) = &issue.parent_id {
+        out.push_str(&format!("parent:     {pid}\n"));
+    }
+    if !issue.blocked_on.is_empty() {
+        out.push_str(&format!("blocked-on: {}\n", issue.blocked_on.join(", ")));
+    }
+    out.push_str(&format!("created:    {}\n", issue.created_at.format("%Y-%m-%d %H:%M:%S UTC")));
+    out.push_str(&format!("updated:    {}\n", issue.updated_at.format("%Y-%m-%d %H:%M:%S UTC")));
+    out.push_str("\nbody:\n");
+    out.push_str(&issue.body);
+    out.push('\n');
+    if !issue.comments.is_empty() {
+        out.push_str("\ncomments:\n");
+        for comment in &issue.comments {
+            out.push_str(&format!(
+                "  [{}] {}: {}\n",
+                comment.created_at.format("%Y-%m-%d %H:%M UTC"),
+                comment.author,
+                comment.body,
+            ));
+        }
+    }
+    out
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Session event formatting
 

--- a/crates/cli/tests/issue_crud.rs
+++ b/crates/cli/tests/issue_crud.rs
@@ -433,3 +433,49 @@ fn extract_branch(json: &str) -> String {
     let end = json[start..].find('"').expect("branch value not terminated") + start;
     json[start..end].to_string()
 }
+
+// Flow: issue show
+
+#[test]
+fn issue_show_prints_title_body_and_status() {
+    let mut h = TestHarness::new();
+    h.start_server();
+    let id = h.ns2_stdout(&["issue", "new", "--title", "Show Me", "--body", "Full description here"]);
+    let out = h.ns2_stdout(&["issue", "show", "--id", &id]);
+    assert!(out.contains("Show Me"), "show should contain title");
+    assert!(out.contains("Full description here"), "show should contain body");
+    assert!(out.contains("open"), "show should contain status");
+}
+
+#[test]
+fn issue_show_json_outputs_valid_json_with_expected_fields() {
+    let mut h = TestHarness::new();
+    h.start_server();
+    let id = h.ns2_stdout(&["issue", "new", "--title", "JSON Issue", "--body", "json body"]);
+    let out = h.ns2_stdout(&["issue", "show", "--id", &id, "--json"]);
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("--json output should be valid JSON");
+    assert_eq!(parsed["id"].as_str().unwrap(), id, "JSON id should match");
+    assert_eq!(parsed["title"].as_str().unwrap(), "JSON Issue");
+    assert_eq!(parsed["body"].as_str().unwrap(), "json body");
+    assert_eq!(parsed["status"].as_str().unwrap(), "open");
+}
+
+#[test]
+fn issue_show_missing_id_exits_nonzero() {
+    let mut h = TestHarness::new();
+    h.start_server();
+    h.ns2()
+        .args(["issue", "show", "--id", "zzzz"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn issue_show_displays_comments() {
+    let mut h = TestHarness::new();
+    h.start_server();
+    let id = h.ns2_stdout(&["issue", "new", "--title", "With Comment", "--body", "b"]);
+    h.ns2().args(["issue", "comment", "--id", &id, "--body", "a comment here"]).assert().success();
+    let out = h.ns2_stdout(&["issue", "show", "--id", &id]);
+    assert!(out.contains("a comment here"), "show should display comments");
+}


### PR DESCRIPTION
Adds `ns2 issue show --id <id>` to inspect a single issue's title,
body, status, assignee, branch, and comments. `--json` flag outputs
machine-readable JSON for scripting.

https://claude.ai/code/session_01MQStSNWYaBrMnaYgBnbQaz