### PR TITLE
Improve stop hook and add agent guidance to CLAUDE.md

### DIFF
--- a/.claude/hooks/stop-commit-push.sh
+++ b/.claude/hooks/stop-commit-push.sh
@@ -10,7 +10,7 @@ GIT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # 1. Check for uncommitted / untracked changes.
 STATUS=$(git -C "$GIT_DIR" status --short 2>/dev/null)
 if [ -n "$STATUS" ]; then
-  echo "You have uncommitted changes. Please commit all your work before stopping." >&2
+  echo "You have uncommitted changes. Commit all changes AND push to the remote branch before stopping." >&2
   exit 2
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ cargo test
 cargo llvm-cov --summary-only
 ```
 
+## Finishing work
+
+Before stopping, always commit all changes and push to the remote branch. Do not create a PR unless explicitly asked, but always commit and push so that your work is not lost.
+
 ## Testing
 
 - Use red-green TDD for all development.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ cargo test
 cargo llvm-cov --summary-only
 ```
 
+## Subagents
+
+Break all non-trivial work into sequential subagents to preserve the context window. Always run subagents one at a time — do not use parallel or background agents, and do not use separate worktrees for subagents. The coordination cost is not worth it.
+
 ## Finishing work
 
 Before stopping, always commit all changes and push to the remote branch. Do not create a PR unless explicitly asked, but always commit and push so that your work is not lost.


### PR DESCRIPTION
## Summary
- Add "Subagents" section to CLAUDE.md: always use sequential subagents, no parallel/background agents or separate worktrees
- Add "Finishing work" section to CLAUDE.md: always commit and push before stopping
- Update stop hook uncommitted-changes error to say commit AND push, preventing agents from committing without pushing and re-triggering the hook

## Test plan
- [ ] Verify stop hook triggers correctly on uncommitted changes
- [ ] Verify stop hook triggers correctly on unpushed commits
- [ ] Verify stop hook passes when repo is clean and pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)