### PR TITLE
Remove issue start/restart, auto-start on in_progress status (GH#122)

### DIFF
--- a/.claude/skills/ns2/SKILL.md
+++ b/.claude/skills/ns2/SKILL.md
@@ -26,7 +26,7 @@ Work in ns2 is managed by creating issues. Every issue is given a dedicated agen
 ```bash
 # Create and immediately start
 id=$(ns2 issue new --title "..." --body "..." --assignee <agent>)
-ns2 issue start --id "$id"
+ns2 issue set-status --id "$id" --status in_progress
 ```
 
 ## Token-efficient monitoring
@@ -64,7 +64,8 @@ ns2 is alpha software, so you may have to debug its work occasionally. ONLY WHEN
 If an issue fails (e.g. rate limit cascade), reopen with context before restarting:
 
 ```bash
-ns2 issue reopen --id "$id" --comment "Restarting after rate limit. Previous approach was correct, pick up from where you left off." --start
+ns2 issue reopen --id "$id" --comment "Restarting after rate limit. Previous approach was correct, pick up from where you left off."
+ns2 issue set-status --id "$id" --status in_progress
 ```
 
 ## Sending Corrections Mid-Session

--- a/.ns2/agents/product-manager.md
+++ b/.ns2/agents/product-manager.md
@@ -35,5 +35,5 @@ Each swe issue must include:
 
 ```bash
 id=$(ns2 issue new --title "..." --body "..." --assignee <agent>)
-ns2 issue start --id "$id" && ns2 issue wait --id "$id"
+ns2 issue set-status --id "$id" --status in_progress && ns2 issue wait --id "$id"
 ```

--- a/crates/cli/src/commands/issue.rs
+++ b/crates/cli/src/commands/issue.rs
@@ -31,15 +31,10 @@ pub async fn run_new(
     assignee: Option<String>,
     parent: Option<String>,
     blocked_on: Vec<String>,
-    start: bool,
     branch: Option<String>,
 ) {
     let client = reqwest::Client::new();
 
-    if start && assignee.is_none() {
-        eprintln!("Error: --start requires --assignee (start needs an agent to run)");
-        std::process::exit(1);
-    }
     if let Some(ref a) = assignee {
         if let Some(dir) = agents::agents_dir() {
             if agents::load_agent(&dir, a).is_none() {
@@ -74,32 +69,6 @@ pub async fn run_new(
     });
     eprintln!("Created issue: {} ({})", issue.title, issue.id);
     println!("{}", issue.id);
-
-    if start {
-        let start_url = format!("{}/issues/{}/start", server, issue.id);
-        let start_resp = client.post(&start_url).send().await.unwrap_or_else(|e| {
-            handle_connection_error(&e);
-        });
-        if !start_resp.status().is_success() {
-            if start_resp.status() == reqwest::StatusCode::NOT_FOUND {
-                eprintln!("Error: issue not found: {}", issue.id);
-                std::process::exit(1);
-            }
-            print_error_response(start_resp).await;
-        }
-        let started: Issue = start_resp.json().await.unwrap_or_else(|e| {
-            eprintln!("Error parsing response: {e}");
-            std::process::exit(1);
-        });
-        eprintln!(
-            "Started issue {}. Session: {}",
-            started.id,
-            started
-                .session_id
-                .map(|id| id.to_string())
-                .unwrap_or_default()
-        );
-    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -190,32 +159,6 @@ pub async fn run_comment(server: &str, id: String, body: String, author: String)
     eprintln!("Comment added to issue {id}.");
 }
 
-pub async fn run_start(server: &str, id: String) {
-    let client = reqwest::Client::new();
-    let url = format!("{server}/issues/{id}/start");
-    let resp = client.post(&url).send().await.unwrap_or_else(|e| {
-        handle_connection_error(&e);
-    });
-    if !resp.status().is_success() {
-        if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            eprintln!("Error: issue not found: {id}");
-            std::process::exit(1);
-        }
-        print_error_response(resp).await;
-    }
-    let issue: Issue = resp.json().await.unwrap_or_else(|e| {
-        eprintln!("Error parsing response: {e}");
-        std::process::exit(1);
-    });
-    eprintln!(
-        "Started issue {id}. Session: {}",
-        issue
-            .session_id
-            .map(|id| id.to_string())
-            .unwrap_or_default()
-    );
-}
-
 pub async fn run_complete(server: &str, id: String, comment: String) {
     let client = reqwest::Client::new();
     let url = format!("{server}/issues/{id}/complete");
@@ -238,7 +181,7 @@ pub async fn run_complete(server: &str, id: String, comment: String) {
     eprintln!("Issue {id} marked as completed.");
 }
 
-pub async fn run_reopen(server: &str, id: String, comment: Option<String>, start: bool) {
+pub async fn run_reopen(server: &str, id: String, comment: Option<String>) {
     let client = reqwest::Client::new();
     let url = format!("{server}/issues/{id}/reopen");
     let req_body = json!({ "comment": comment });
@@ -258,31 +201,6 @@ pub async fn run_reopen(server: &str, id: String, comment: Option<String>, start
         print_error_response(resp).await;
     }
     eprintln!("Issue {id} reopened.");
-
-    if start {
-        let start_url = format!("{server}/issues/{id}/start");
-        let start_resp = client.post(&start_url).send().await.unwrap_or_else(|e| {
-            handle_connection_error(&e);
-        });
-        if !start_resp.status().is_success() {
-            if start_resp.status() == reqwest::StatusCode::NOT_FOUND {
-                eprintln!("Error: issue not found: {id}");
-                std::process::exit(1);
-            }
-            print_error_response(start_resp).await;
-        }
-        let started: Issue = start_resp.json().await.unwrap_or_else(|e| {
-            eprintln!("Error parsing response: {e}");
-            std::process::exit(1);
-        });
-        eprintln!(
-            "Started issue {id}. Session: {}",
-            started
-                .session_id
-                .map(|id| id.to_string())
-                .unwrap_or_default()
-        );
-    }
 }
 
 pub async fn run_list(
@@ -360,6 +278,36 @@ pub async fn run_show(server: &str, id: String, json: bool) {
     } else {
         print!("{}", format_issue_show(&issue));
     }
+}
+
+/// `ns2 issue set-status --id X --status S`
+///
+/// Calls `PATCH /issues/:id/status` with the given status.
+/// When status is `in_progress`, the server auto-starts the issue.
+pub async fn run_set_status(server: &str, id: String, status: String) {
+    let client = reqwest::Client::new();
+    let url = format!("{server}/issues/{id}/status");
+    let req_body = json!({ "status": status });
+    let resp = client
+        .patch(&url)
+        .json(&req_body)
+        .send()
+        .await
+        .unwrap_or_else(|e| {
+            handle_connection_error(&e);
+        });
+    if !resp.status().is_success() {
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            eprintln!("Error: issue not found: {id}");
+            std::process::exit(1);
+        }
+        print_error_response(resp).await;
+    }
+    let issue: Issue = resp.json().await.unwrap_or_else(|e| {
+        eprintln!("Error parsing response: {e}");
+        std::process::exit(1);
+    });
+    eprintln!("Issue {id} status set to {}.", issue.status);
 }
 
 pub async fn run_cancel(server: &str, id: String) {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,7 +8,7 @@ mod render;
 #[command(name = "ns2")]
 #[command(about = "An issue-driven agent orchestration tool.")]
 #[command(
-    long_about = "ns2 is an issue-driven agent orchestration tool.\n\nConcepts:\n  agent    a named system prompt stored in .ns2/agents/; defines how the model behaves\n  issue    a work item assigned to an agent; the primary way to get work done\n  session  internal implementation detail — created automatically when an issue starts\n\nTypical workflow:\n  ns2 server start\n  ns2 agent list\n  id=$(ns2 issue new --title \"...\" --body \"...\" --assignee swe)\n  ns2 issue start --id \"$id\"\n  ns2 issue wait --id \"$id\"\n  ns2 issue complete --id \"$id\" --comment \"Done\""
+    long_about = "ns2 is an issue-driven agent orchestration tool.\n\nConcepts:\n  agent    a named system prompt stored in .ns2/agents/; defines how the model behaves\n  issue    a work item assigned to an agent; the primary way to get work done\n  session  internal implementation detail — created automatically when an issue starts\n\nTypical workflow:\n  ns2 server start\n  ns2 agent list\n  id=$(ns2 issue new --title \"...\" --body \"...\" --assignee swe)\n  ns2 issue set-status --id \"$id\" --status in_progress\n  ns2 issue wait --id \"$id\"\n  ns2 issue complete --id \"$id\" --comment \"Done\""
 )]
 struct Cli {
     #[arg(
@@ -34,7 +34,7 @@ enum Command {
     },
     #[command(
         about = "Inspect agent sessions (implementation detail — use `issue` to get work done).",
-        long_about = "Sessions are the internal agent runs that power issues. You typically don't create sessions directly — use `ns2 issue start` instead, which creates a session automatically.\n\nUse session commands for inspection: tail output, list recent runs, or stop a runaway session.\n\nLifecycle:\n  created    session exists but no message sent yet; agent not started\n  running    agent is active and processing messages\n  completed  agent finished successfully\n  failed     agent ended with an error (check tail output for details)\n  cancelled  stopped manually via session stop"
+        long_about = "Sessions are the internal agent runs that power issues. You typically don't create sessions directly — use `ns2 issue set-status --status in_progress` instead, which creates a session automatically.\n\nUse session commands for inspection: tail output, list recent runs, or stop a runaway session.\n\nLifecycle:\n  created    session exists but no message sent yet; agent not started\n  running    agent is active and processing messages\n  completed  agent finished successfully\n  failed     agent ended with an error (check tail output for details)\n  cancelled  stopped manually via session stop"
     )]
     Session {
         #[command(subcommand)]
@@ -58,7 +58,7 @@ enum Command {
     },
     #[command(
         about = "Track and manage work items.",
-        long_about = "Issues are lightweight work items with a title, body, optional assignee agent, and status lifecycle.\n\nLifecycle:\n  open       issue created, not yet assigned to a session\n  running    an agent session is actively working on this issue\n  completed  work finished and reviewed\n  failed     session ended with an error\n\nTypical workflow:\n  id=$(ns2 issue new --title \"...\" --body \"...\" --assignee swe)\n  ns2 issue start --id \"$id\"\n  ns2 issue wait --id \"$id\"\n  ns2 issue complete --id \"$id\" --comment \"Done: ...\"\n\nUse `issue list` to see current issues; use `issue wait` to block until issues finish."
+        long_about = "Issues are lightweight work items with a title, body, optional assignee agent, and status lifecycle.\n\nLifecycle:\n  open       issue created, not yet assigned to a session\n  running    an agent session is actively working on this issue\n  completed  work finished and reviewed\n  failed     session ended with an error\n\nTypical workflow:\n  id=$(ns2 issue new --title \"...\" --body \"...\" --assignee swe)\n  ns2 issue set-status --id \"$id\" --status in_progress\n  ns2 issue wait --id \"$id\"\n  ns2 issue complete --id \"$id\" --comment \"Done: ...\"\n\nUse `issue list` to see current issues; use `issue wait` to block until issues finish."
     )]
     Issue {
         #[command(subcommand)]
@@ -397,11 +397,6 @@ enum IssueAction {
         blocked_on: Vec<String>,
         #[arg(
             long,
-            help = "Immediately start the issue after creating it. Requires --assignee."
-        )]
-        start: bool,
-        #[arg(
-            long,
             help = "Git branch name to associate with this issue. Auto-generated from title if omitted."
         )]
         branch: Option<String>,
@@ -426,7 +421,8 @@ enum IssueAction {
         #[arg(long, help = "New git branch name for this issue.")]
         branch: Option<String>,
     },
-    #[command(about = "Post a comment to an issue.")]
+    #[command(
+        about = "Post a comment to an issue.")]
     Comment {
         #[arg(long, help = "The issue ID. Required.")]
         id: String,
@@ -440,14 +436,6 @@ enum IssueAction {
         author: String,
     },
     #[command(
-        about = "Create an agent session for this issue and start it.",
-        long_about = "Creates a new session using the issue's assignee agent, sends the issue title and body as the opening message, and links the session to the issue. Sets the issue status to 'running'.\n\nPrints a confirmation to stderr including the session UUID:\n  Started issue <id>. Session: <uuid>\n\nCapture the session UUID for later tailing:\n  session=$(ns2 issue start --id \"$id\" 2>&1 | awk '/Session:/{print $NF}')"
-    )]
-    Start {
-        #[arg(long, help = "The issue ID. Required.")]
-        id: String,
-    },
-    #[command(
         about = "Mark an issue as completed.",
         long_about = "Marks an issue completed and adds a final summary comment. The --comment flag is required."
     )]
@@ -456,6 +444,16 @@ enum IssueAction {
         id: String,
         #[arg(long, help = "A final summary of what was done. Required.")]
         comment: String,
+    },
+    #[command(
+        about = "Set the status of an issue.",
+        long_about = "Update an issue's status directly. Use status 'in_progress' to auto-start the issue (spawns the agent harness).\n\nAvailable statuses: open, in_progress, running, completed, failed, cancelled, waiting\n\nTypical usage:\n  ns2 issue set-status --id \"$id\" --status in_progress\n\nSetting in_progress will:\n  - Create a new session and start the agent if the issue is open.\n  - Resume the existing session if the issue is waiting.\n  - Clear any failed session and create a fresh one if the issue is failed."
+    )]
+    SetStatus {
+        #[arg(long, help = "The issue ID. Required.")]
+        id: String,
+        #[arg(long, help = "The new status. Required.")]
+        status: String,
     },
     #[command(
         about = "Move a failed or completed issue back to open.",
@@ -469,8 +467,6 @@ enum IssueAction {
             help = "Append a comment to the issue thread before transitioning back to open. Author is 'user'."
         )]
         comment: Option<String>,
-        #[arg(long, help = "Immediately start the issue after reopening it.")]
-        start: bool,
     },
     #[command(
         about = "List issues.",
@@ -687,7 +683,6 @@ async fn main() {
                 assignee,
                 parent,
                 blocked_on,
-                start,
                 branch,
             } => {
                 commands::issue::run_new(
@@ -697,7 +692,6 @@ async fn main() {
                     assignee,
                     parent,
                     blocked_on,
-                    start,
                     branch,
                 )
                 .await;
@@ -726,14 +720,14 @@ async fn main() {
             IssueAction::Comment { id, body, author } => {
                 commands::issue::run_comment(&cli.server, id, body, author).await;
             }
-            IssueAction::Start { id } => {
-                commands::issue::run_start(&cli.server, id).await;
-            }
             IssueAction::Complete { id, comment } => {
                 commands::issue::run_complete(&cli.server, id, comment).await;
             }
-            IssueAction::Reopen { id, comment, start } => {
-                commands::issue::run_reopen(&cli.server, id, comment, start).await;
+            IssueAction::SetStatus { id, status } => {
+                commands::issue::run_set_status(&cli.server, id, status).await;
+            }
+            IssueAction::Reopen { id, comment } => {
+                commands::issue::run_reopen(&cli.server, id, comment).await;
             }
             IssueAction::List {
                 status,
@@ -1343,27 +1337,21 @@ mod tests {
     }
 
     #[test]
-    fn issue_reopen_parses_start_flag() {
-        let cli =
-            Cli::try_parse_from(["ns2", "issue", "reopen", "--id", "ab12", "--start"]).unwrap();
-        match cli.command {
-            Command::Issue {
-                action: IssueAction::Reopen { start, .. },
-            } => {
-                assert!(start);
-            }
-            _ => panic!("expected issue reopen command"),
-        }
+    fn issue_reopen_start_flag_removed_fails_to_parse() {
+        // --start flag has been removed from reopen
+        let result =
+            Cli::try_parse_from(["ns2", "issue", "reopen", "--id", "ab12", "--start"]);
+        assert!(result.is_err(), "--start on reopen should fail to parse after removal");
     }
 
     #[test]
-    fn issue_reopen_no_start_flag_is_false() {
+    fn issue_reopen_without_start_flag_parses() {
         let cli = Cli::try_parse_from(["ns2", "issue", "reopen", "--id", "ab12"]).unwrap();
         match cli.command {
             Command::Issue {
-                action: IssueAction::Reopen { start, .. },
+                action: IssueAction::Reopen { id, .. },
             } => {
-                assert!(!start);
+                assert_eq!(id, "ab12");
             }
             _ => panic!("expected issue reopen command"),
         }
@@ -1512,8 +1500,9 @@ mod tests {
     }
 
     #[test]
-    fn issue_new_parses_start_flag() {
-        let cli = Cli::try_parse_from([
+    fn issue_new_start_flag_removed_fails_to_parse() {
+        // --start flag has been removed from `issue new`
+        let result = Cli::try_parse_from([
             "ns2",
             "issue",
             "new",
@@ -1524,27 +1513,19 @@ mod tests {
             "--assignee",
             "swe",
             "--start",
-        ])
-        .unwrap();
-        match cli.command {
-            Command::Issue {
-                action: IssueAction::New { start, .. },
-            } => {
-                assert!(start);
-            }
-            _ => panic!("expected issue new command"),
-        }
+        ]);
+        assert!(result.is_err(), "--start on issue new should fail to parse after removal");
     }
 
     #[test]
-    fn issue_new_no_start_flag_is_false() {
+    fn issue_new_without_start_flag_parses() {
         let cli =
             Cli::try_parse_from(["ns2", "issue", "new", "--title", "t", "--body", "b"]).unwrap();
         match cli.command {
             Command::Issue {
-                action: IssueAction::New { start, .. },
+                action: IssueAction::New { title, .. },
             } => {
-                assert!(!start);
+                assert_eq!(title, "t");
             }
             _ => panic!("expected issue new command"),
         }
@@ -1603,6 +1584,72 @@ mod tests {
     fn issue_cancel_missing_id_fails_to_parse() {
         let result = Cli::try_parse_from(["ns2", "issue", "cancel"]);
         assert!(result.is_err(), "cancel without --id should fail to parse");
+    }
+
+    // ─── issue set-status CLI parse tests ─────────────────────────────────────
+
+    #[test]
+    fn issue_set_status_parses_id_and_status() {
+        let cli = Cli::try_parse_from([
+            "ns2",
+            "issue",
+            "set-status",
+            "--id",
+            "ab12",
+            "--status",
+            "in_progress",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Issue {
+                action: IssueAction::SetStatus { id, status },
+            } => {
+                assert_eq!(id, "ab12");
+                assert_eq!(status, "in_progress");
+            }
+            _ => panic!("expected issue set-status command"),
+        }
+    }
+
+    #[test]
+    fn issue_set_status_missing_id_fails_to_parse() {
+        let result =
+            Cli::try_parse_from(["ns2", "issue", "set-status", "--status", "in_progress"]);
+        assert!(
+            result.is_err(),
+            "set-status without --id should fail to parse"
+        );
+    }
+
+    #[test]
+    fn issue_set_status_missing_status_fails_to_parse() {
+        let result = Cli::try_parse_from(["ns2", "issue", "set-status", "--id", "ab12"]);
+        assert!(
+            result.is_err(),
+            "set-status without --status should fail to parse"
+        );
+    }
+
+    #[test]
+    fn issue_set_status_with_open_status_parses() {
+        let cli = Cli::try_parse_from([
+            "ns2",
+            "issue",
+            "set-status",
+            "--id",
+            "ab12",
+            "--status",
+            "open",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Issue {
+                action: IssueAction::SetStatus { status, .. },
+            } => {
+                assert_eq!(status, "open");
+            }
+            _ => panic!("expected issue set-status command"),
+        }
     }
 
     #[test]

--- a/crates/cli/src/render.rs
+++ b/crates/cli/src/render.rs
@@ -242,6 +242,7 @@ pub struct IssueTreeNode {
 pub fn issue_status_symbol(status: &IssueStatus, tick: usize) -> (String, &'static str) {
     match status {
         IssueStatus::Running => (spinner_char(tick).to_string(), "running"),
+        IssueStatus::InProgress => (spinner_char(tick).to_string(), "in_progress"),
         IssueStatus::Completed => ("✔".to_string(), "completed"),
         IssueStatus::Failed => ("✗".to_string(), "failed"),
         IssueStatus::Open => ("●".to_string(), "open"),

--- a/crates/cli/src/render.rs
+++ b/crates/cli/src/render.rs
@@ -510,4 +510,17 @@ mod tests {
         assert_eq!(sym, "⏸");
         assert_eq!(label, "waiting");
     }
+
+    // ── InProgress symbol test ────────────────────────────────────────────────
+
+    #[test]
+    fn issue_status_symbol_in_progress_returns_spinner() {
+        let (sym, label) = issue_status_symbol(&IssueStatus::InProgress, 0);
+        // The symbol must be a known braille spinner character.
+        assert!(
+            SPINNER_FRAMES.contains(&sym.chars().next().expect("symbol must be non-empty")),
+            "in_progress symbol must be a spinner character, got: {sym:?}"
+        );
+        assert_eq!(label, "in_progress");
+    }
 }

--- a/crates/cli/tests/issue_crud.rs
+++ b/crates/cli/tests/issue_crud.rs
@@ -437,8 +437,9 @@ fn issue_start_without_assignee_fails() {
     let mut h = TestHarness::new();
     h.start_server();
     let id = h.ns2_stdout(&["issue", "new", "--title", "No Assignee", "--body", "b"]);
+    // Use set-status in_progress; without assignee it should fail with 400
     h.ns2()
-        .args(["issue", "start", "--id", &id])
+        .args(["issue", "set-status", "--id", &id, "--status", "in_progress"])
         .assert()
         .failure()
         .stderr(
@@ -465,8 +466,9 @@ fn issue_start_already_completed_fails() {
         .args(["issue", "complete", "--id", &id, "--comment", "done"])
         .assert()
         .success();
+    // Trying to set in_progress on a completed issue with session should fail
     h.ns2()
-        .args(["issue", "start", "--id", &id])
+        .args(["issue", "set-status", "--id", &id, "--status", "in_progress"])
         .assert()
         .failure();
 }
@@ -495,7 +497,7 @@ fn issue_operations_on_nonexistent_id_fail() {
     let mut h = TestHarness::new();
     h.start_server();
     h.ns2()
-        .args(["issue", "start", "--id", "zzzz"])
+        .args(["issue", "set-status", "--id", "zzzz", "--status", "in_progress"])
         .assert()
         .failure()
         .stderr(

--- a/crates/cli/tests/orphan_recovery.rs
+++ b/crates/cli/tests/orphan_recovery.rs
@@ -53,7 +53,7 @@ fn orphan_session_with_linked_issue_posts_comment_and_fails_issue() {
         "--assignee",
         "swe",
     ]);
-    h.ns2_stdout(&["issue", "start", "--id", &issue_id]);
+    h.ns2_stdout(&["issue", "set-status", "--id", &issue_id, "--status", "in_progress"]);
     h.ns2_stdout(&["issue", "wait", "--id", &issue_id]);
 
     h.http_patch(

--- a/crates/cli/tests/worktree.rs
+++ b/crates/cli/tests/worktree.rs
@@ -235,7 +235,7 @@ fn issue_start_creates_worktree_for_issue_with_branch() {
     let branch = extract_json_str(&json, "branch");
 
     h.ns2()
-        .args(["issue", "start", "--id", &id])
+        .args(["issue", "set-status", "--id", &id, "--status", "in_progress"])
         .assert()
         .success();
     h.ns2()
@@ -276,7 +276,7 @@ fn issue_start_reuses_existing_worktree() {
         "feature/shared",
     ]);
     h.ns2()
-        .args(["issue", "start", "--id", &id_a])
+        .args(["issue", "set-status", "--id", &id_a, "--status", "in_progress"])
         .assert()
         .success();
     h.ns2()
@@ -297,7 +297,7 @@ fn issue_start_reuses_existing_worktree() {
         "feature/shared",
     ]);
     h.ns2()
-        .args(["issue", "start", "--id", &id_b])
+        .args(["issue", "set-status", "--id", &id_b, "--status", "in_progress"])
         .assert()
         .success();
     h.ns2()
@@ -351,7 +351,7 @@ fn worktree_not_deleted_after_session_completes() {
     let branch = extract_json_str(&json, "branch");
 
     h.ns2()
-        .args(["issue", "start", "--id", &id])
+        .args(["issue", "set-status", "--id", &id, "--status", "in_progress"])
         .assert()
         .success();
     h.ns2()

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -47,7 +47,6 @@ fn build_router(state: AppState) -> Router {
         .route("/issues/:id", get(issue::get_issue))
         .route("/issues/:id", axum::routing::patch(issue::edit_issue))
         .route("/issues/:id/comments", post(issue::add_comment))
-        .route("/issues/:id/start", post(issue::start_issue))
         .route("/issues/:id/complete", post(issue::complete_issue))
         .route("/issues/:id/cancel", post(issue::cancel_issue))
         .route("/issues/:id/reopen", post(issue::reopen_issue))
@@ -1942,13 +1941,11 @@ mod tests {
         let id = created["id"].as_str().unwrap();
 
         let start_resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/issues/{id}/start"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(issue_req(
+                "PATCH",
+                &format!("/issues/{id}/status"),
+                &serde_json::json!({"status": "in_progress"}),
+            ))
             .await
             .unwrap();
         assert_eq!(start_resp.status(), StatusCode::BAD_REQUEST);
@@ -1973,24 +1970,20 @@ mod tests {
         let id = created["id"].as_str().unwrap();
 
         app.clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/issues/{id}/start"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(issue_req(
+                "PATCH",
+                &format!("/issues/{id}/status"),
+                &serde_json::json!({"status": "in_progress"}),
+            ))
             .await
             .unwrap();
 
         let second_start = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/issues/{id}/start"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(issue_req(
+                "PATCH",
+                &format!("/issues/{id}/status"),
+                &serde_json::json!({"status": "in_progress"}),
+            ))
             .await
             .unwrap();
         assert_eq!(second_start.status(), StatusCode::BAD_REQUEST);
@@ -2093,13 +2086,11 @@ mod tests {
         let issue_id = created["id"].as_str().unwrap().to_string();
 
         app.clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/issues/{issue_id}/start"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(issue_req(
+                "PATCH",
+                &format!("/issues/{issue_id}/status"),
+                &serde_json::json!({"status": "in_progress"}),
+            ))
             .await
             .unwrap();
 
@@ -2744,13 +2735,11 @@ mod tests {
         let issue_id = created["id"].as_str().unwrap().to_string();
 
         app.clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/issues/{issue_id}/start"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(issue_req(
+                "PATCH",
+                &format!("/issues/{issue_id}/status"),
+                &serde_json::json!({"status": "in_progress"}),
+            ))
             .await
             .unwrap();
 
@@ -2882,13 +2871,11 @@ mod tests {
             .unwrap();
 
         app.clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/issues/{issue_id}/start"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(issue_req(
+                "PATCH",
+                &format!("/issues/{issue_id}/status"),
+                &serde_json::json!({"status": "in_progress"}),
+            ))
             .await
             .unwrap();
 
@@ -2979,13 +2966,11 @@ mod tests {
         let issue_id = created["id"].as_str().unwrap().to_string();
 
         app.clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/issues/{issue_id}/start"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(issue_req(
+                "PATCH",
+                &format!("/issues/{issue_id}/status"),
+                &serde_json::json!({"status": "in_progress"}),
+            ))
             .await
             .unwrap();
 
@@ -3073,13 +3058,11 @@ mod tests {
         let issue_id = created["id"].as_str().unwrap().to_string();
 
         app.clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/issues/{issue_id}/start"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(issue_req(
+                "PATCH",
+                &format!("/issues/{issue_id}/status"),
+                &serde_json::json!({"status": "in_progress"}),
+            ))
             .await
             .unwrap();
 
@@ -4196,13 +4179,11 @@ mod tests {
 
         // Start the work issue (emits StatusChanged → Running)
         app.clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/issues/{work_id}/start"))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(issue_req(
+                "PATCH",
+                &format!("/issues/{work_id}/status"),
+                &serde_json::json!({"status": "in_progress"}),
+            ))
             .await
             .unwrap();
 
@@ -4289,6 +4270,293 @@ mod tests {
             20,
             "default limit should be 20, got {}",
             arr.len()
+        );
+    }
+
+    // ─── PATCH /issues/:id/status with in_progress auto-starts ──────────────
+
+    async fn patch_issue_status(
+        app: Router,
+        id: &str,
+        body: serde_json::Value,
+    ) -> axum::response::Response {
+        app.oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/issues/{id}/status"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_set_in_progress_on_open_issue_auto_starts() {
+        let (app, state) = test_app_with_state().await;
+
+        // Create issue with assignee
+        let create_resp = app
+            .clone()
+            .oneshot(issue_req(
+                "POST",
+                "/issues",
+                &serde_json::json!({
+                    "title": "In-progress test",
+                    "body": "body",
+                    "assignee": "test-agent"
+                }),
+            ))
+            .await
+            .unwrap();
+        let body = response_body_bytes(create_resp).await;
+        let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let issue_id = created["id"].as_str().unwrap().to_string();
+
+        // Set status to in_progress
+        let resp = patch_issue_status(
+            app.clone(),
+            &issue_id,
+            serde_json::json!({"status": "in_progress"}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "in_progress transition should return 200"
+        );
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // The returned status should be "running" (harness was spawned)
+        assert_eq!(
+            v["status"], "running",
+            "returned issue must have status=running, not in_progress"
+        );
+        assert!(
+            !v["session_id"].is_null(),
+            "session_id must be set after in_progress transition"
+        );
+
+        // Eventually should reach waiting (stub client)
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            let issue = state.db.get_issue(issue_id.clone()).await.unwrap();
+            if issue.status == IssueStatus::Waiting {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() <= deadline,
+                "issue did not reach waiting within 5s; status={}",
+                issue.status
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_set_in_progress_without_assignee_returns_400() {
+        let app = test_app().await;
+
+        // Create issue WITHOUT assignee
+        let create_resp = app
+            .clone()
+            .oneshot(issue_req(
+                "POST",
+                "/issues",
+                &serde_json::json!({
+                    "title": "No assignee",
+                    "body": "body"
+                }),
+            ))
+            .await
+            .unwrap();
+        let body = response_body_bytes(create_resp).await;
+        let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let issue_id = created["id"].as_str().unwrap().to_string();
+
+        let resp = patch_issue_status(
+            app,
+            &issue_id,
+            serde_json::json!({"status": "in_progress"}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "in_progress without assignee must return 400"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_set_in_progress_on_failed_session_issue_creates_fresh_session() {
+        let (app, state) = test_app_with_state().await;
+
+        // Create an issue and manually put it in failed state with a session
+        let old_session_id = Uuid::new_v4();
+        let old_session = types::Session {
+            id: old_session_id,
+            name: "old-session".into(),
+            status: types::SessionStatus::Failed,
+            agent: Some("test-agent".into()),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&old_session).await.unwrap();
+
+        let issue = types::Issue {
+            id: "fi01".to_string(),
+            title: "Failed issue".to_string(),
+            body: "body".to_string(),
+            status: types::IssueStatus::Failed,
+            branch: String::new(),
+            assignee: Some("test-agent".to_string()),
+            session_id: Some(old_session_id),
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        // Set status to in_progress — should clear old failed session and create new one
+        let resp = patch_issue_status(
+            app.clone(),
+            "fi01",
+            serde_json::json!({"status": "in_progress"}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "in_progress on failed issue must return 200"
+        );
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            v["status"], "running",
+            "failed issue with in_progress should become running"
+        );
+        // The session_id should NOT be the old failed one
+        let new_session_id = v["session_id"].as_str().expect("session_id must be set");
+        assert_ne!(
+            new_session_id,
+            old_session_id.to_string(),
+            "a new session must be created, not the old failed one"
+        );
+
+        // Old session should be cancelled
+        let old_sess = state.db.get_session(old_session_id).await.unwrap();
+        assert_eq!(
+            old_sess.status,
+            types::SessionStatus::Cancelled,
+            "old failed session should be marked cancelled"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_set_in_progress_on_waiting_issue_resumes_session() {
+        let (app, state) = test_app_with_state().await;
+
+        // Create a waiting session
+        let waiting_session_id = Uuid::new_v4();
+        let waiting_session = types::Session {
+            id: waiting_session_id,
+            name: "waiting-session".into(),
+            status: types::SessionStatus::Waiting,
+            agent: Some("test-agent".into()),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&waiting_session).await.unwrap();
+        state
+            .db
+            .update_session_status(waiting_session_id, types::SessionStatus::Waiting)
+            .await
+            .unwrap();
+
+        // Create issue in Waiting state with session
+        let issue = types::Issue {
+            id: "wi01".to_string(),
+            title: "Waiting issue".to_string(),
+            body: "body".to_string(),
+            status: types::IssueStatus::Waiting,
+            branch: String::new(),
+            assignee: Some("test-agent".to_string()),
+            session_id: Some(waiting_session_id),
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        // Set status to in_progress — should resume existing waiting session
+        let resp = patch_issue_status(
+            app.clone(),
+            "wi01",
+            serde_json::json!({"status": "in_progress"}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "in_progress on waiting issue must return 200"
+        );
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            v["status"], "running",
+            "waiting issue with in_progress should become running"
+        );
+        // Session id should be the SAME waiting session (reuse)
+        let returned_session_id = v["session_id"].as_str().expect("session_id must be set");
+        assert_eq!(
+            returned_session_id,
+            waiting_session_id.to_string(),
+            "should reuse the existing waiting session, not create a new one"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_post_issues_id_start_returns_404_route_removed() {
+        let app = test_app().await;
+
+        // Create an issue first
+        let create_resp = app
+            .clone()
+            .oneshot(issue_req(
+                "POST",
+                "/issues",
+                &serde_json::json!({
+                    "title": "Test",
+                    "body": "body",
+                    "assignee": "test-agent"
+                }),
+            ))
+            .await
+            .unwrap();
+        let body = response_body_bytes(create_resp).await;
+        let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let issue_id = created["id"].as_str().unwrap().to_string();
+
+        // POST /issues/:id/start should return 404 (route removed)
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/issues/{issue_id}/start"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "POST /issues/:id/start must return 404 after route removal"
         );
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4653,4 +4653,148 @@ mod tests {
             "error message must hint at `reopen`, got: {err_msg}"
         );
     }
+
+    // ─── Test 2: Running issue with Running session blocks in_progress ────────
+
+    #[tokio::test]
+    async fn test_set_in_progress_on_running_issue_with_session_returns_400() {
+        let (app, state) = test_app_with_state().await;
+
+        // Create a Running session.
+        let running_session_id = Uuid::new_v4();
+        let running_session = types::Session {
+            id: running_session_id,
+            name: "running-session".into(),
+            status: types::SessionStatus::Running,
+            agent: Some("test-agent".into()),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&running_session).await.unwrap();
+
+        // Create an issue in Running state with the running session.
+        let issue = types::Issue {
+            id: "ri01".to_string(),
+            title: "Running issue".to_string(),
+            body: "body".to_string(),
+            status: types::IssueStatus::Running,
+            branch: String::new(),
+            assignee: Some("test-agent".to_string()),
+            session_id: Some(running_session_id),
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        // PATCH /issues/ri01/status with {"status": "in_progress"} must return 400.
+        let resp = patch_issue_status(
+            app.clone(),
+            "ri01",
+            serde_json::json!({"status": "in_progress"}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "in_progress on running issue must return 400"
+        );
+        let body = response_body_bytes(resp).await;
+        let err_msg = String::from_utf8_lossy(&body);
+        assert!(
+            err_msg.contains("running"),
+            "error message must mention 'running', got: {err_msg}"
+        );
+    }
+
+    // ─── Test 3: Waiting issue with no session_id returns 400 ─────────────────
+
+    #[tokio::test]
+    async fn test_set_in_progress_on_waiting_issue_without_session_returns_400() {
+        let (app, state) = test_app_with_state().await;
+
+        // Create an issue in Waiting state with session_id: None.
+        let issue = types::Issue {
+            id: "wi02".to_string(),
+            title: "Waiting no-session issue".to_string(),
+            body: "body".to_string(),
+            status: types::IssueStatus::Waiting,
+            branch: String::new(),
+            assignee: Some("test-agent".to_string()),
+            session_id: None,
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        // PATCH /issues/wi02/status with {"status": "in_progress"} must return 400.
+        let resp = patch_issue_status(
+            app.clone(),
+            "wi02",
+            serde_json::json!({"status": "in_progress"}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "in_progress on waiting issue with no session_id must return 400"
+        );
+    }
+
+    // ─── Test 4: Non-in_progress status update stores the new status ──────────
+
+    #[tokio::test]
+    async fn test_patch_issue_status_non_in_progress_updates_field() {
+        let (app, state) = test_app_with_state().await;
+
+        // Create an open issue.
+        let create_resp = app
+            .clone()
+            .oneshot(issue_req(
+                "POST",
+                "/issues",
+                &serde_json::json!({
+                    "title": "Status update test",
+                    "body": "body"
+                }),
+            ))
+            .await
+            .unwrap();
+        let body = response_body_bytes(create_resp).await;
+        let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let issue_id = created["id"].as_str().unwrap().to_string();
+
+        // PATCH /issues/{id}/status with {"status": "waiting"}.
+        let resp = patch_issue_status(
+            app.clone(),
+            &issue_id,
+            serde_json::json!({"status": "waiting"}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "PATCH with non-in_progress status must return 200"
+        );
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            v["status"], "waiting",
+            "returned issue must have the new status"
+        );
+
+        // Confirm persistence: fetch from DB directly.
+        let persisted = state.db.get_issue(issue_id).await.unwrap();
+        assert_eq!(
+            persisted.status,
+            types::IssueStatus::Waiting,
+            "DB must persist the new status"
+        );
+    }
 }
+

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4559,4 +4559,98 @@ mod tests {
             "POST /issues/:id/start must return 404 after route removal"
         );
     }
+
+    #[tokio::test]
+    async fn test_set_in_progress_on_cancelled_issue_hints_reopen() {
+        let (app, state) = test_app_with_state().await;
+
+        // Create an issue in Cancelled state (no session).
+        let issue = types::Issue {
+            id: "ci01".to_string(),
+            title: "Cancelled issue".to_string(),
+            body: "body".to_string(),
+            status: types::IssueStatus::Cancelled,
+            branch: String::new(),
+            assignee: Some("test-agent".to_string()),
+            session_id: None,
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        // Try to set to in_progress — must fail with a hint about `reopen`.
+        let resp = patch_issue_status(
+            app.clone(),
+            "ci01",
+            serde_json::json!({"status": "in_progress"}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "in_progress on cancelled issue must return 400"
+        );
+        let body = response_body_bytes(resp).await;
+        let err_msg = String::from_utf8_lossy(&body);
+        assert!(
+            err_msg.contains("reopen"),
+            "error message must hint at `reopen`, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_set_in_progress_on_cancelled_issue_with_session_hints_reopen() {
+        let (app, state) = test_app_with_state().await;
+
+        // Create a cancelled session.
+        let cancelled_session_id = Uuid::new_v4();
+        let cancelled_session = types::Session {
+            id: cancelled_session_id,
+            name: "cancelled-session".into(),
+            status: types::SessionStatus::Cancelled,
+            agent: Some("test-agent".into()),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&cancelled_session).await.unwrap();
+
+        // Create an issue in Cancelled state with a cancelled session.
+        let issue = types::Issue {
+            id: "ci02".to_string(),
+            title: "Cancelled issue with session".to_string(),
+            body: "body".to_string(),
+            status: types::IssueStatus::Cancelled,
+            branch: String::new(),
+            assignee: Some("test-agent".to_string()),
+            session_id: Some(cancelled_session_id),
+            parent_id: None,
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        // Try to set to in_progress — must fail with a hint about `reopen`.
+        let resp = patch_issue_status(
+            app.clone(),
+            "ci02",
+            serde_json::json!({"status": "in_progress"}),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "in_progress on cancelled issue with session must return 400"
+        );
+        let body = response_body_bytes(resp).await;
+        let err_msg = String::from_utf8_lossy(&body);
+        assert!(
+            err_msg.contains("reopen"),
+            "error message must hint at `reopen`, got: {err_msg}"
+        );
+    }
 }

--- a/crates/server/src/routes/issue.rs
+++ b/crates/server/src/routes/issue.rs
@@ -4,7 +4,7 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Deserializer};
-use types::{Issue, IssueStatus};
+use types::{Issue, IssueStatus, SessionStatus};
 
 use super::Error;
 use crate::harness_spawn::spawn_harness_sync;
@@ -169,12 +169,15 @@ pub async fn add_comment(
     Ok(Json(issue))
 }
 
-pub async fn start_issue(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
+/// Internal helper: start an issue by calling `issue_service.start_issue()` and
+/// spawning the harness.  Used both from `update_issue_status` (when the new
+/// status is `InProgress`) and the legacy `start_issue` handler.
+async fn do_start_issue(
+    state: &AppState,
+    id: String,
 ) -> std::result::Result<Json<Issue>, Error> {
     let outcome = state.issue_service.start_issue(id).await?;
-    let msg_tx = spawn_harness_sync(&state, outcome.session, Some(outcome.issue.id.clone()));
+    let msg_tx = spawn_harness_sync(state, outcome.session, Some(outcome.issue.id.clone()));
     msg_tx.send(outcome.initial_message).await.ok();
     Ok(Json(outcome.issue))
 }
@@ -225,6 +228,19 @@ pub async fn cancel_issue(
     Ok(Json(issue))
 }
 
+/// PATCH /issues/:id/status — update an issue's status.
+///
+/// When the new status is `in_progress`, this handler:
+/// 1. Checks the issue has an assignee (returns 400 if not).
+/// 2. If the issue has a linked session in `Failed` state, marks that session
+///    `Cancelled` and clears the `session_id` on the issue.
+/// 3. If the issue is in `Waiting` state (has an existing session), directly
+///    spawns the harness against the existing session (resume mode).
+/// 4. Otherwise calls `issue_service.start_issue()` and spawns the harness.
+/// 5. Returns the issue in `running` state (never `in_progress` — that status
+///    is only accepted as input, never stored).
+///
+/// For any other status the issue's status is updated directly in the DB.
 pub async fn update_issue_status(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -234,6 +250,80 @@ pub async fn update_issue_status(
         .status
         .parse::<IssueStatus>()
         .map_err(Error::BadRequest)?;
+
+    if new_status == IssueStatus::InProgress {
+        // Fetch the current issue to validate preconditions.
+        let issue = state.db.get_issue(id.clone()).await?;
+
+        // Must have an assignee.
+        if issue.assignee.is_none() {
+            return Err(Error::BadRequest(
+                "issue has no assignee; set one with `issue edit --assignee <agent>`".into(),
+            ));
+        }
+
+        // If the issue is Waiting with an existing session, resume it directly
+        // (spawn harness against existing session without creating a new one).
+        if issue.status == types::IssueStatus::Waiting {
+            if let Some(session_id) = issue.session_id {
+                let session = state.db.get_session(session_id).await?;
+                // Update the issue to Running state.
+                let mut updated_issue = issue.clone();
+                updated_issue.status = types::IssueStatus::Running;
+                updated_issue.updated_at = chrono::Utc::now();
+                state.db.update_issue(&updated_issue).await?;
+                // Spawn/resume the harness for the existing session.
+                let msg_tx = spawn_harness_sync(&state, session, Some(issue.id.clone()));
+                // Send a resume message to wake the agent.
+                msg_tx.send("Please continue.".to_string()).await.ok();
+                let refreshed = state.db.get_issue(id).await?;
+                return Ok(Json(refreshed));
+            }
+        }
+
+        // If the issue has a Failed session, cancel it and clear session_id so
+        // start_issue creates a fresh one.
+        if let Some(session_id) = issue.session_id {
+            let session = state.db.get_session(session_id).await?;
+            if session.status == SessionStatus::Failed {
+                // Mark old session cancelled.
+                let _ = state
+                    .db
+                    .update_session_status(session_id, SessionStatus::Cancelled)
+                    .await;
+                // Clear session_id on the issue and set to Open so start_issue accepts it.
+                let mut updated_issue = issue.clone();
+                updated_issue.session_id = None;
+                updated_issue.status = types::IssueStatus::Open;
+                state.db.update_issue(&updated_issue).await?;
+            } else if issue.status != types::IssueStatus::Open {
+                // Issue has a session that isn't failed (e.g. running/completed/cancelled)
+                // and the issue is not Open — cannot restart.
+                return Err(Error::BadRequest(format!(
+                    "cannot set in_progress on issue in {} state",
+                    issue.status
+                )));
+            }
+        } else if issue.status == types::IssueStatus::Failed {
+            // Issue has no session but is in Failed state — allow restart
+            // (set back to Open so start_issue accepts it).
+            let mut updated_issue = issue.clone();
+            updated_issue.status = types::IssueStatus::Open;
+            updated_issue.session_id = None;
+            state.db.update_issue(&updated_issue).await?;
+        } else if issue.status != types::IssueStatus::Open {
+            // Issue has no session and is not Open or Failed — cannot restart.
+            return Err(Error::BadRequest(format!(
+                "cannot set in_progress on issue in {} state",
+                issue.status
+            )));
+        }
+
+        // Delegate to the internal start logic.
+        return do_start_issue(&state, id).await;
+    }
+
+    // For all other statuses: simple field update.
     let mut issue = state.db.get_issue(id.clone()).await?;
     issue.status = new_status;
     state.db.update_issue(&issue).await?;

--- a/crates/server/src/routes/issue.rs
+++ b/crates/server/src/routes/issue.rs
@@ -22,6 +22,17 @@ pub fn slugify(title: &str) -> String {
     issues::slugify(title)
 }
 
+// Builds a user-facing error message when an issue cannot be set to in_progress
+// due to its current status. Cancelled issues get an extra hint.
+fn bad_status_error(status: &IssueStatus) -> String {
+    let base = format!("cannot set in_progress on issue in {status} state");
+    if *status == IssueStatus::Cancelled {
+        format!("{base}; use `ns2 issue reopen --id <id>` first")
+    } else {
+        base
+    }
+}
+
 // Wraps a present JSON field (including null) in Some, leaving absent fields as None.
 // Used with #[serde(default, deserialize_with = "deserialize_some")] to distinguish
 // "field absent" (None) from "field explicitly null" (Some(None)).
@@ -170,8 +181,8 @@ pub async fn add_comment(
 }
 
 /// Internal helper: start an issue by calling `issue_service.start_issue()` and
-/// spawning the harness.  Used both from `update_issue_status` (when the new
-/// status is `InProgress`) and the legacy `start_issue` handler.
+/// spawning the harness.  Used by `update_issue_status` when the new status is
+/// `InProgress`.
 async fn do_start_issue(
     state: &AppState,
     id: String,
@@ -279,6 +290,9 @@ pub async fn update_issue_status(
                 let refreshed = state.db.get_issue(id).await?;
                 return Ok(Json(refreshed));
             }
+            // session_id is None: a Waiting issue with no session cannot be
+            // resumed.  Fall through to the checks below, which will produce
+            // the "in waiting state" error — the correct behaviour.
         }
 
         // If the issue has a Failed session, cancel it and clear session_id so
@@ -299,10 +313,7 @@ pub async fn update_issue_status(
             } else if issue.status != types::IssueStatus::Open {
                 // Issue has a session that isn't failed (e.g. running/completed/cancelled)
                 // and the issue is not Open — cannot restart.
-                return Err(Error::BadRequest(format!(
-                    "cannot set in_progress on issue in {} state",
-                    issue.status
-                )));
+                return Err(Error::BadRequest(bad_status_error(&issue.status)));
             }
         } else if issue.status == types::IssueStatus::Failed {
             // Issue has no session but is in Failed state — allow restart
@@ -313,10 +324,7 @@ pub async fn update_issue_status(
             state.db.update_issue(&updated_issue).await?;
         } else if issue.status != types::IssueStatus::Open {
             // Issue has no session and is not Open or Failed — cannot restart.
-            return Err(Error::BadRequest(format!(
-                "cannot set in_progress on issue in {} state",
-                issue.status
-            )));
+            return Err(Error::BadRequest(bad_status_error(&issue.status)));
         }
 
         // Delegate to the internal start logic.

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 #[serde(rename_all = "snake_case")]
 pub enum IssueStatus {
     Open,
+    InProgress,
     Running,
     Completed,
     Failed,
@@ -17,6 +18,7 @@ impl std::fmt::Display for IssueStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Open => write!(f, "open"),
+            Self::InProgress => write!(f, "in_progress"),
             Self::Running => write!(f, "running"),
             Self::Completed => write!(f, "completed"),
             Self::Failed => write!(f, "failed"),
@@ -31,6 +33,7 @@ impl std::str::FromStr for IssueStatus {
     fn from_str(s: &str) -> std::result::Result<Self, String> {
         match s {
             "open" => Ok(Self::Open),
+            "in_progress" => Ok(Self::InProgress),
             "running" => Ok(Self::Running),
             "completed" => Ok(Self::Completed),
             "failed" => Ok(Self::Failed),
@@ -494,6 +497,7 @@ mod tests {
     fn issue_status_display_round_trip() {
         for status in [
             IssueStatus::Open,
+            IssueStatus::InProgress,
             IssueStatus::Running,
             IssueStatus::Completed,
             IssueStatus::Failed,
@@ -504,6 +508,25 @@ mod tests {
             let parsed: IssueStatus = s.parse().expect("should parse");
             assert_eq!(parsed, status);
         }
+    }
+
+    #[test]
+    fn issue_status_in_progress_display() {
+        assert_eq!(IssueStatus::InProgress.to_string(), "in_progress");
+    }
+
+    #[test]
+    fn issue_status_in_progress_from_str() {
+        let s: IssueStatus = "in_progress".parse().expect("should parse");
+        assert_eq!(s, IssueStatus::InProgress);
+    }
+
+    #[test]
+    fn issue_status_in_progress_serde_roundtrip() {
+        let json = serde_json::to_string(&IssueStatus::InProgress).expect("serialize");
+        assert_eq!(json, "\"in_progress\"");
+        let decoded: IssueStatus = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(decoded, IssueStatus::InProgress);
     }
 
     #[test]

--- a/product-flows/03-issue-lifecycle.md
+++ b/product-flows/03-issue-lifecycle.md
@@ -1,7 +1,7 @@
 
 # Flow 03: Issue Lifecycle
 
-Create an issue, assign it to an agent, start a session, wait for completion, and mark it done. This is the primary orchestration smoke test.
+Create an issue, assign it to an agent, set status to in_progress to automatically start execution, wait for completion, and mark it done. This is the primary orchestration smoke test.
 
 ## Prerequisites
 
@@ -35,13 +35,13 @@ ns2 issue list --status open
 
 Expected: a table showing the issue with status `open`, assignee `swe`, and auto-generated branch `<id>-add-a-greeting`.
 
-### Step 3: Start the issue
+### Step 3: Set status to in_progress to auto-start execution
 
 ```bash
-ns2 issue start --id "$ISSUE"
+ns2 issue set-status --id "$ISSUE" --status in_progress
 ```
 
-Expected: session UUID printed, issue status transitions to `running`.
+Expected: issue transitions to `running` and a session is automatically created and started.
 
 ### Step 4: Wait for completion
 
@@ -105,7 +105,7 @@ ns2 issue list --status waiting
 
 - [ ] `ns2 issue new` prints a 4-character issue ID to stdout
 - [ ] New issues start with status `open` and an auto-generated branch slug
-- [ ] `ns2 issue start` creates a session linked to the issue and sets status to `running`
+- [ ] Setting status to `in_progress` automatically creates a session and starts execution
 - [ ] The session uses the issue's assignee as the agent type
 - [ ] `ns2 issue wait` blocks until the issue reaches a terminal state and exits 0
 - [ ] When the agent calls `stop(status="complete", comment="...")`, the comment is posted and the issue becomes `completed`
@@ -113,5 +113,6 @@ ns2 issue list --status waiting
 - [ ] When the session ends without the agent calling the stop tool, the issue becomes `waiting` with no auto-comment
 - [ ] `ns2 issue complete` adds a manual summary comment
 - [ ] `ns2 issue comment` adds comments with the specified author
-- [ ] Issue status transitions: open → running → completed (via stop tool) or open → running → waiting (no stop tool)
+- [ ] Issue status transitions: open → running (via in_progress) → completed (via stop tool) or open → running → waiting (no stop tool)
+- [ ] If the issue's session was in an error state when in_progress is set, the old session is removed before creating a new one
 - [ ] No panics or unhandled errors in server output


### PR DESCRIPTION
## Summary

- Removes `ns2 issue start` and `ns2 issue restart` CLI commands
- Adds `ns2 issue set-status --id <ID> --status <status>` command
- When an issue status is set to `in_progress`, the server automatically creates a new session and starts the harness
- If the issue has a failed session, it is cleared before creating a new one
- Updates all agent definitions and skills that referenced `issue start`

## Changes

- `crates/types`: adds `IssueStatus::InProgress` variant  
- `crates/server`: `PATCH /issues/:id/status` now handles `in_progress` by auto-starting harness; removes `/issues/:id/start` route
- `crates/cli`: removes `start`/`restart` subcommands, adds `set-status` subcommand
- `.ns2/agents/*.md`, `.claude/skills/ns2/SKILL.md`: updated to use `set-status`
- `product-flows/03-issue-lifecycle.md`: updated to reflect new workflow

## Test plan

- [x] All unit tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy --tests -- -D warnings -W clippy::pedantic -W clippy::nursery`)
- [x] Architecture review completed
- [x] Test quality review completed

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)