### PR TITLE
Move cwd from tool construction to execute() call site

### DIFF
--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -629,7 +629,7 @@ mod tests {
             }
         }
 
-        async fn execute(&self, _input: serde_json::Value) -> tools::Result<String> {
+        async fn execute(&self, _input: serde_json::Value, _cwd: Option<&std::path::Path>) -> tools::Result<String> {
             Ok("file content here".into())
         }
     }
@@ -647,7 +647,7 @@ mod tests {
             }
         }
 
-        async fn execute(&self, _input: serde_json::Value) -> tools::Result<String> {
+        async fn execute(&self, _input: serde_json::Value, _cwd: Option<&std::path::Path>) -> tools::Result<String> {
             Err(tools::Error::InvalidInput("cannot read file".into()))
         }
     }

--- a/crates/harness/src/loop_.rs
+++ b/crates/harness/src/loop_.rs
@@ -122,7 +122,7 @@ pub(crate) async fn run_tool_dispatch_loop(
                 } else {
                     // Run the actual tool
                     let tool_output = match config.tools.iter().find(|t| t.definition().name == *name) {
-                        Some(tool) => match tool.execute(input.clone()).await {
+                        Some(tool) => match tool.execute(input.clone(), config.cwd.as_deref()).await {
                             Ok(output) => output,
                             Err(e) => format!("Error: {e}"),
                         },
@@ -181,17 +181,10 @@ pub async fn run(
     // a git worktree and set cwd to the worktree path.
     let session_cwd = resolve_session_cwd(&db, config.session.id).await;
 
-    // If we resolved a cwd, rebuild the standard tool set with that cwd so all
-    // file operations and shell commands run relative to the worktree.
-    // Also store it on config so hooks are spawned with the same working directory.
-    if let Some(ref cwd) = session_cwd {
-        config.tools = vec![
-            Arc::new(tools::BashTool { cwd: Some(cwd.clone()) }),
-            Arc::new(tools::ReadTool { cwd: Some(cwd.clone()) }),
-            Arc::new(tools::WriteTool { cwd: Some(cwd.clone()) }),
-            Arc::new(tools::EditTool { cwd: Some(cwd.clone()) }),
-        ];
-        config.cwd = Some(cwd.clone());
+    // If we resolved a cwd, store it on config so it is passed to tool dispatch
+    // and hook subprocesses at execution time.
+    if let Some(cwd) = session_cwd {
+        config.cwd = Some(cwd);
     }
 
     // Resolve the effective git root (injected in tests; discovered via git in production).

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -58,10 +58,10 @@ pub async fn run(config: ServerConfig) -> Result<()> {
         }
     };
     let tools: Vec<Arc<dyn tools::Tool>> = vec![
-        Arc::new(tools::ReadTool { cwd: None }),
-        Arc::new(tools::BashTool { cwd: None }),
-        Arc::new(tools::WriteTool { cwd: None }),
-        Arc::new(tools::EditTool { cwd: None }),
+        Arc::new(tools::ReadTool),
+        Arc::new(tools::BashTool),
+        Arc::new(tools::WriteTool),
+        Arc::new(tools::EditTool),
     ];
 
     let db_path = config.data_dir.join("ns2.db");

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -16,10 +16,6 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Resolve a path against an optional cwd.
-/// - If `cwd` is `Some` and `path` is relative, returns `cwd.join(path)`.
-/// - If `path` is absolute, returns it unchanged regardless of `cwd`.
-/// - If `cwd` is `None`, returns the path unchanged.
 fn resolve_path(cwd: Option<&Path>, path: &str) -> PathBuf {
     let p = Path::new(path);
     if p.is_absolute() {
@@ -34,12 +30,10 @@ fn resolve_path(cwd: Option<&Path>, path: &str) -> PathBuf {
 #[async_trait]
 pub trait Tool: Send + Sync {
     fn definition(&self) -> types::ToolDefinition;
-    async fn execute(&self, input: serde_json::Value) -> Result<String>;
+    async fn execute(&self, input: serde_json::Value, cwd: Option<&Path>) -> Result<String>;
 }
 
-pub struct ReadTool {
-    pub cwd: Option<PathBuf>,
-}
+pub struct ReadTool;
 
 #[async_trait]
 impl Tool for ReadTool {
@@ -60,21 +54,19 @@ impl Tool for ReadTool {
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String> {
+    async fn execute(&self, input: serde_json::Value, cwd: Option<&Path>) -> Result<String> {
         let path = input
             .get("path")
             .and_then(|v| v.as_str())
             .ok_or_else(|| Error::InvalidInput("missing required field: path".into()))?;
 
-        let resolved = resolve_path(self.cwd.as_deref(), path);
+        let resolved = resolve_path(cwd, path);
         let content = tokio::fs::read_to_string(&resolved).await?;
         Ok(content)
     }
 }
 
-pub struct BashTool {
-    pub cwd: Option<PathBuf>,
-}
+pub struct BashTool;
 
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
@@ -101,7 +93,7 @@ impl Tool for BashTool {
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String> {
+    async fn execute(&self, input: serde_json::Value, cwd: Option<&Path>) -> Result<String> {
         let command = input
             .get("command")
             .and_then(|v| v.as_str())
@@ -120,8 +112,8 @@ impl Tool for BashTool {
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
 
-        if let Some(ref cwd) = self.cwd {
-            cmd.current_dir(cwd);
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
         }
 
         let child = cmd.spawn().map_err(Error::Io)?;
@@ -150,9 +142,7 @@ impl Tool for BashTool {
     }
 }
 
-pub struct WriteTool {
-    pub cwd: Option<PathBuf>,
-}
+pub struct WriteTool;
 
 #[async_trait]
 impl Tool for WriteTool {
@@ -177,7 +167,7 @@ impl Tool for WriteTool {
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String> {
+    async fn execute(&self, input: serde_json::Value, cwd: Option<&Path>) -> Result<String> {
         let path = input
             .get("path")
             .and_then(|v| v.as_str())
@@ -188,7 +178,7 @@ impl Tool for WriteTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| Error::InvalidInput("missing required field: content".into()))?;
 
-        let resolved = resolve_path(self.cwd.as_deref(), path);
+        let resolved = resolve_path(cwd, path);
 
         if let Some(parent) = resolved.parent() {
             if !parent.as_os_str().is_empty() {
@@ -203,9 +193,7 @@ impl Tool for WriteTool {
     }
 }
 
-pub struct EditTool {
-    pub cwd: Option<PathBuf>,
-}
+pub struct EditTool;
 
 #[async_trait]
 impl Tool for EditTool {
@@ -238,7 +226,7 @@ impl Tool for EditTool {
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String> {
+    async fn execute(&self, input: serde_json::Value, cwd: Option<&Path>) -> Result<String> {
         let path = input
             .get("path")
             .and_then(|v| v.as_str())
@@ -259,7 +247,7 @@ impl Tool for EditTool {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let resolved = resolve_path(self.cwd.as_deref(), path);
+        let resolved = resolve_path(cwd, path);
         let resolved_str = resolved.to_string_lossy();
 
         let contents = tokio::fs::read_to_string(&resolved).await.map_err(|e| {
@@ -298,14 +286,11 @@ mod tests {
 
     #[tokio::test]
     async fn bash_tool_cwd_pwd_shows_given_directory() {
-        // BashTool with cwd set should run commands in that directory.
         let dir = tempfile::tempdir().expect("create temp dir");
-        let tool = BashTool { cwd: Some(dir.path().to_path_buf()) };
-        let result = tool
-            .execute(serde_json::json!({"command": "pwd"}))
+        let result = BashTool
+            .execute(serde_json::json!({"command": "pwd"}), Some(dir.path()))
             .await
             .expect("pwd should succeed");
-        // The real path is used to handle symlinks (e.g. /var vs /private/var on macOS).
         let real_dir = std::fs::canonicalize(dir.path()).unwrap();
         assert!(
             result.trim() == real_dir.to_str().unwrap()
@@ -317,10 +302,8 @@ mod tests {
 
     #[tokio::test]
     async fn bash_tool_no_cwd_inherits_process_cwd() {
-        // BashTool with cwd=None should inherit the process's current directory.
-        let tool = BashTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"command": "pwd"}))
+        let result = BashTool
+            .execute(serde_json::json!({"command": "pwd"}), None)
             .await
             .expect("pwd should succeed");
         assert!(!result.trim().is_empty(), "pwd must produce output");
@@ -328,14 +311,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_tool_relative_path_resolved_against_cwd() {
-        // ReadTool with cwd=Some(dir) should read <dir>/foo.txt when given "foo.txt".
         let dir = tempfile::tempdir().expect("create temp dir");
         let file_path = dir.path().join("foo.txt");
         tokio::fs::write(&file_path, "relative content").await.unwrap();
 
-        let tool = ReadTool { cwd: Some(dir.path().to_path_buf()) };
-        let result = tool
-            .execute(serde_json::json!({"path": "foo.txt"}))
+        let result = ReadTool
+            .execute(serde_json::json!({"path": "foo.txt"}), Some(dir.path()))
             .await
             .expect("read should succeed");
         assert_eq!(result, "relative content");
@@ -343,15 +324,13 @@ mod tests {
 
     #[tokio::test]
     async fn read_tool_absolute_path_unaffected_by_cwd() {
-        // ReadTool: an absolute path must bypass cwd entirely.
         let dir = tempfile::tempdir().expect("create temp dir");
         let abs_file = tempfile::NamedTempFile::new().unwrap();
         let abs_path = abs_file.path().to_str().unwrap().to_owned();
         tokio::fs::write(&abs_path, "absolute content").await.unwrap();
 
-        let tool = ReadTool { cwd: Some(dir.path().to_path_buf()) };
-        let result = tool
-            .execute(serde_json::json!({"path": abs_path}))
+        let result = ReadTool
+            .execute(serde_json::json!({"path": abs_path}), Some(dir.path()))
             .await
             .expect("read absolute path should succeed");
         assert_eq!(result, "absolute content");
@@ -359,10 +338,9 @@ mod tests {
 
     #[tokio::test]
     async fn write_tool_relative_path_resolved_against_cwd() {
-        // WriteTool with cwd=Some(dir) should write to <dir>/out.txt when given "out.txt".
         let dir = tempfile::tempdir().expect("create temp dir");
-        let tool = WriteTool { cwd: Some(dir.path().to_path_buf()) };
-        tool.execute(serde_json::json!({"path": "out.txt", "content": "hi"}))
+        WriteTool
+            .execute(serde_json::json!({"path": "out.txt", "content": "hi"}), Some(dir.path()))
             .await
             .expect("write should succeed");
 
@@ -372,37 +350,39 @@ mod tests {
 
     #[tokio::test]
     async fn write_tool_absolute_path_unaffected_by_cwd() {
-        // WriteTool: an absolute path must bypass cwd.
         let cwd_dir = tempfile::tempdir().expect("create temp dir");
         let abs_dir = tempfile::tempdir().expect("create abs temp dir");
         let abs_path = abs_dir.path().join("absolute.txt");
         let abs_path_str = abs_path.to_str().unwrap().to_owned();
 
-        let tool = WriteTool { cwd: Some(cwd_dir.path().to_path_buf()) };
-        tool.execute(serde_json::json!({"path": abs_path_str, "content": "abs content"}))
+        WriteTool
+            .execute(
+                serde_json::json!({"path": abs_path_str, "content": "abs content"}),
+                Some(cwd_dir.path()),
+            )
             .await
             .expect("write absolute path should succeed");
 
         let written = tokio::fs::read_to_string(&abs_path).await.unwrap();
         assert_eq!(written, "abs content");
-        // Verify the file was NOT written inside cwd_dir
         assert!(!cwd_dir.path().join("absolute.txt").exists());
     }
 
     #[tokio::test]
     async fn edit_tool_relative_path_resolved_against_cwd() {
-        // EditTool with cwd=Some(dir) should edit <dir>/edit.txt when given "edit.txt".
         let dir = tempfile::tempdir().expect("create temp dir");
         let file_path = dir.path().join("edit.txt");
         tokio::fs::write(&file_path, "hello world").await.unwrap();
 
-        let tool = EditTool { cwd: Some(dir.path().to_path_buf()) };
-        let result = tool
-            .execute(serde_json::json!({
-                "path": "edit.txt",
-                "old_string": "world",
-                "new_string": "rust"
-            }))
+        let result = EditTool
+            .execute(
+                serde_json::json!({
+                    "path": "edit.txt",
+                    "old_string": "world",
+                    "new_string": "rust"
+                }),
+                Some(dir.path()),
+            )
             .await
             .expect("edit should succeed");
         assert!(result.contains("1"), "should report 1 replacement");
@@ -413,20 +393,22 @@ mod tests {
 
     #[tokio::test]
     async fn edit_tool_absolute_path_unaffected_by_cwd() {
-        // EditTool: an absolute path must bypass cwd.
         let cwd_dir = tempfile::tempdir().expect("create temp dir");
         let abs_file = tempfile::NamedTempFile::new().unwrap();
         let abs_path = abs_file.path().to_str().unwrap().to_owned();
         tokio::fs::write(&abs_path, "foo bar").await.unwrap();
 
-        let tool = EditTool { cwd: Some(cwd_dir.path().to_path_buf()) };
-        tool.execute(serde_json::json!({
-            "path": abs_path,
-            "old_string": "foo",
-            "new_string": "baz"
-        }))
-        .await
-        .expect("edit absolute path should succeed");
+        EditTool
+            .execute(
+                serde_json::json!({
+                    "path": abs_path,
+                    "old_string": "foo",
+                    "new_string": "baz"
+                }),
+                Some(cwd_dir.path()),
+            )
+            .await
+            .expect("edit absolute path should succeed");
 
         let contents = tokio::fs::read_to_string(&abs_path).await.unwrap();
         assert_eq!(contents, "baz bar");
@@ -440,17 +422,15 @@ mod tests {
         write!(tmp, "hello from file").expect("write temp file");
         let path = tmp.path().to_str().unwrap().to_owned();
 
-        let tool = ReadTool { cwd: None };
-        let result = tool.execute(serde_json::json!({"path": path})).await;
+        let result = ReadTool.execute(serde_json::json!({"path": path}), None).await;
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
         assert_eq!(result.unwrap(), "hello from file");
     }
 
     #[tokio::test]
     async fn read_tool_file_not_found() {
-        let tool = ReadTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"path": "/nonexistent/path/that/does/not/exist.txt"}))
+        let result = ReadTool
+            .execute(serde_json::json!({"path": "/nonexistent/path/that/does/not/exist.txt"}), None)
             .await;
         assert!(result.is_err(), "expected Err for missing file");
         assert!(matches!(result.unwrap_err(), Error::Io(_)));
@@ -458,23 +438,19 @@ mod tests {
 
     #[tokio::test]
     async fn read_tool_missing_path_field() {
-        let tool = ReadTool { cwd: None };
-        let result = tool.execute(serde_json::json!({})).await;
+        let result = ReadTool.execute(serde_json::json!({}), None).await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::InvalidInput(_)));
     }
 
     #[test]
     fn read_tool_definition_has_correct_name() {
-        let tool = ReadTool { cwd: None };
-        let def = tool.definition();
-        assert_eq!(def.name, "read");
+        assert_eq!(ReadTool.definition().name, "read");
     }
 
     #[test]
     fn read_tool_definition_schema_has_path_property() {
-        let tool = ReadTool { cwd: None };
-        let def = tool.definition();
+        let def = ReadTool.definition();
         assert_eq!(def.input_schema["type"], "object");
         assert!(def.input_schema["properties"]["path"].is_object());
         let required = def.input_schema["required"].as_array().unwrap();
@@ -485,21 +461,17 @@ mod tests {
 
     #[tokio::test]
     async fn bash_tool_happy_path() {
-        let tool = BashTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"command": "echo hello"}))
+        let result = BashTool
+            .execute(serde_json::json!({"command": "echo hello"}), None)
             .await;
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
-        // stderr is empty, so output should be plain stdout with no labels
         assert_eq!(result.unwrap(), "hello\n");
     }
 
     #[tokio::test]
     async fn bash_tool_stderr_labeled_in_output() {
-        let tool = BashTool { cwd: None };
-        // Write to both stdout and stderr
-        let result = tool
-            .execute(serde_json::json!({"command": "echo out; echo err >&2"}))
+        let result = BashTool
+            .execute(serde_json::json!({"command": "echo out; echo err >&2"}), None)
             .await;
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
         let output = result.unwrap();
@@ -511,9 +483,8 @@ mod tests {
 
     #[tokio::test]
     async fn bash_tool_nonzero_exit_returns_exit_error() {
-        let tool = BashTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"command": "exit 1"}))
+        let result = BashTool
+            .execute(serde_json::json!({"command": "exit 1"}), None)
             .await;
         assert!(result.is_err(), "expected Err for non-zero exit");
         assert!(
@@ -524,9 +495,8 @@ mod tests {
 
     #[tokio::test]
     async fn bash_tool_timeout_returns_timeout_error() {
-        let tool = BashTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"command": "sleep 60", "timeout_ms": 100}))
+        let result = BashTool
+            .execute(serde_json::json!({"command": "sleep 60", "timeout_ms": 100}), None)
             .await;
         assert!(result.is_err(), "expected Err for timeout");
         assert!(
@@ -537,17 +507,15 @@ mod tests {
 
     #[tokio::test]
     async fn bash_tool_missing_command_field() {
-        let tool = BashTool { cwd: None };
-        let result = tool.execute(serde_json::json!({})).await;
+        let result = BashTool.execute(serde_json::json!({}), None).await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::InvalidInput(_)));
     }
 
     #[tokio::test]
     async fn bash_tool_signal_killed_returns_exit_error_minus_one() {
-        let tool = BashTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"command": "kill -9 $$"}))
+        let result = BashTool
+            .execute(serde_json::json!({"command": "kill -9 $$"}), None)
             .await;
         assert!(
             matches!(result, Err(Error::ExitError { code: -1, .. })),
@@ -558,9 +526,7 @@ mod tests {
 
     #[test]
     fn bash_tool_definition_has_correct_name() {
-        let tool = BashTool { cwd: None };
-        let def = tool.definition();
-        assert_eq!(def.name, "bash");
+        assert_eq!(BashTool.definition().name, "bash");
     }
 
     // --- WriteTool tests ---
@@ -571,9 +537,8 @@ mod tests {
         let path = dir.path().join("out.txt");
         let path_str = path.to_str().unwrap().to_owned();
 
-        let tool = WriteTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"path": path_str, "content": "hello write"}))
+        let result = WriteTool
+            .execute(serde_json::json!({"path": path_str, "content": "hello write"}), None)
             .await;
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
 
@@ -587,9 +552,8 @@ mod tests {
         let path = dir.path().join("subdir").join("nested").join("out.txt");
         let path_str = path.to_str().unwrap().to_owned();
 
-        let tool = WriteTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"path": path_str, "content": "nested content"}))
+        let result = WriteTool
+            .execute(serde_json::json!({"path": path_str, "content": "nested content"}), None)
             .await;
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
 
@@ -599,9 +563,8 @@ mod tests {
 
     #[tokio::test]
     async fn write_tool_missing_path_field() {
-        let tool = WriteTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"content": "some content"}))
+        let result = WriteTool
+            .execute(serde_json::json!({"content": "some content"}), None)
             .await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::InvalidInput(_)));
@@ -609,9 +572,8 @@ mod tests {
 
     #[tokio::test]
     async fn write_tool_missing_content_field() {
-        let tool = WriteTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({"path": "/tmp/test.txt"}))
+        let result = WriteTool
+            .execute(serde_json::json!({"path": "/tmp/test.txt"}), None)
             .await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::InvalidInput(_)));
@@ -619,9 +581,7 @@ mod tests {
 
     #[test]
     fn write_tool_definition_has_correct_name() {
-        let tool = WriteTool { cwd: None };
-        let def = tool.definition();
-        assert_eq!(def.name, "write");
+        assert_eq!(WriteTool.definition().name, "write");
     }
 
     // --- EditTool tests ---
@@ -632,13 +592,15 @@ mod tests {
         write!(tmp, "hello world").expect("write temp file");
         let path = tmp.path().to_str().unwrap().to_owned();
 
-        let tool = EditTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({
-                "path": path,
-                "old_string": "world",
-                "new_string": "rust"
-            }))
+        let result = EditTool
+            .execute(
+                serde_json::json!({
+                    "path": path,
+                    "old_string": "world",
+                    "new_string": "rust"
+                }),
+                None,
+            )
             .await;
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
 
@@ -652,13 +614,15 @@ mod tests {
         write!(tmp, "hello world").expect("write temp file");
         let path = tmp.path().to_str().unwrap().to_owned();
 
-        let tool = EditTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({
-                "path": path,
-                "old_string": "nonexistent",
-                "new_string": "replacement"
-            }))
+        let result = EditTool
+            .execute(
+                serde_json::json!({
+                    "path": path,
+                    "old_string": "nonexistent",
+                    "new_string": "replacement"
+                }),
+                None,
+            )
             .await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::InvalidInput(_)));
@@ -666,13 +630,15 @@ mod tests {
 
     #[tokio::test]
     async fn edit_tool_file_not_found() {
-        let tool = EditTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({
-                "path": "/nonexistent/path/that/does/not/exist.txt",
-                "old_string": "foo",
-                "new_string": "bar"
-            }))
+        let result = EditTool
+            .execute(
+                serde_json::json!({
+                    "path": "/nonexistent/path/that/does/not/exist.txt",
+                    "old_string": "foo",
+                    "new_string": "bar"
+                }),
+                None,
+            )
             .await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::InvalidInput(_)));
@@ -684,14 +650,16 @@ mod tests {
         write!(tmp, "foo foo foo").expect("write temp file");
         let path = tmp.path().to_str().unwrap().to_owned();
 
-        let tool = EditTool { cwd: None };
-        let result = tool
-            .execute(serde_json::json!({
-                "path": path,
-                "old_string": "foo",
-                "new_string": "bar",
-                "replace_all": true
-            }))
+        let result = EditTool
+            .execute(
+                serde_json::json!({
+                    "path": path,
+                    "old_string": "foo",
+                    "new_string": "bar",
+                    "replace_all": true
+                }),
+                None,
+            )
             .await;
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
 
@@ -701,8 +669,6 @@ mod tests {
 
     #[test]
     fn edit_tool_definition_has_correct_name() {
-        let tool = EditTool { cwd: None };
-        let def = tool.definition();
-        assert_eq!(def.name, "edit");
+        assert_eq!(EditTool.definition().name, "edit");
     }
 }


### PR DESCRIPTION
Tool structs (BashTool, ReadTool, WriteTool, EditTool) no longer carry a
cwd field. Instead, cwd is passed as Option<&Path> to execute() at
dispatch time, matching how hooks already receive cwd. This eliminates
the awkward pattern in harness::run() that discarded and rebuilt all tool
instances just to inject a resolved worktree path.

https://claude.ai/code/session_01YSNfbs5MbsRUmgbdkpv55Q