### PR TITLE
GH#92 Step 8: ns2 issue watch and subscribe commands

### DIFF
--- a/crates/cli/src/commands/issue.rs
+++ b/crates/cli/src/commands/issue.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use serde_json::json;
 use types::{Issue, IssueStatus};
+use events::SystemEvent;
 use crate::client::{handle_connection_error, print_error_response};
-use crate::render::{format_issue_show, print_issue_row, render_issue_tree, IssueTreeNode};
+use crate::render::{format_issue_show, format_issue_event, print_issue_row, render_issue_tree, IssueTreeNode};
 
 pub(crate) fn issue_is_terminal(status: &IssueStatus) -> bool {
     matches!(status, IssueStatus::Completed | IssueStatus::Failed | IssueStatus::Cancelled)
@@ -507,6 +508,130 @@ pub(crate) async fn run_wait(server: &str, ids: Vec<String>, timeout: Option<u64
         eprintln!("One or more issues failed.");
         std::process::exit(1);
     }
+}
+
+/// `ns2 issue watch --id X`
+///
+/// Connects to `GET /events?issue_id=<id>` as an SSE stream and renders each
+/// `IssueEvent` to stdout, one line per event.  Exits on Ctrl-C (SIGINT) or
+/// when the server closes the stream.
+pub(crate) async fn run_watch(server: &str, id: String) {
+    use futures::StreamExt;
+    use std::io::Write;
+
+    let url = format!("{}/events?issue_id={}", server, id);
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(0)) // no timeout — long-lived SSE stream
+        .build()
+        .unwrap_or_default();
+
+    let resp = client.get(&url).send().await.unwrap_or_else(|e| {
+        handle_connection_error(&e);
+    });
+    if !resp.status().is_success() {
+        print_error_response(resp).await;
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut buf = String::new();
+
+    // Install a simple Ctrl-C handler so the process exits cleanly.
+    let running = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let running_clone = running.clone();
+    // Best-effort SIGINT handler — drop the JoinHandle intentionally (fire-and-forget).
+    let _ctrl_c = tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        running_clone.store(false, std::sync::atomic::Ordering::SeqCst);
+    });
+
+    let stdout = std::io::stdout();
+
+    while running.load(std::sync::atomic::Ordering::SeqCst) {
+        match stream.next().await {
+            None => break, // server closed the stream
+            Some(Err(_)) => break,
+            Some(Ok(bytes)) => {
+                let chunk = String::from_utf8_lossy(&bytes).to_string();
+                let frames = crate::render::parse_sse_frames(&mut buf, &chunk);
+                for frame in frames {
+                    // Each SSE frame is one or more "field: value" lines.
+                    // We look for the `data:` line.
+                    for line in frame.lines() {
+                        let data = if let Some(rest) = line.strip_prefix("data: ") {
+                            rest
+                        } else {
+                            continue;
+                        };
+
+                        // Parse as SystemEvent, then extract IssueEvent.
+                        let Ok(ev) = serde_json::from_str::<SystemEvent>(data) else {
+                            continue;
+                        };
+                        if let SystemEvent::Issue(issue_event) = ev {
+                            let line = format_issue_event(&issue_event);
+                            let mut out = stdout.lock();
+                            writeln!(out, "{line}").ok();
+                            out.flush().ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `ns2 issue subscribe --id X --deliver-to issue:<id>|session:<id>`
+///
+/// Sugar for creating an internal hook that delivers a notification comment
+/// whenever issue X has a status change or a comment added.
+pub(crate) async fn run_subscribe(server: &str, id: String, deliver_to: String) {
+    let client = reqwest::Client::new();
+    let url = format!("{}/hooks", server);
+
+    // Parse "issue:<id>" or "session:<id>"
+    let (target_type, target_id) = if let Some(rest) = deliver_to.strip_prefix("issue:") {
+        ("issue", rest.to_string())
+    } else if let Some(rest) = deliver_to.strip_prefix("session:") {
+        ("session", rest.to_string())
+    } else {
+        eprintln!("Error: --deliver-to must be 'issue:<id>' or 'session:<id>', got: {deliver_to}");
+        std::process::exit(1);
+    };
+
+    let hook_name = format!("subscribe-{id}");
+    let body_template = "Issue {{ event.data.issue.id }}: {{ event.data.to }}".to_string();
+
+    let req_body = json!({
+        "name": hook_name,
+        "source": {
+            "type": "internal",
+            "event_types": ["issue.status_changed", "issue.comment_added"],
+        },
+        "filter": {
+            "conditions": [
+                { "field": "data.issue.id", "op": "eq", "value": id }
+            ]
+        },
+        "action": {
+            "type": "send_message",
+            "target": { "type": target_type, "content": target_id },
+            "body": body_template,
+        },
+    });
+
+    let resp = client.post(&url).json(&req_body).send().await.unwrap_or_else(|e| {
+        handle_connection_error(&e);
+    });
+    if !resp.status().is_success() {
+        print_error_response(resp).await;
+    }
+    let hook: serde_json::Value = resp.json().await.unwrap_or_else(|e| {
+        eprintln!("Error parsing response: {e}");
+        std::process::exit(1);
+    });
+    let hook_id = hook["id"].as_str().unwrap_or("?");
+    eprintln!("Created hook: {} ({})", hook["name"].as_str().unwrap_or(""), hook_id);
+    println!("{hook_id}");
 }
 
 #[cfg(test)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -332,6 +332,18 @@ enum IssueAction {
         #[arg(long, help = "Output as JSON instead of human-readable format.")]
         json: bool,
     },
+    #[command(about = "Stream live events for an issue to stdout.", long_about = "Connects to the server's SSE event stream filtered to issue <id> and prints each event as it arrives.\n\nOutput format (one line per event):\n  [created]        open  – <title>\n  [status_changed] open → running\n  [comment_added]  <author>: \"<body>\"\n\nExits on Ctrl-C or when the server closes the stream.")]
+    Watch {
+        #[arg(long, help = "The issue ID to watch. Required.")]
+        id: String,
+    },
+    #[command(about = "Subscribe to issue events and deliver notifications.", long_about = "Creates an internal hook that posts a comment notification to <deliver-to> whenever issue <id> has a status change or a new comment.\n\nThis is sugar for `ns2 hook new` with:\n  --source internal\n  --event-type issue.status_changed\n  --event-type issue.comment_added\n  --filter-field data.issue.id=<id>\n  --action send-message\n\nPrints the created hook ID to stdout.")]
+    Subscribe {
+        #[arg(long, help = "The issue ID to subscribe to. Required.")]
+        id: String,
+        #[arg(long = "deliver-to", help = "Notification target in the form 'issue:<id>' or 'session:<id>'. Required.")]
+        deliver_to: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -459,6 +471,12 @@ async fn main() {
             }
             IssueAction::Cancel { id } => {
                 commands::issue::run_cancel(&cli.server, id).await;
+            }
+            IssueAction::Watch { id } => {
+                commands::issue::run_watch(&cli.server, id).await;
+            }
+            IssueAction::Subscribe { id, deliver_to } => {
+                commands::issue::run_subscribe(&cli.server, id, deliver_to).await;
             }
         },
         Command::Hook { action } => match action {
@@ -2130,5 +2148,69 @@ mod tests {
             }
             _ => panic!("expected hook logs command"),
         }
+    }
+
+    // ─── `ns2 issue watch` CLI parse tests ───────────────────────────────────
+
+    #[test]
+    fn issue_watch_parses_id_flag() {
+        let cli = Cli::try_parse_from(["ns2", "issue", "watch", "--id", "ab12"]).unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Watch { id } } => {
+                assert_eq!(id, "ab12");
+            }
+            _ => panic!("expected issue watch command"),
+        }
+    }
+
+    #[test]
+    fn issue_watch_missing_id_fails_to_parse() {
+        let result = Cli::try_parse_from(["ns2", "issue", "watch"]);
+        assert!(result.is_err(), "watch without --id should fail to parse");
+    }
+
+    // ─── `ns2 issue subscribe` CLI parse tests ────────────────────────────────
+
+    #[test]
+    fn issue_subscribe_parses_id_and_deliver_to_issue() {
+        let cli = Cli::try_parse_from([
+            "ns2", "issue", "subscribe", "--id", "ab12", "--deliver-to", "issue:watcher1",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Subscribe { id, deliver_to } } => {
+                assert_eq!(id, "ab12");
+                assert_eq!(deliver_to, "issue:watcher1");
+            }
+            _ => panic!("expected issue subscribe command"),
+        }
+    }
+
+    #[test]
+    fn issue_subscribe_parses_deliver_to_session() {
+        let cli = Cli::try_parse_from([
+            "ns2", "issue", "subscribe",
+            "--id", "ab12",
+            "--deliver-to", "session:550e8400-e29b-41d4-a716-446655440000",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Issue { action: IssueAction::Subscribe { deliver_to, .. } } => {
+                assert_eq!(deliver_to, "session:550e8400-e29b-41d4-a716-446655440000");
+            }
+            _ => panic!("expected issue subscribe command"),
+        }
+    }
+
+    #[test]
+    fn issue_subscribe_missing_id_fails_to_parse() {
+        let result = Cli::try_parse_from(["ns2", "issue", "subscribe", "--deliver-to", "issue:w1"]);
+        assert!(result.is_err(), "subscribe without --id should fail to parse");
+    }
+
+    #[test]
+    fn issue_subscribe_missing_deliver_to_fails_to_parse() {
+        let result = Cli::try_parse_from(["ns2", "issue", "subscribe", "--id", "ab12"]);
+        assert!(result.is_err(), "subscribe without --deliver-to should fail to parse");
     }
 }

--- a/crates/cli/src/render.rs
+++ b/crates/cli/src/render.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 use types::{Issue, SessionStatus, ContentBlock, IssueStatus};
-use events::SessionEvent;
+use events::{IssueEvent, SessionEvent};
 
 // ────────────────────────────────────────────────────────────────────────────
 // Spinner / animated progress helpers
@@ -143,6 +143,29 @@ pub(crate) fn print_session_event(event: &SessionEvent, to_stderr: bool) {
                     print!("{output}");
                 }
             }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Issue event rendering (for `ns2 issue watch`)
+
+/// Render a single `IssueEvent` to a human-readable one-liner.
+///
+/// Format:
+/// - `[created]        open  – <title>`
+/// - `[status_changed] <from> → <to>`
+/// - `[comment_added]  <author>: "<body>"`
+pub(crate) fn format_issue_event(event: &IssueEvent) -> String {
+    match event {
+        IssueEvent::Created(issue) => {
+            format!("[created]        {}  – {}", issue.status, issue.title)
+        }
+        IssueEvent::StatusChanged { from, to, .. } => {
+            format!("[status_changed] {} → {}", from, to)
+        }
+        IssueEvent::CommentAdded { comment, .. } => {
+            format!("[comment_added]  {}: \"{}\"", comment.author, comment.body)
         }
     }
 }
@@ -317,4 +340,82 @@ pub(crate) fn render_session_line(
         _ => String::new(),
     };
     format!("[{id_prefix}] {display_name}: {snippet_part}{sym} {label}")
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests for format_issue_event
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use events::{IssueEvent};
+    use types::{Issue, IssueStatus, IssueComment};
+
+    fn make_issue(id: &str, title: &str, status: IssueStatus) -> Issue {
+        Issue {
+            id: id.to_string(),
+            title: title.to_string(),
+            body: String::new(),
+            status,
+            branch: "main".into(),
+            assignee: None,
+            session_id: None,
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn format_issue_event_created_contains_created_tag_status_and_title() {
+        let issue = make_issue("ab12", "Add a greeting", IssueStatus::Open);
+        let line = format_issue_event(&IssueEvent::Created(issue));
+        assert!(line.contains("[created]"), "must contain [created] tag");
+        assert!(line.contains("open"), "must contain status");
+        assert!(line.contains("Add a greeting"), "must contain title");
+        assert!(line.contains('–'), "must contain em-dash separator");
+    }
+
+    #[test]
+    fn format_issue_event_status_changed_shows_arrow() {
+        let issue = make_issue("ab12", "Test", IssueStatus::Running);
+        let line = format_issue_event(&IssueEvent::StatusChanged {
+            issue,
+            from: IssueStatus::Open,
+            to: IssueStatus::Running,
+        });
+        assert!(line.contains("[status_changed]"), "must contain [status_changed] tag");
+        assert!(line.contains("open"), "must contain 'from' status");
+        assert!(line.contains("running"), "must contain 'to' status");
+        assert!(line.contains('→'), "must contain arrow");
+    }
+
+    #[test]
+    fn format_issue_event_status_changed_running_to_completed() {
+        let issue = make_issue("ab12", "Test", IssueStatus::Completed);
+        let line = format_issue_event(&IssueEvent::StatusChanged {
+            issue,
+            from: IssueStatus::Running,
+            to: IssueStatus::Completed,
+        });
+        assert!(line.contains("running → completed"), "should show running → completed");
+    }
+
+    #[test]
+    fn format_issue_event_comment_added_shows_author_and_body() {
+        let issue = make_issue("ab12", "Test", IssueStatus::Running);
+        let comment = IssueComment {
+            author: "swe".into(),
+            body: "Agent completed the task and created hello.txt.".into(),
+            created_at: Utc::now(),
+        };
+        let line = format_issue_event(&IssueEvent::CommentAdded { issue, comment });
+        assert!(line.contains("[comment_added]"), "must contain [comment_added] tag");
+        assert!(line.contains("swe"), "must contain author");
+        assert!(line.contains("Agent completed the task"), "must contain comment body");
+        assert!(line.contains('"'), "comment body must be quoted");
+    }
 }

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -66,7 +66,11 @@ pub struct HarnessConfig {
 mod tests {
     use super::*;
     use mockall::mock;
+    use std::sync::Mutex;
     use tokio::sync::{broadcast, mpsc};
+
+    // Serialize tests that mutate NS2_MAX_RETRIES to prevent races.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     mock! {
         pub TestDb {}
@@ -2480,6 +2484,7 @@ mod tests {
     /// test does not actually wait 10 s per retry.
     #[tokio::test(start_paused = true)]
     async fn test_429_retried_up_to_5_times_then_succeeds() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let session = make_session();
         let mock_db = permissive_mock_db();
 
@@ -2596,11 +2601,7 @@ mod tests {
     /// inside the retry loop so the env value is sampled at test time.
     #[tokio::test(start_paused = true)]
     async fn test_ns2_max_retries_env_override() {
-        // SAFETY: This test mutates a process-global env var.  We set it immediately
-        // before the call and restore it in a guard.  Parallel test execution might
-        // race this, but `start_paused = true` keeps execution single-threaded within
-        // the tokio runtime so the set→run→restore happens atomically from the
-        // scheduler's perspective.
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("NS2_MAX_RETRIES", "2");
 
         let session = make_session();

--- a/crates/server/src/routes/events_route.rs
+++ b/crates/server/src/routes/events_route.rs
@@ -352,4 +352,66 @@ mod tests {
         assert_eq!(received.len(), 1, "only 1 session event should pass");
         assert!(matches!(received[0], SystemEvent::Session { .. }));
     }
+
+    // ── issue_id filter: only emits events for the matching issue ─────────────
+
+    #[tokio::test]
+    async fn issue_id_filter_only_passes_matching_issue_events() {
+        let bus = EventBus::new(32);
+        let mut rx = bus.subscribe();
+
+        let target_id = "ab12";
+        let other_id = "cd34";
+
+        // Emit events for two different issues
+        bus.send(SystemEvent::Issue(IssueEvent::Created(make_issue(target_id))));
+        bus.send(SystemEvent::Issue(IssueEvent::StatusChanged {
+            issue: make_issue(other_id),
+            from: IssueStatus::Open,
+            to: IssueStatus::Running,
+        }));
+        bus.send(SystemEvent::Issue(IssueEvent::StatusChanged {
+            issue: make_issue(target_id),
+            from: IssueStatus::Open,
+            to: IssueStatus::Running,
+        }));
+        // Also emit a session event (should be filtered out)
+        bus.send(SystemEvent::Session {
+            session_id: uuid::Uuid::new_v4(),
+            event: events::SessionEvent::Done,
+        });
+
+        let q = EventsQuery {
+            session_id: None,
+            issue_id: Some(target_id.to_string()),
+            types: None,
+            last_turns: None,
+        };
+
+        let mut received = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            if q.matches(&ev) {
+                received.push(ev);
+            }
+        }
+
+        assert_eq!(
+            received.len(),
+            2,
+            "only events for issue {target_id} should pass, got {received:?}"
+        );
+        for ev in &received {
+            match ev {
+                SystemEvent::Issue(ie) => {
+                    let issue_id = match ie {
+                        IssueEvent::Created(i) => &i.id,
+                        IssueEvent::StatusChanged { issue, .. } => &issue.id,
+                        IssueEvent::CommentAdded { issue, .. } => &issue.id,
+                    };
+                    assert_eq!(issue_id, target_id, "all received events must be for target issue");
+                }
+                _ => panic!("received non-issue event"),
+            }
+        }
+    }
 }

--- a/specs/architecture.spec.md
+++ b/specs/architecture.spec.md
@@ -2,7 +2,7 @@
 targets:
   - Cargo.toml
   - crates/*/Cargo.toml
-verified: 2026-04-29T17:14:15Z
+verified: 2026-05-05T19:31:44Z
 ---
 
 # Architecture Spec
@@ -28,11 +28,15 @@ graph TD
     agents --> workspace
     specs --> workspace
 
-    harness --> db & anthropic & tools & agents & workspace
+    events --> types
 
-    issues --> db
+    harness --> db & anthropic & tools & agents & workspace & events
 
-    server --> issues & db & anthropic & tools & harness
+    issues --> db & events
+
+    hooks --> events & db & issues & types
+
+    server --> issues & db & anthropic & tools & harness & events & hooks
 
     tui --> types
     cli --> agents & specs & workspace & server & types
@@ -40,9 +44,11 @@ graph TD
 
 Arrows point from dependent to dependency.
 
+> **Known violations (tracked):** `hooks` depends on `issues` and directly uses sqlx — both reach across layer boundaries. These are tracked in GH#97 and GH#98 and will be resolved in follow-up work.
+
 ## Crates
 
-**`types`** — shared domain types: `Session`, `Turn`, `ContentBlock`, `Issue`, SSE events, tool shapes. No behavior.
+**`types`** — shared domain types: `Session`, `Turn`, `ContentBlock`, `Issue`, tool shapes. No behavior.
 
 **`db`** — SQLite access via sqlx. Owns schema, migrations, and every query.
 _Doesn't own: SQL written anywhere else._
@@ -58,14 +64,18 @@ _Doesn't own: session or turn state._
 
 **`specs`** — reads/writes `.spec.md` files; staleness checking.
 
-**`harness`** — agent turn loop. Context window construction, system prompt loading, tool dispatch, worktree resolution. Emits events to a broadcast channel; one instance per active session.
+**`events`** — global event bus. Defines `SystemEvent` (the top-level envelope), `SessionEvent` (turn-level harness events), and `IssueEvent` (issue lifecycle events). `EventBus` is a cheaply-cloneable `tokio::broadcast` wrapper; `send` is fire-and-forget.
+
+**`harness`** — agent turn loop. Context window construction, system prompt loading, tool dispatch, worktree resolution. Publishes `SystemEvent::Session` events to the `EventBus`; one instance per active session.
 _Doesn't own: issue lifecycle or state transitions — that's `issues`. No HTTP._
 
-**`issues`** — pure issue domain service. Owns the state machine (open → running → completed/failed/cancelled), `start_issue`, `complete_issue`, `reopen_issue`, `orphan_sweep`. Exposes `IssueService` and `StartIssueOutcome`.
+**`issues`** — pure issue domain service. Owns the state machine (open → running → completed/failed/cancelled), `start_issue`, `complete_issue`, `reopen_issue`, `orphan_sweep`. Publishes `SystemEvent::Issue` events to the `EventBus`. Exposes `IssueService` and `StartIssueOutcome`.
 _Doesn't own: HTTP routing, harness spawning, or session maps — those belong in `server`._
-**Dependencies:** `types`, `db`.
 
-**`server`** — axum HTTP server. Routes, SSE fan-out, `ServerConfig`, session maps, harness spawning. Constructs the Anthropic client, standard tools, and `spawn_harness_sync`. Delegates issue lifecycle to `IssueService` but owns all harness lifecycle.
+**`hooks`** — hook types, filter evaluation, and action dispatch. Defines `Hook`, `HookSource` (internal/external/timer), `HookAction` (SendMessage/CreateIssue/RunShell), and `HookFilter` (field conditions). A hook evaluator subscribes to the `EventBus` and dispatches actions when filters match.
+_Known violations tracked in GH#97 (direct `issues` dep) and GH#98 (direct sqlx dep)._
+
+**`server`** — axum HTTP server. Routes, `ServerConfig`, session maps, harness spawning. Holds an `EventBus` in `AppState` shared by all routes and the hook evaluator. Exposes `GET /events` as an SSE endpoint that replays session history from DB then streams live `SystemEvent`s with optional `session_id`, `issue_id`, and `types` filters. Constructs the Anthropic client, standard tools, and `spawn_harness_sync`. Delegates issue lifecycle to `IssueService` but owns all harness lifecycle.
 _Doesn't own: issue business logic — delegate to `issues`._
 
 **`tui`** — ratatui terminal UI. Connects to the server via SSE. Thin client: all state comes from the server.


### PR DESCRIPTION
## Summary

- Adds `ns2 issue watch --id X`: streams live issue events from `GET /events?issue_id=X` and renders them to stdout in human-readable format
- Adds `ns2 issue subscribe --id X --deliver-to issue:<id>|session:<id>`: creates an internal hook that delivers notifications on issue status changes and comments
- Fixes a pre-existing race condition in harness tests where `NS2_MAX_RETRIES` env var mutation by `test_ns2_max_retries_env_override` could interfere with `test_429_retried_up_to_5_times_then_succeeds` running in parallel

## Output format for `ns2 issue watch`

```
[created]        open  – Add a greeting
[status_changed] open → running
[comment_added]  swe: "Agent completed the task and created hello.txt."
[status_changed] running → completed
```

## Test plan

- [ ] Unit tests for CLI parsing: `issue_watch_parses_id_flag`, `issue_subscribe_parses_id_and_deliver_to_issue`, `issue_subscribe_parses_deliver_to_session`
- [ ] Unit tests for event rendering: `format_issue_event_created_*`, `format_issue_event_status_changed_*`, `format_issue_event_comment_added_*`
- [ ] Integration: `ns2 issue watch --id X` streams events and exits on stream close
- [ ] Integration: `ns2 issue subscribe --id X --deliver-to issue:Y` creates hook visible in `ns2 hook list`

Closes #92 (step 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)