### PR TITLE
Add stop hook for commit + push (GH#89)

### DIFF
--- a/.claude/hooks/stop-commit-push.sh
+++ b/.claude/hooks/stop-commit-push.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Stop hook: blocks the session from completing if there are uncommitted changes
+# or commits that have not been pushed to the remote.
+#
+# Works for both Claude Code sessions (where CLAUDE_PROJECT_DIR is set) and
+# ns2 harness sessions (where the hook subprocess cwd is the session worktree).
+
+GIT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# 1. Check for uncommitted / untracked changes.
+STATUS=$(git -C "$GIT_DIR" status --short 2>/dev/null)
+if [ -n "$STATUS" ]; then
+  echo "You have uncommitted changes. Please commit all your work before stopping."
+  exit 1
+fi
+
+# 2. Check for commits that exist locally but have not been pushed to any remote.
+HAS_REMOTE=$(git -C "$GIT_DIR" remote 2>/dev/null)
+if [ -n "$HAS_REMOTE" ]; then
+  UNPUSHED=$(git -C "$GIT_DIR" log HEAD --oneline --not --remotes 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$UNPUSHED" -gt 0 ]; then
+    echo "You have ${UNPUSHED} unpushed commit(s). Please push your work before stopping."
+    exit 1
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,18 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}\"/.claude/hooks/stop-commit-push.sh",
+            "timeout": 30,
+            "statusMessage": "Checking for uncommitted or unpushed work..."
+          }
+        ]
+      }
     ]
   }
 }

--- a/crates/cli/tests/session_advanced.rs
+++ b/crates/cli/tests/session_advanced.rs
@@ -256,3 +256,54 @@ exit 0
     );
     assert!(combined.contains("uncommitted changes"), "expected 'uncommitted changes' message");
 }
+
+#[test]
+fn commit_guard_exits_nonzero_on_unpushed_commits() {
+    let mut h = common::TestHarness::new();
+    h.start_server();
+    h.setup_origin();
+    // Push initial state so the local branch tracks origin
+    h.git(&["push", "-u", "origin", "HEAD"]);
+
+    let hooks_dir = h.repo_dir.path().join(".claude/hooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    let script_path = hooks_dir.join("stop-commit-push.sh");
+    std::fs::write(&script_path, r#"#!/usr/bin/env bash
+GIT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+STATUS=$(git -C "$GIT_DIR" status --short 2>/dev/null)
+if [ -n "$STATUS" ]; then
+  echo "You have uncommitted changes. Please commit your work before stopping."
+  exit 1
+fi
+HAS_REMOTE=$(git -C "$GIT_DIR" remote 2>/dev/null)
+if [ -n "$HAS_REMOTE" ]; then
+  UNPUSHED=$(git -C "$GIT_DIR" log HEAD --oneline --not --remotes 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$UNPUSHED" -gt 0 ]; then
+    echo "You have ${UNPUSHED} unpushed commit(s). Please push your work before stopping."
+    exit 1
+  fi
+fi
+exit 0
+"#).unwrap();
+    std::process::Command::new("chmod")
+        .args(["+x", script_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    // Commit the script so the working tree is clean
+    h.git(&["add", "."]);
+    h.git(&["commit", "-m", "add commit-push guard"]);
+    // Do NOT push — this commit should be detected as unpushed
+    let repo_dir = h.repo_dir.path().to_path_buf();
+    let output = std::process::Command::new(script_path.to_str().unwrap())
+        .current_dir(&repo_dir)
+        .env("CLAUDE_PROJECT_DIR", &repo_dir)
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "exit code should be non-zero with unpushed commits");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(combined.contains("unpushed commit"), "expected 'unpushed commit' message, got: {combined}");
+}

--- a/crates/harness/src/hooks.rs
+++ b/crates/harness/src/hooks.rs
@@ -1,22 +1,29 @@
 use agents::{AgentHooks, HookCommand, HookEntry};
 use regex::Regex;
+use std::path::Path;
 use uuid::Uuid;
 
 /// Run a single hook command with JSON on stdin.
 /// Returns `(exit_code, stdout, stderr)`.
 /// Kills the process and returns exit_code=1 on timeout.
-pub(crate) async fn run_hook(cmd: &HookCommand, stdin_json: &str) -> (i32, String, String) {
+/// When `cwd` is `Some`, the subprocess is started with that working directory
+/// so hooks run inside the agent's worktree rather than the server's cwd.
+pub(crate) async fn run_hook(cmd: &HookCommand, stdin_json: &str, cwd: Option<&Path>) -> (i32, String, String) {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::process::Command;
     use tokio::time::{sleep, Duration};
 
-    let mut child = match Command::new("sh")
+    let mut builder = Command::new("sh");
+    builder
         .arg("-c")
         .arg(&cmd.command)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
+        .stderr(std::process::Stdio::piped());
+    if let Some(dir) = cwd {
+        builder.current_dir(dir);
+    }
+    let mut child = match builder.spawn()
     {
         Ok(c) => c,
         Err(e) => {
@@ -79,10 +86,12 @@ pub(crate) fn matching_hook_entries<'a>(entries: &'a [HookEntry], tool_name: &st
 /// Run PreToolUse hooks for `tool_name`.
 /// Returns `Some(blocked_message)` if any hook exits non-zero (tool should be skipped),
 /// or `None` if all hooks pass.
+/// `cwd` is forwarded to the hook subprocess so it runs in the session's worktree.
 pub(crate) async fn run_pre_tool_use_hooks(
     hooks: &AgentHooks,
     tool_name: &str,
     tool_input: &serde_json::Value,
+    cwd: Option<&Path>,
 ) -> Option<String> {
     let stdin = serde_json::json!({
         "tool_name": tool_name,
@@ -92,7 +101,7 @@ pub(crate) async fn run_pre_tool_use_hooks(
 
     for entry in matching_hook_entries(&hooks.pre_tool_use, tool_name) {
         for cmd in &entry.hooks {
-            let (exit_code, _stdout, stderr) = run_hook(cmd, &stdin_str).await;
+            let (exit_code, _stdout, stderr) = run_hook(cmd, &stdin_str, cwd).await;
             if exit_code != 0 {
                 return Some(if stderr.is_empty() {
                     format!("Hook blocked tool '{tool_name}' (exit {exit_code})")
@@ -106,11 +115,13 @@ pub(crate) async fn run_pre_tool_use_hooks(
 }
 
 /// Run PostToolUse hooks for `tool_name`. Exit code is always ignored.
+/// `cwd` is forwarded to the hook subprocess so it runs in the session's worktree.
 pub(crate) async fn run_post_tool_use_hooks(
     hooks: &AgentHooks,
     tool_name: &str,
     tool_input: &serde_json::Value,
     tool_result: &str,
+    cwd: Option<&Path>,
 ) {
     let stdin = serde_json::json!({
         "tool_name": tool_name,
@@ -121,7 +132,7 @@ pub(crate) async fn run_post_tool_use_hooks(
 
     for entry in matching_hook_entries(&hooks.post_tool_use, tool_name) {
         for cmd in &entry.hooks {
-            run_hook(cmd, &stdin_str).await;
+            run_hook(cmd, &stdin_str, cwd).await;
         }
     }
 }
@@ -134,13 +145,16 @@ pub(crate) async fn run_post_tool_use_hooks(
 /// open — the hook is skipped and the session is allowed to complete normally.
 /// This prevents an infinite loop when a hook script cannot be found (e.g. because
 /// `$CLAUDE_PROJECT_DIR` is unset and the path cannot be resolved).
-pub(crate) async fn run_stop_hooks(hooks: &AgentHooks, session_id: Uuid) -> Option<String> {
+///
+/// `cwd` sets the working directory for the hook subprocess so it runs inside the
+/// session's worktree rather than the server process's cwd.
+pub(crate) async fn run_stop_hooks(hooks: &AgentHooks, session_id: Uuid, cwd: Option<&Path>) -> Option<String> {
     let stdin = serde_json::json!({ "session_id": session_id.to_string() });
     let stdin_str = stdin.to_string();
 
     for entry in &hooks.stop {
         for cmd in &entry.hooks {
-            let (exit_code, stdout, _stderr) = run_hook(cmd, &stdin_str).await;
+            let (exit_code, stdout, _stderr) = run_hook(cmd, &stdin_str, cwd).await;
             if exit_code != 0 {
                 // Exit 127 = command not found: configuration error, not a deliberate
                 // block. Fail open so the agent is not trapped in an infinite loop.

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -53,6 +53,10 @@ pub struct HarnessConfig {
     pub tools: Vec<Arc<dyn tools::Tool>>,
     /// Injectable git root for tests. Production code passes `None`; tests pass `Some(temp_dir)`.
     pub git_root: Option<PathBuf>,
+    /// Session working directory (worktree path). Hooks are spawned with this as their cwd
+    /// so they operate on the correct tree. Set by `run()` after resolving the worktree;
+    /// tests leave this as `None`.
+    pub cwd: Option<PathBuf>,
 }
 
 
@@ -273,6 +277,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
 
         let client = Arc::new(StubClient);
@@ -318,6 +323,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(StubClient);
         let db = Arc::new(mock_db);
@@ -364,6 +370,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(StubClient);
         let db = Arc::new(mock_db);
@@ -385,6 +392,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(StubClient);
         let db = Arc::new(mock_db);
@@ -429,6 +437,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(StubClient);
         let db = Arc::new(mock_db);
@@ -520,6 +529,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(MultiBlockClient);
         let db = Arc::new(mock_db);
@@ -553,6 +563,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(StubClient);
         let db = Arc::new(mock_db);
@@ -651,6 +662,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![Arc::new(AlwaysOkTool)],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(ToolUseClient::new());
         let db = Arc::new(mock_db);
@@ -719,6 +731,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![Arc::new(AlwaysErrTool)],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(ToolUseClient::new());
         let db = Arc::new(mock_db);
@@ -869,6 +882,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![Arc::new(AlwaysOkTool)],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(TwoToolClient { call_count: std::sync::atomic::AtomicU32::new(0) });
         let db = Arc::new(mock_db);
@@ -979,6 +993,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
 
         let db = Arc::new(mock_db);
@@ -1053,6 +1068,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(MaxTokensClient);
         let db = Arc::new(mock_db);
@@ -1150,6 +1166,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![Arc::new(AlwaysOkTool)], // only "read", not "nonexistent_tool"
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(UnknownToolClient::new());
         let db = Arc::new(mock_db);
@@ -1198,6 +1215,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![], // empty
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(StubClient);
         let db = Arc::new(mock_db);
@@ -1275,6 +1293,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![Arc::new(AlwaysOkTool)],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(ToolUseClient::new());
         let db = Arc::new(mock_db);
@@ -1339,6 +1358,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![Arc::new(AlwaysOkTool)],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(TwoToolOrderingClient {
             call_count: std::sync::atomic::AtomicU32::new(0),
@@ -1433,6 +1453,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(KnownTokenClient);
         let db = Arc::new(mock_db);
@@ -1562,6 +1583,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
 
         let db = Arc::new(mock_db);
@@ -1653,6 +1675,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(SystemCapturingClient::new());
         let client_ref = Arc::clone(&client);
@@ -1702,6 +1725,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: Some(tmp.path().to_path_buf()),
+            cwd: None,
         };
         let client = Arc::new(SystemCapturingClient::new());
         let client_ref = Arc::clone(&client);
@@ -1756,6 +1780,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: Some(tmp.path().to_path_buf()),
+            cwd: None,
         };
         let client = Arc::new(SystemCapturingClient::new());
         let client_ref = Arc::clone(&client);
@@ -1807,6 +1832,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: Some(tmp.path().to_path_buf()),
+            cwd: None,
         };
         let client = Arc::new(SystemCapturingClient::new());
         let client_ref = Arc::clone(&client);
@@ -1864,6 +1890,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: Some(tmp.path().to_path_buf()),
+            cwd: None,
         };
         let client = Arc::new(SystemCapturingClient::new());
         let client_ref = Arc::clone(&client);
@@ -1924,6 +1951,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: Some(tmp.path().to_path_buf()),
+            cwd: None,
         };
         let client = Arc::new(SystemCapturingClient::new());
         let client_ref = Arc::clone(&client);
@@ -2005,7 +2033,7 @@ mod tests {
         };
 
         let result =
-            run_pre_tool_use_hooks(&hooks, "read", &serde_json::json!({"path": "/tmp/f"})).await;
+            run_pre_tool_use_hooks(&hooks, "read", &serde_json::json!({"path": "/tmp/f"}), None).await;
         assert!(result.is_none(), "exit 0 hook must not block the tool, got: {result:?}");
     }
 
@@ -2022,7 +2050,7 @@ mod tests {
         };
 
         let result =
-            run_pre_tool_use_hooks(&hooks, "bash", &serde_json::json!({})).await;
+            run_pre_tool_use_hooks(&hooks, "bash", &serde_json::json!({}), None).await;
         assert!(result.is_some(), "exit 1 hook must block the tool");
         let msg = result.unwrap();
         assert!(
@@ -2044,7 +2072,7 @@ mod tests {
         };
 
         let result =
-            run_pre_tool_use_hooks(&hooks, "read", &serde_json::json!({})).await;
+            run_pre_tool_use_hooks(&hooks, "read", &serde_json::json!({}), None).await;
         assert!(result.is_none(), "hook for 'bash' must not match tool 'read'");
     }
 
@@ -2060,7 +2088,7 @@ mod tests {
             ..AgentHooks::default()
         };
 
-        run_post_tool_use_hooks(&hooks, "bash", &serde_json::json!({}), "result").await;
+        run_post_tool_use_hooks(&hooks, "bash", &serde_json::json!({}), "result", None).await;
     }
 
     #[tokio::test]
@@ -2075,7 +2103,7 @@ mod tests {
             ..AgentHooks::default()
         };
 
-        let result = run_stop_hooks(&hooks, Uuid::new_v4()).await;
+        let result = run_stop_hooks(&hooks, Uuid::new_v4(), None).await;
         assert!(result.is_none(), "exit 0 stop hook must allow completion, got: {result:?}");
     }
 
@@ -2091,7 +2119,7 @@ mod tests {
             ..AgentHooks::default()
         };
 
-        let result = run_stop_hooks(&hooks, Uuid::new_v4()).await;
+        let result = run_stop_hooks(&hooks, Uuid::new_v4(), None).await;
         assert!(result.is_some(), "exit 1 stop hook must inject a message");
         let msg = result.unwrap();
         assert!(
@@ -2115,7 +2143,7 @@ mod tests {
             ..AgentHooks::default()
         };
 
-        let result = run_stop_hooks(&hooks, Uuid::new_v4()).await;
+        let result = run_stop_hooks(&hooks, Uuid::new_v4(), None).await;
         assert!(
             result.is_none(),
             "exit 127 (command not found) must fail open and allow completion, got: {result:?}"
@@ -2123,9 +2151,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_stop_hook_runs_in_session_cwd() {
+        use agents::{AgentHooks, HookEntry};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Write a marker in the temp dir; the hook echoes pwd and exits 1 to surface the cwd.
+        std::fs::write(tmp.path().join("marker.txt"), "present").unwrap();
+
+        let hooks = AgentHooks {
+            stop: vec![HookEntry {
+                matcher: None,
+                hooks: vec![hook_cmd("echo $(pwd); exit 1", 5)],
+            }],
+            ..AgentHooks::default()
+        };
+
+        let result = run_stop_hooks(&hooks, Uuid::new_v4(), Some(tmp.path())).await;
+        assert!(result.is_some(), "hook must inject a message when running with a cwd");
+        let msg = result.unwrap();
+        let canonical = std::fs::canonicalize(tmp.path()).unwrap();
+        assert!(
+            msg.trim().ends_with(canonical.to_str().unwrap()),
+            "hook must run in the session cwd; expected suffix {:?}, got: {msg:?}",
+            canonical.to_str().unwrap()
+        );
+    }
+
+    #[tokio::test]
     async fn test_hook_timeout_kills_command_and_returns_exit_1() {
         let cmd = hook_cmd("sleep 5", 1);
-        let (exit_code, _stdout, stderr) = run_hook(&cmd, "{}").await;
+        let (exit_code, _stdout, stderr) = run_hook(&cmd, "{}", None).await;
         assert_eq!(exit_code, 1, "timed-out hook must return exit_code=1");
         assert!(
             stderr.contains("timed out"),
@@ -2173,6 +2228,7 @@ mod tests {
             model: "test".into(),
             tools: vec![Arc::new(AlwaysOkTool)],
             git_root: None,
+            cwd: None,
         };
         let client: Arc<dyn AnthropicClient> = Arc::new(ToolUseClient::new());
         let db: Arc<dyn db::Db> = Arc::new(mock_db);
@@ -2227,6 +2283,7 @@ mod tests {
             model: "test".into(),
             tools: vec![Arc::new(AlwaysOkTool)],
             git_root: None,
+            cwd: None,
         };
         let client: Arc<dyn AnthropicClient> = Arc::new(ToolUseClient::new());
         let db: Arc<dyn db::Db> = Arc::new(mock_db);
@@ -2284,6 +2341,7 @@ mod tests {
             model: "test".into(),
             tools: vec![Arc::new(AlwaysOkTool)],
             git_root: None,
+            cwd: None,
         };
         let client: Arc<dyn AnthropicClient> = Arc::new(ToolUseClient::new());
         let db: Arc<dyn db::Db> = Arc::new(mock_db);
@@ -2324,6 +2382,7 @@ mod tests {
             model: "test".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client: Arc<dyn AnthropicClient> = Arc::new(StubClient);
         let mock_db = permissive_mock_db();
@@ -2359,6 +2418,7 @@ mod tests {
             model: "test".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client: Arc<dyn AnthropicClient> = Arc::new(StubClient);
         let mock_db = permissive_mock_db();
@@ -2421,6 +2481,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         // 5 failures then success — exactly at the retry limit
         let client = Arc::new(RateLimitThenOkClient::new(5));
@@ -2462,6 +2523,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         // 6 failures → exceeds max 5 retries
         let client = Arc::new(RateLimitThenOkClient::new(6));
@@ -2504,6 +2566,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         let client = Arc::new(AlwaysServerErrorClient);
         let db = Arc::new(mock_db);
@@ -2541,6 +2604,7 @@ mod tests {
             model: "claude-opus-4-5".into(),
             tools: vec![],
             git_root: None,
+            cwd: None,
         };
         // 3 failures → exceeds override max of 2
         let client = Arc::new(RateLimitThenOkClient::new(3));
@@ -2612,6 +2676,7 @@ mod tests {
             model: "test".into(),
             tools: vec![Arc::new(AlwaysOkTool)],
             git_root: Some(tmp.path().to_path_buf()),
+            cwd: None,
         };
         let client = Arc::new(ToolUseClient::new());
         let db = Arc::new(mock_db);
@@ -2675,6 +2740,7 @@ mod tests {
             model: "test".into(),
             tools: vec![Arc::new(AlwaysOkTool)],
             git_root: Some(tmp.path().to_path_buf()),
+            cwd: None,
         };
         let client = Arc::new(ToolUseClient::new());
         let db = Arc::new(mock_db);

--- a/crates/harness/src/loop_.rs
+++ b/crates/harness/src/loop_.rs
@@ -12,6 +12,8 @@ use chrono::Utc;
 
 /// Run the tool dispatch loop for a single LLM turn sequence.
 /// `messages` should already contain the full history including the new user message.
+/// Hook subprocesses are started with `config.cwd` as their working directory so they
+/// operate on the session's worktree rather than the server's cwd.
 pub(crate) async fn run_tool_dispatch_loop(
     config: &HarnessConfig,
     client: &Arc<dyn anthropic::AnthropicClient>,
@@ -86,7 +88,7 @@ pub(crate) async fn run_tool_dispatch_loop(
             "tool_use" => { /* dispatch tools below */ }
             "end_turn" => {
                 // Run Stop hooks; if any exit non-zero, return their stdout as an injected message
-                if let Some(injected) = run_stop_hooks(hooks, config.session.id).await {
+                if let Some(injected) = run_stop_hooks(hooks, config.session.id, config.cwd.as_deref()).await {
                     return Ok(Some(injected));
                 }
                 break;
@@ -113,7 +115,7 @@ pub(crate) async fn run_tool_dispatch_loop(
             if let ContentBlock::ToolUse { id, name, input } = block {
                 // Run PreToolUse hooks
                 let result = if let Some(blocked) =
-                    run_pre_tool_use_hooks(hooks, name, input).await
+                    run_pre_tool_use_hooks(hooks, name, input, config.cwd.as_deref()).await
                 {
                     // Hook blocked the tool — return hook stderr as the tool result
                     blocked
@@ -127,7 +129,7 @@ pub(crate) async fn run_tool_dispatch_loop(
                         None => format!("Error: unknown tool '{name}'"),
                     };
                     // Run PostToolUse hooks (exit code ignored)
-                    run_post_tool_use_hooks(hooks, name, input, &tool_output).await;
+                    run_post_tool_use_hooks(hooks, name, input, &tool_output, config.cwd.as_deref()).await;
                     tool_output
                 };
                 tool_result_blocks.push(ContentBlock::ToolResult {
@@ -181,6 +183,7 @@ pub async fn run(
 
     // If we resolved a cwd, rebuild the standard tool set with that cwd so all
     // file operations and shell commands run relative to the worktree.
+    // Also store it on config so hooks are spawned with the same working directory.
     if let Some(ref cwd) = session_cwd {
         config.tools = vec![
             Arc::new(tools::BashTool { cwd: Some(cwd.clone()) }),
@@ -188,6 +191,7 @@ pub async fn run(
             Arc::new(tools::WriteTool { cwd: Some(cwd.clone()) }),
             Arc::new(tools::EditTool { cwd: Some(cwd.clone()) }),
         ];
+        config.cwd = Some(cwd.clone());
     }
 
     // Resolve the effective git root (injected in tests; discovered via git in production).

--- a/crates/server/src/harness_spawn.rs
+++ b/crates/server/src/harness_spawn.rs
@@ -33,6 +33,7 @@ pub(crate) fn spawn_harness_sync(
         model,
         tools,
         git_root: None,
+        cwd: None,
     };
 
     let session_id = session_clone.id;


### PR DESCRIPTION
- Create .claude/hooks/stop-commit-push.sh: blocks session completion if
  there are uncommitted/untracked changes or unpushed commits. Works for
  both Claude Code (CLAUDE_PROJECT_DIR) and ns2 sessions (process cwd).

- Register the Stop hook in .claude/settings.json so it fires for Claude
  Code sessions and for ns2 agents with include_project_config: true.

- Add HarnessConfig.cwd field and thread the session worktree path through
  run_tool_dispatch_loop → run_stop/pre/post_tool_use_hooks → run_hook, so
  ns2 hooks spawn with the correct working directory (their worktree, not
  the server's cwd). This fixes all hook types, confirming the constraint
  raised in the issue holds for every ns2 hook.

- Tests: commit_guard_exits_nonzero_on_unpushed_commits (new), and
  test_stop_hook_runs_in_session_cwd (new harness unit test).

https://claude.ai/code/session_01WWAWZUoqTomcJWyjQQbuCh