### PR TITLE
Add --timeout flag to session tail/wait and issue wait

### DIFF
--- a/crates/cli/src/commands/issue.rs
+++ b/crates/cli/src/commands/issue.rs
@@ -286,13 +286,16 @@ pub(crate) async fn run_list(
     }
 }
 
-pub(crate) async fn run_wait(server: &str, ids: Vec<String>) {
+pub(crate) async fn run_wait(server: &str, ids: Vec<String>, timeout: Option<u64>) {
     if ids.is_empty() {
         eprintln!("Error: at least one --id is required");
         std::process::exit(1);
     }
 
     let client = reqwest::Client::new();
+    let deadline = timeout.map(|secs| {
+        tokio::time::Instant::now() + tokio::time::Duration::from_secs(secs)
+    });
 
     // Helper: fetch an issue tree rooted at `id` recursively.
     async fn fetch_issue_tree(
@@ -438,6 +441,13 @@ pub(crate) async fn run_wait(server: &str, ids: Vec<String>) {
                 final_statuses.push((root.issue.id.clone(), root.issue.status.clone()));
             }
             break;
+        }
+
+        if let Some(dl) = deadline {
+            if tokio::time::Instant::now() >= dl {
+                eprintln!("Timeout expired.");
+                std::process::exit(1);
+            }
         }
 
         tick = tick.wrapping_add(1);

--- a/crates/cli/src/commands/session.rs
+++ b/crates/cli/src/commands/session.rs
@@ -108,13 +108,21 @@ pub(crate) async fn run_new(
     }
 }
 
-pub(crate) async fn run_tail(server: &str, id: Option<String>, name: Option<String>, turns: Option<usize>) {
+pub(crate) async fn run_tail(server: &str, id: Option<String>, name: Option<String>, turns: Option<usize>, timeout: Option<u64>) {
     let session_id = resolve_session_id(server, id, name).await;
     let mut url = format!("{}/sessions/{}/events", server, session_id);
     if let Some(n) = turns {
         url = format!("{url}?last_turns={n}");
     }
-    stream_events(&url, false).await;
+    if let Some(secs) = timeout {
+        let duration = tokio::time::Duration::from_secs(secs);
+        if tokio::time::timeout(duration, stream_events(&url, false)).await.is_err() {
+            eprintln!("Timeout expired.");
+            std::process::exit(1);
+        }
+    } else {
+        stream_events(&url, false).await;
+    }
 }
 
 pub(crate) async fn run_send(server: &str, id: Option<String>, name: Option<String>, message: String) {
@@ -138,7 +146,7 @@ pub(crate) async fn run_stop(server: &str, id: Option<String>, name: Option<Stri
     println!("Stop not yet implemented for session {session_id}");
 }
 
-pub(crate) async fn run_wait(server: &str, ids: Vec<String>) {
+pub(crate) async fn run_wait(server: &str, ids: Vec<String>, timeout: Option<u64>) {
     if ids.is_empty() {
         eprintln!("Error: at least one --id is required");
         std::process::exit(1);
@@ -153,6 +161,10 @@ pub(crate) async fn run_wait(server: &str, ids: Vec<String>) {
     }
 
     use std::io::Write;
+
+    let deadline = timeout.map(|secs| {
+        tokio::time::Instant::now() + tokio::time::Duration::from_secs(secs)
+    });
 
     let mut terminal_statuses: HashMap<String, SessionStatus> = HashMap::new();
     // Track snippet text per session id for the progress display.
@@ -238,6 +250,14 @@ pub(crate) async fn run_wait(server: &str, ids: Vec<String>) {
         if all_done {
             break;
         }
+
+        if let Some(dl) = deadline {
+            if tokio::time::Instant::now() >= dl {
+                eprintln!("Timeout expired.");
+                std::process::exit(1);
+            }
+        }
+
         tick = tick.wrapping_add(1);
         tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -116,6 +116,8 @@ enum SessionAction {
         name: Option<String>,
         #[arg(long, help = "Only replay the last N turns of history before streaming live. 0 skips all history.")]
         turns: Option<usize>,
+        #[arg(long, help = "Exit after N seconds even if the session has not finished. Exits 0 if session completed naturally, 1 if timeout fired.")]
+        timeout: Option<u64>,
     },
     #[command(about = "Queue a message to a session.", long_about = "Queue a message to a session.\n\nUse this to give follow-up instructions, provide additional context, or correct an agent that's going down an incorrect path. The message is queued immediately; the agent picks it up on its next turn. Messages can only be sent to sessions that are in the `created` or `running` state.")]
     Send {
@@ -137,6 +139,8 @@ enum SessionAction {
     Wait {
         #[arg(long = "id", num_args = 1.., help = "Session UUIDs to wait on. Repeat for multiple.")]
         ids: Vec<String>,
+        #[arg(long, help = "Exit after N seconds even if sessions have not finished. Exits 1 if timeout fired before completion.")]
+        timeout: Option<u64>,
     },
 }
 
@@ -249,6 +253,8 @@ enum IssueAction {
     Wait {
         #[arg(long = "id", num_args = 1.., help = "Issue IDs to wait on. Repeat for multiple.")]
         ids: Vec<String>,
+        #[arg(long, help = "Exit after N seconds even if issues have not finished. Exits 1 if timeout fired before completion.")]
+        timeout: Option<u64>,
     },
 }
 
@@ -312,8 +318,8 @@ async fn main() {
             SessionAction::New { name, agent, message, wait } => {
                 commands::session::run_new(&cli.server, name, agent, message, wait).await;
             }
-            SessionAction::Tail { id, name, turns } => {
-                commands::session::run_tail(&cli.server, id, name, turns).await;
+            SessionAction::Tail { id, name, turns, timeout } => {
+                commands::session::run_tail(&cli.server, id, name, turns, timeout).await;
             }
             SessionAction::Send { id, name, message } => {
                 commands::session::run_send(&cli.server, id, name, message).await;
@@ -321,8 +327,8 @@ async fn main() {
             SessionAction::Stop { id, name } => {
                 commands::session::run_stop(&cli.server, id, name).await;
             }
-            SessionAction::Wait { ids } => {
-                commands::session::run_wait(&cli.server, ids).await;
+            SessionAction::Wait { ids, timeout } => {
+                commands::session::run_wait(&cli.server, ids, timeout).await;
             }
         },
         Command::Agent { action } => match action {
@@ -369,8 +375,8 @@ async fn main() {
             IssueAction::List { status, assignee, parent, blocked_on } => {
                 commands::issue::run_list(&cli.server, status, assignee, parent, blocked_on).await;
             }
-            IssueAction::Wait { ids } => {
-                commands::issue::run_wait(&cli.server, ids).await;
+            IssueAction::Wait { ids, timeout } => {
+                commands::issue::run_wait(&cli.server, ids, timeout).await;
             }
         },
         Command::Worktree { action } => match action {
@@ -600,6 +606,72 @@ mod tests {
     use clap::Parser;
 
     #[test]
+    fn session_tail_parses_timeout_flag() {
+        let cli = Cli::try_parse_from(["ns2", "session", "tail", "--id", "abc", "--timeout", "10"]).unwrap();
+        match cli.command {
+            Command::Session { action: SessionAction::Tail { timeout, .. } } => {
+                assert_eq!(timeout, Some(10));
+            }
+            _ => panic!("expected session tail command"),
+        }
+    }
+
+    #[test]
+    fn session_tail_no_timeout_is_none() {
+        let cli = Cli::try_parse_from(["ns2", "session", "tail", "--id", "abc"]).unwrap();
+        match cli.command {
+            Command::Session { action: SessionAction::Tail { timeout, .. } } => {
+                assert_eq!(timeout, None);
+            }
+            _ => panic!("expected session tail command"),
+        }
+    }
+
+    #[test]
+    fn session_wait_parses_timeout_flag() {
+        let cli = Cli::try_parse_from(["ns2", "session", "wait", "--id", "abc", "--timeout", "30"]).unwrap();
+        match cli.command {
+            Command::Session { action: SessionAction::Wait { timeout, .. } } => {
+                assert_eq!(timeout, Some(30));
+            }
+            _ => panic!("expected session wait command"),
+        }
+    }
+
+    #[test]
+    fn session_wait_no_timeout_is_none() {
+        let cli = Cli::try_parse_from(["ns2", "session", "wait", "--id", "abc"]).unwrap();
+        match cli.command {
+            Command::Session { action: SessionAction::Wait { timeout, .. } } => {
+                assert_eq!(timeout, None);
+            }
+            _ => panic!("expected session wait command"),
+        }
+    }
+
+    #[test]
+    fn issue_wait_parses_timeout_flag() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "wait", "--id", "abc", "--timeout", "60"]).unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Wait { timeout, .. } } => {
+                assert_eq!(timeout, Some(60));
+            }
+            _ => panic!("expected issue wait command"),
+        }
+    }
+
+    #[test]
+    fn issue_wait_no_timeout_is_none() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "wait", "--id", "abc"]).unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Wait { timeout, .. } } => {
+                assert_eq!(timeout, None);
+            }
+            _ => panic!("expected issue wait command"),
+        }
+    }
+
+    #[test]
     fn session_tail_parses_turns_flag() {
         let cli = Cli::try_parse_from(["ns2", "session", "tail", "--id", "abc", "--turns", "5"]).unwrap();
         match cli.command {
@@ -716,7 +788,7 @@ mod tests {
         ])
         .unwrap();
         match cli.command {
-            Command::Session { action: SessionAction::Wait { ids } } => {
+            Command::Session { action: SessionAction::Wait { ids, .. } } => {
                 assert_eq!(ids.len(), 2);
                 assert!(ids.iter().any(|id| id == uuid1));
                 assert!(ids.iter().any(|id| id == uuid2));

--- a/crates/cli/tests/issue_crud.rs
+++ b/crates/cli/tests/issue_crud.rs
@@ -3,6 +3,22 @@ mod common;
 use common::TestHarness;
 use predicates::prelude::*;
 
+// ─── Flow 55: issue wait --timeout ───────────────────────────────────────────
+
+#[test]
+fn issue_wait_timeout_exits_nonzero_on_non_terminal_issue() {
+    let mut h = TestHarness::new();
+    h.start_server();
+
+    // An issue in 'open' state with no session — never finishes on its own.
+    let id = h.ns2_stdout(&["issue", "new", "--title", "t", "--body", "b"]);
+
+    h.ns2()
+        .args(["issue", "wait", "--id", &id, "--timeout", "1"])
+        .assert()
+        .failure();
+}
+
 fn write_agent(h: &TestHarness, name: &str) {
     let dir = h.repo_dir.path().join(".ns2/agents");
     std::fs::create_dir_all(&dir).unwrap();

--- a/crates/cli/tests/session_crud.rs
+++ b/crates/cli/tests/session_crud.rs
@@ -2,6 +2,22 @@ mod common;
 
 use predicates::prelude::*;
 
+// ─── Flow 55: --timeout flag ──────────────────────────────────────────────────
+
+#[test]
+fn session_wait_timeout_exits_nonzero_on_non_terminal_session() {
+    let mut h = common::TestHarness::new();
+    h.start_server();
+
+    // A session without a message stays in 'created' — never finishes.
+    let uuid = h.ns2_stdout(&["session", "new"]);
+
+    h.ns2()
+        .args(["session", "wait", "--id", &uuid, "--timeout", "1"])
+        .assert()
+        .failure();
+}
+
 // ─── Flow 02: session create / list ──────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Closes #55. Adds --timeout <N> (seconds) to `session tail`, `session wait`,
and `issue wait`. When the timeout fires before the operation completes the
command exits 1; natural completion retains existing exit-code semantics.
The running session/issue is never terminated — only the client command exits.

https://claude.ai/code/session_01Q8DA1qKuGLpKhqGHkmw5kR