### PR TITLE
feat: cron-style timer hooks (GH#108)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1076,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "cron",
  "db",
  "events",
  "issues",

--- a/crates/cli/src/commands/hook.rs
+++ b/crates/cli/src/commands/hook.rs
@@ -16,6 +16,16 @@ fn parse_filter_field(s: &str) -> (String, serde_json::Value) {
     }
 }
 
+// ── Helper: build timer source JSON ──────────────────────────────────────────
+
+fn build_timer_source(schedule: Option<&str>) -> serde_json::Value {
+    let Some(sched) = schedule else {
+        eprintln!("Error: --schedule is required when --source timer is used. Example: --schedule \"0 9 * * 1\"");
+        std::process::exit(1);
+    };
+    json!({ "type": "timer", "schedule": sched })
+}
+
 // ── run_new ───────────────────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
@@ -30,6 +40,7 @@ pub async fn run_new(
     body_template: Option<String>,
     title: Option<String>,
     assignee: Option<String>,
+    schedule: Option<String>,
 ) {
     let client = reqwest::Client::new();
     let url = format!("{server}/hooks");
@@ -40,16 +51,8 @@ pub async fn run_new(
             "type": "internal",
             "event_types": event_types,
         }),
-        "external" => json!({
-            "type": "external",
-        }),
-        "timer" => {
-            // For timer we'd need a schedule, but keep minimal for now
-            json!({
-                "type": "timer",
-                "schedule": event_types.first().map_or("", std::string::String::as_str),
-            })
-        }
+        "external" => json!({ "type": "external" }),
+        "timer" => build_timer_source(schedule.as_deref()),
         other => {
             eprintln!("Error: unknown source type '{other}'. Use: internal, external, timer");
             std::process::exit(1);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -82,6 +82,7 @@ enum Command {
     },
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 enum HookSubcommand {
     #[command(
@@ -113,6 +114,8 @@ enum HookSubcommand {
         title: Option<String>,
         #[arg(long, help = "Assignee for create-issue action.")]
         assignee: Option<String>,
+        #[arg(long, help = "Cron schedule for timer source (e.g. '0 9 * * 1' = Monday 9am).")]
+        schedule: Option<String>,
     },
     #[command(about = "List hooks.")]
     List {
@@ -776,6 +779,7 @@ async fn main() {
                 body,
                 title,
                 assignee,
+                schedule,
             } => {
                 commands::hook::run_new(
                     &cli.server,
@@ -788,6 +792,7 @@ async fn main() {
                     body,
                     title,
                     assignee,
+                    schedule,
                 )
                 .await;
             }
@@ -2558,6 +2563,105 @@ mod tests {
     }
 
     // ─── `ns2 hook` CLI parse tests ──────────────────────────────────────────
+
+    #[test]
+    fn hook_new_parses_schedule_flag() {
+        let cli = Cli::try_parse_from([
+            "ns2",
+            "hook",
+            "new",
+            "--name",
+            "timer-hook",
+            "--source",
+            "timer",
+            "--schedule",
+            "0 9 * * 1",
+            "--action",
+            "send-message",
+            "--target",
+            "issue:abc1",
+            "--body",
+            "Monday morning",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Hook {
+                action:
+                    HookSubcommand::New {
+                        name,
+                        source,
+                        schedule,
+                        ..
+                    },
+            } => {
+                assert_eq!(name, "timer-hook");
+                assert_eq!(source, "timer");
+                assert_eq!(schedule.as_deref(), Some("0 9 * * 1"));
+            }
+            _ => panic!("expected hook new command"),
+        }
+    }
+
+    #[test]
+    fn hook_new_no_schedule_is_none() {
+        let cli = Cli::try_parse_from([
+            "ns2",
+            "hook",
+            "new",
+            "--name",
+            "notify",
+            "--source",
+            "internal",
+            "--event-type",
+            "issue.created",
+            "--action",
+            "send-message",
+            "--target",
+            "issue:abc1",
+            "--body",
+            "hi",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Hook {
+                action: HookSubcommand::New { schedule, .. },
+            } => {
+                assert!(schedule.is_none());
+            }
+            _ => panic!("expected hook new command"),
+        }
+    }
+
+    #[test]
+    fn hook_new_timer_source_with_every_minute_schedule() {
+        let cli = Cli::try_parse_from([
+            "ns2",
+            "hook",
+            "new",
+            "--name",
+            "every-minute",
+            "--source",
+            "timer",
+            "--schedule",
+            "* * * * *",
+            "--action",
+            "send-message",
+            "--target",
+            "issue:abc1",
+            "--body",
+            "tick",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Hook {
+                action: HookSubcommand::New { schedule, source, .. },
+            } => {
+                assert_eq!(source, "timer");
+                assert_eq!(schedule.as_deref(), Some("* * * * *"));
+            }
+            _ => panic!("expected hook new command"),
+        }
+    }
 
     #[test]
     fn hook_new_parses_required_flags() {

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -15,6 +15,7 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
 minijinja = "2"
+cron = "0.12"
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/hooks/src/cron.rs
+++ b/crates/hooks/src/cron.rs
@@ -215,4 +215,23 @@ mod tests {
         // POSIX "1,3,5" (Mon,Wed,Fri) → crate "2,4,6"
         assert_eq!(translate_dow("1,3,5").unwrap(), "2,4,6");
     }
+
+    #[test]
+    fn translate_dow_question_mark_passes_through() {
+        assert_eq!(translate_dow("?").unwrap(), "?");
+    }
+
+    #[test]
+    fn translate_dow_step_notation_1_5_step_2() {
+        // POSIX "1-5/2" (Mon-Fri, every 2nd) → crate "2-6/2"
+        assert_eq!(translate_dow("1-5/2").unwrap(), "2-6/2");
+    }
+
+    #[test]
+    fn translate_dow_token_rejects_value_above_7() {
+        let result = translate_dow("8");
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("invalid cron DOW value"), "got: {msg}");
+    }
 }

--- a/crates/hooks/src/cron.rs
+++ b/crates/hooks/src/cron.rs
@@ -1,0 +1,218 @@
+use chrono::{DateTime, Utc};
+use std::str::FromStr;
+
+/// Convert a 5-field cron expression (POSIX `minute hour dom month dow`)
+/// to the 7-field format expected by the `cron` crate
+/// (`second minute hour dom month dow [year]`).
+///
+/// The POSIX dow field uses `0-6` (or `0-7`) where `0/7 = Sunday`.
+/// The `cron` crate uses `1-7` where `1 = Sunday` (i.e. each value is +1).
+/// We translate numeric-only tokens; named tokens (Mon, Tue, …) pass through.
+fn to_cron_expr(five_field: &str) -> Result<String, String> {
+    let parts: Vec<&str> = five_field.split_whitespace().collect();
+    if parts.len() != 5 {
+        return Err(format!(
+            "invalid cron schedule: expected 5 fields, got {}",
+            parts.len()
+        ));
+    }
+    let (minute, hour, dom, month, dow_posix) =
+        (parts[0], parts[1], parts[2], parts[3], parts[4]);
+
+    // Convert the DOW field from POSIX (0=Sun) to cron-crate (1=Sun) by
+    // incrementing each numeric token by 1. Named tokens pass through unchanged.
+    let dow_crate = translate_dow(dow_posix)?;
+
+    Ok(format!("0 {minute} {hour} {dom} {month} {dow_crate}"))
+}
+
+/// Translate a POSIX DOW field token-by-token.
+/// POSIX: 0=Sun, 1=Mon, …, 6=Sat (7 also treated as Sun in many crons).
+/// cron-crate: 1=Sun, 2=Mon, …, 7=Sat.
+fn translate_dow(posix_dow: &str) -> Result<String, String> {
+    if posix_dow == "*" || posix_dow == "?" {
+        return Ok(posix_dow.to_string());
+    }
+
+    // Split on commas to handle lists like "1,3,5"
+    let mut translated_parts = Vec::new();
+    for part in posix_dow.split(',') {
+        translated_parts.push(translate_dow_part(part)?);
+    }
+    Ok(translated_parts.join(","))
+}
+
+/// Translate a single DOW part which may contain `/step` and `-range` notation.
+fn translate_dow_part(part: &str) -> Result<String, String> {
+    // Handle step notation: "1-5/2"
+    if let Some((range, step)) = part.split_once('/') {
+        let translated_range = translate_dow_range(range)?;
+        return Ok(format!("{translated_range}/{step}"));
+    }
+    translate_dow_range(part)
+}
+
+/// Translate a DOW range like "1-5" or a single value "1" or a named value "Mon".
+fn translate_dow_range(range: &str) -> Result<String, String> {
+    if let Some((start, end)) = range.split_once('-') {
+        let s = translate_dow_token(start)?;
+        let e = translate_dow_token(end)?;
+        Ok(format!("{s}-{e}"))
+    } else {
+        translate_dow_token(range)
+    }
+}
+
+/// Translate a single DOW token: numeric 0-7 → +1, named (Mon etc.) unchanged.
+fn translate_dow_token(token: &str) -> Result<String, String> {
+    // If it looks like a number, add 1 (with wrapping: 7 → 1 like Sunday)
+    if let Ok(n) = token.parse::<u8>() {
+        // POSIX 0 and 7 both mean Sunday → cron-crate 1
+        let translated = if n == 0 || n == 7 { 1u8 } else { n + 1 };
+        if translated > 7 {
+            return Err(format!("invalid cron DOW value: {token}"));
+        }
+        Ok(translated.to_string())
+    } else {
+        // Named token (Mon, Tue, etc.) — pass through
+        Ok(token.to_string())
+    }
+}
+
+/// Compute the next fire time for `schedule` (a 5-field cron expression:
+/// minute hour dom month dow) strictly after `after`.
+///
+/// Returns `Err` if the expression cannot be parsed.
+///
+/// # Errors
+///
+/// Returns an error string if the cron expression cannot be parsed.
+pub fn next_after(schedule: &str, after: DateTime<Utc>) -> Result<DateTime<Utc>, String> {
+    let expr_str = to_cron_expr(schedule)?;
+    let schedule_parsed = cron::Schedule::from_str(&expr_str)
+        .map_err(|e| format!("invalid cron schedule: {e}"))?;
+
+    schedule_parsed
+        .after(&after)
+        .next()
+        .ok_or_else(|| "cron schedule produces no upcoming events".to_string())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn next_after_monday_9am_before_fires_this_week() {
+        // "0 9 * * 1" = 9:00 every Monday
+        // Given: 2024-01-15 08:59:00 UTC (a Monday)
+        // next_after should return 2024-01-15 09:00:00 UTC
+        let t = Utc.with_ymd_and_hms(2024, 1, 15, 8, 59, 0).unwrap();
+        let next = next_after("0 9 * * 1", t).unwrap();
+        assert_eq!(next, Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn next_after_monday_9am_after_fires_next_week() {
+        // Given: 2024-01-15 09:01:00 UTC (1 minute past 9am Monday)
+        // next_after should return the NEXT Monday at 9am (2024-01-22 09:00:00 UTC)
+        let t = Utc.with_ymd_and_hms(2024, 1, 15, 9, 1, 0).unwrap();
+        let next = next_after("0 9 * * 1", t).unwrap();
+        assert_eq!(next, Utc.with_ymd_and_hms(2024, 1, 22, 9, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn next_after_every_minute_fires_at_next_minute() {
+        // "* * * * *" fires every minute
+        // Given: 2024-01-15 09:00:30 UTC (30 sec past the minute)
+        // Should fire at the NEXT minute: 2024-01-15 09:01:00 UTC
+        let t = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
+        let next = next_after("* * * * *", t).unwrap();
+        assert_eq!(next, Utc.with_ymd_and_hms(2024, 1, 15, 9, 1, 0).unwrap());
+    }
+
+    #[test]
+    fn next_after_invalid_expression_returns_error() {
+        let t = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 0).unwrap();
+        let result = next_after("not-a-cron", t);
+        assert!(result.is_err(), "invalid cron should return Err");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("invalid cron schedule"),
+            "error should mention 'invalid cron schedule', got: {err}"
+        );
+    }
+
+    #[test]
+    fn next_after_every_hour_at_minute_0() {
+        // "0 * * * *" = top of every hour
+        // Given: 2024-01-15 09:45:00 UTC
+        // Should fire at 2024-01-15 10:00:00 UTC
+        let t = Utc.with_ymd_and_hms(2024, 1, 15, 9, 45, 0).unwrap();
+        let next = next_after("0 * * * *", t).unwrap();
+        assert_eq!(next, Utc.with_ymd_and_hms(2024, 1, 15, 10, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn next_after_daily_midnight() {
+        // "0 0 * * *" = midnight every day
+        // Given: 2024-01-15 12:00:00 UTC
+        // Should fire at 2024-01-16 00:00:00 UTC
+        let t = Utc.with_ymd_and_hms(2024, 1, 15, 12, 0, 0).unwrap();
+        let next = next_after("0 0 * * *", t).unwrap();
+        assert_eq!(next, Utc.with_ymd_and_hms(2024, 1, 16, 0, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn next_after_at_exact_fire_time_moves_to_next_occurrence() {
+        // If we ask for the next fire "after" 2024-01-15 09:00:00 exactly,
+        // we should NOT get 09:00:00 back — the `after` is exclusive.
+        let t = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 0).unwrap();
+        let next = next_after("0 9 * * 1", t).unwrap();
+        assert_eq!(next, Utc.with_ymd_and_hms(2024, 1, 22, 9, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn translate_dow_star_passes_through() {
+        assert_eq!(translate_dow("*").unwrap(), "*");
+    }
+
+    #[test]
+    fn translate_dow_zero_to_one() {
+        // POSIX 0 = Sunday → crate 1
+        assert_eq!(translate_dow("0").unwrap(), "1");
+    }
+
+    #[test]
+    fn translate_dow_one_to_two() {
+        // POSIX 1 = Monday → crate 2
+        assert_eq!(translate_dow("1").unwrap(), "2");
+    }
+
+    #[test]
+    fn translate_dow_seven_to_one() {
+        // POSIX 7 = Sunday (alias) → crate 1
+        assert_eq!(translate_dow("7").unwrap(), "1");
+    }
+
+    #[test]
+    fn translate_dow_named_passes_through() {
+        assert_eq!(translate_dow("Mon").unwrap(), "Mon");
+        assert_eq!(translate_dow("Fri").unwrap(), "Fri");
+    }
+
+    #[test]
+    fn translate_dow_range() {
+        // POSIX "1-5" (Mon-Fri) → crate "2-6"
+        assert_eq!(translate_dow("1-5").unwrap(), "2-6");
+    }
+
+    #[test]
+    fn translate_dow_list() {
+        // POSIX "1,3,5" (Mon,Wed,Fri) → crate "2,4,6"
+        assert_eq!(translate_dow("1,3,5").unwrap(), "2,4,6");
+    }
+}

--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -3,6 +3,9 @@ pub use types::{
     MessageTarget, Op,
 };
 
+pub mod cron;
+pub mod timer;
+
 // ── Filter evaluation ─────────────────────────────────────────────────────────
 
 pub mod evaluate {

--- a/crates/hooks/src/timer.rs
+++ b/crates/hooks/src/timer.rs
@@ -21,6 +21,63 @@ pub fn should_fire(schedule: &str, now: DateTime<Utc>) -> bool {
     }
 }
 
+/// Process all enabled timer hooks for a single scheduler tick at `now`.
+///
+/// Checks each hook's schedule against the 60-second rolling window and, for
+/// those that match, emits a `SystemEvent::TimerFired` on the event bus and
+/// spawns a task to execute the hook action.
+pub(crate) async fn process_timer_hooks(
+    hook_store: &Arc<dyn HookStore>,
+    event_bus: &EventBus,
+    issue_svc: &issues::IssueService,
+    now: DateTime<Utc>,
+) {
+    let hooks = hook_store
+        .list_hooks(Some(true), Some("timer"))
+        .await
+        .unwrap_or_default();
+
+    for hook in hooks {
+        let HookSource::Timer { ref schedule } = hook.source else {
+            continue;
+        };
+
+        if !should_fire(schedule, now) {
+            continue;
+        }
+
+        // Compute the exact fire time for the event payload
+        let window_start = now - Duration::seconds(60);
+        let Ok(fired_at) = next_after(schedule, window_start) else {
+            continue;
+        };
+
+        // Emit TimerFired event
+        event_bus.send(SystemEvent::TimerFired {
+            hook_id: hook.id.clone(),
+            fired_at,
+        });
+
+        // Execute the hook action
+        let event = SystemEvent::TimerFired {
+            hook_id: hook.id.clone(),
+            fired_at,
+        };
+        let hook_store_clone = Arc::clone(hook_store);
+        let issue_svc_clone = issue_svc.clone();
+        let hook_clone = hook.clone();
+        tokio::spawn(async move {
+            crate::execute::run_action(
+                &hook_clone,
+                &event,
+                &issue_svc_clone,
+                hook_store_clone.as_ref(),
+            )
+            .await;
+        });
+    }
+}
+
 /// Run the timer scheduler loop.
 ///
 /// Wakes every 30 seconds and fires any enabled timer hooks whose schedule
@@ -37,51 +94,7 @@ pub async fn run_timer_scheduler(
     loop {
         interval.tick().await;
         let now = Utc::now();
-
-        let hooks = hook_store
-            .list_hooks(Some(true), Some("timer"))
-            .await
-            .unwrap_or_default();
-
-        for hook in hooks {
-            let HookSource::Timer { ref schedule } = hook.source else {
-                continue;
-            };
-
-            if !should_fire(schedule, now) {
-                continue;
-            }
-
-            // Compute the exact fire time for the event payload
-            let window_start = now - Duration::seconds(60);
-            let Ok(fired_at) = next_after(schedule, window_start) else {
-                continue;
-            };
-
-            // Emit TimerFired event
-            event_bus.send(SystemEvent::TimerFired {
-                hook_id: hook.id.clone(),
-                fired_at,
-            });
-
-            // Execute the hook action
-            let event = SystemEvent::TimerFired {
-                hook_id: hook.id.clone(),
-                fired_at,
-            };
-            let hook_store_clone = Arc::clone(&hook_store);
-            let issue_svc_clone = issue_svc.clone();
-            let hook_clone = hook.clone();
-            tokio::spawn(async move {
-                crate::execute::run_action(
-                    &hook_clone,
-                    &event,
-                    &issue_svc_clone,
-                    hook_store_clone.as_ref(),
-                )
-                .await;
-            });
-        }
+        process_timer_hooks(&hook_store, &event_bus, &issue_svc, now).await;
     }
 }
 
@@ -108,48 +121,7 @@ mod tests {
     use chrono::TimeZone;
     use types::{Hook, HookAction, HookExecution, HookSource, MessageTarget};
 
-    // ── Stub stores ───────────────────────────────────────────────────────────
-
-    struct SpyStore {
-        hooks: Vec<Hook>,
-        fired_events: std::sync::Mutex<Vec<SystemEvent>>,
-    }
-
-    #[async_trait]
-    impl HookStore for SpyStore {
-        async fn create_hook(&self, _h: &types::Hook) -> db::Result<()> {
-            Ok(())
-        }
-        async fn list_hooks(
-            &self,
-            _enabled: Option<bool>,
-            _source_type: Option<&str>,
-        ) -> db::Result<Vec<types::Hook>> {
-            Ok(self.hooks.clone())
-        }
-        async fn get_hook(&self, _id: &str) -> db::Result<types::Hook> {
-            Err(db::Error::NotFound)
-        }
-        async fn update_hook(&self, _h: &types::Hook) -> db::Result<()> {
-            Ok(())
-        }
-        async fn delete_hook(&self, _id: &str) -> db::Result<()> {
-            Ok(())
-        }
-        async fn create_execution(&self, _e: &HookExecution) -> db::Result<()> {
-            Ok(())
-        }
-        async fn update_execution(&self, _e: &HookExecution) -> db::Result<()> {
-            Ok(())
-        }
-        async fn list_executions(
-            &self,
-            _hook_id: &str,
-            _limit: usize,
-        ) -> db::Result<Vec<HookExecution>> {
-            Ok(vec![])
-        }
-    }
+    // ── Single stub store (merged from SpyStore + StubStore) ─────────────────
 
     struct StubStore {
         hooks: Vec<Hook>,
@@ -208,6 +180,11 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
+    }
+
+    async fn make_issue_service() -> issues::IssueService {
+        let (db, _hook_store) = db::connect("sqlite::memory:").await.unwrap();
+        issues::IssueService::new(db)
     }
 
     // ── should_fire tests ─────────────────────────────────────────────────────
@@ -269,57 +246,40 @@ mod tests {
         );
     }
 
+    /// Boundary: at exactly 60 seconds after the fire time, the hook must still
+    /// fire (the window is inclusive on both ends for the 60-second boundary).
+    ///
+    /// "0 9 * * 1" fires at 09:00:00.
+    /// now = 09:01:00 → `window_start` = 09:00:00 → `next_after(09:00:00)` = next Monday 09:00
+    /// so at exactly 60s past, it does NOT fire (boundary is exclusive on the start).
     #[test]
-    fn should_fire_is_deterministic() {
-        // A pure function of its inputs — same inputs, same output.
-        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
-        let result = should_fire("0 9 * * 1", now);
-        assert_eq!(result, should_fire("0 9 * * 1", now));
+    fn should_fire_at_exactly_60s_boundary() {
+        // "0 9 * * 1" = Monday 9:00 UTC
+        // now = 09:01:00 exactly (60s after the fire time)
+        // window_start = 09:00:00 → next_after(09:00:00) is exclusive → next Monday → does NOT fire
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 1, 0).unwrap();
+        assert!(
+            !should_fire("0 9 * * 1", now),
+            "hook must not fire at exactly 60s after the fire time (window_start is exclusive)"
+        );
     }
 
-    // ── Integration-style tests using the core firing logic ───────────────────
+    // ── process_timer_hooks integration tests ─────────────────────────────────
 
     #[tokio::test]
     async fn timer_scheduler_fires_hook_within_window() {
         let hook = make_timer_hook("timer-01", "* * * * *");
-        let store = Arc::new(SpyStore {
-            hooks: vec![hook],
-            fired_events: std::sync::Mutex::new(vec![]),
-        });
-
+        let store: Arc<dyn HookStore> = Arc::new(StubStore { hooks: vec![hook] });
         let bus = EventBus::new(64);
         let mut rx = bus.subscribe();
+        let svc = make_issue_service().await;
 
-        // Simulate one tick of the scheduler with a known "now"
         // now = 09:00:30 → window_start = 08:59:30
         // "* * * * *" → next_after(08:59:30) = 09:00:00 ≤ 09:00:30 → fires
         let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
 
-        // Call the core firing logic directly (not the loop, to keep the test fast)
-        let hooks = store.list_hooks(Some(true), Some("timer")).await.unwrap();
-        for hook in &hooks {
-            let HookSource::Timer { ref schedule } = hook.source else {
-                continue;
-            };
-            if should_fire(schedule, now) {
-                let window_start = now - Duration::seconds(60);
-                let fired_at = next_after(schedule, window_start).unwrap();
-                bus.send(SystemEvent::TimerFired {
-                    hook_id: hook.id.clone(),
-                    fired_at,
-                });
-                store
-                    .fired_events
-                    .lock()
-                    .unwrap()
-                    .push(SystemEvent::TimerFired {
-                        hook_id: hook.id.clone(),
-                        fired_at,
-                    });
-            }
-        }
+        process_timer_hooks(&store, &bus, &svc, now).await;
 
-        // Check the event was sent
         let event = rx.try_recv().expect("TimerFired event should have been sent");
         match &event {
             SystemEvent::TimerFired { hook_id, fired_at } => {
@@ -331,41 +291,103 @@ mod tests {
             }
             _ => panic!("expected TimerFired event, got: {event:?}"),
         }
-
-        // Verify it was captured in the spy
-        let count = store.fired_events.lock().unwrap().len();
-        assert_eq!(count, 1);
     }
 
     #[tokio::test]
     async fn timer_scheduler_does_not_fire_outside_window() {
         let hook = make_timer_hook("timer-02", "0 9 * * 1"); // Monday 9am
-        let store = Arc::new(StubStore { hooks: vec![hook] });
+        let store: Arc<dyn HookStore> = Arc::new(StubStore { hooks: vec![hook] });
         let bus = EventBus::new(64);
         let mut rx = bus.subscribe();
+        let svc = make_issue_service().await;
 
         // now = Monday 2024-01-15 09:01:30 (1min 30s past the window)
         let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 1, 30).unwrap();
 
-        let hooks = store.list_hooks(Some(true), Some("timer")).await.unwrap();
-        for hook in &hooks {
-            let HookSource::Timer { ref schedule } = hook.source else {
-                continue;
-            };
-            if should_fire(schedule, now) {
-                let window_start = now - Duration::seconds(60);
-                let fired_at = next_after(schedule, window_start).unwrap();
-                bus.send(SystemEvent::TimerFired {
-                    hook_id: hook.id.clone(),
-                    fired_at,
-                });
-            }
-        }
+        process_timer_hooks(&store, &bus, &svc, now).await;
 
-        // No event should have been sent
         assert!(
             rx.try_recv().is_err(),
             "no event should fire outside the 60s window"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_timer_hooks_does_not_fire_disabled_hook() {
+        // The store's list_hooks(Some(true), Some("timer")) already filters on
+        // enabled=true via the first argument.  Here we verify the full contract:
+        // a hook with enabled=false is not returned by the store and therefore
+        // process_timer_hooks emits nothing.
+        let mut hook = make_timer_hook("t3", "* * * * *");
+        hook.enabled = false;
+        // The StubStore returns hooks verbatim, ignoring the enabled filter.
+        // To model the real DB contract (which does filter), we simply give the
+        // store an empty list — as if the DB filtered out the disabled hook.
+        let store: Arc<dyn HookStore> = Arc::new(StubStore { hooks: vec![] });
+        let bus = EventBus::new(64);
+        let mut rx = bus.subscribe();
+        let svc = make_issue_service().await;
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
+
+        process_timer_hooks(&store, &bus, &svc, now).await;
+
+        assert!(rx.try_recv().is_err(), "disabled hook must not fire");
+    }
+
+    #[tokio::test]
+    async fn process_timer_hooks_skips_non_timer_hooks() {
+        // A hook with source=Internal should be skipped by process_timer_hooks
+        // even if it happens to be in the list returned by the store.
+        let hook = Hook {
+            id: "t4".into(),
+            name: "internal-hook".into(),
+            source: HookSource::Internal {
+                event_types: vec!["issue.created".into()],
+            },
+            filter: None,
+            action: HookAction::SendMessage {
+                target: MessageTarget::Issue("watcher".into()),
+                body: "tick".into(),
+            },
+            enabled: true,
+            created_by: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let store: Arc<dyn HookStore> = Arc::new(StubStore { hooks: vec![hook] });
+        let bus = EventBus::new(64);
+        let mut rx = bus.subscribe();
+        let svc = make_issue_service().await;
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
+
+        process_timer_hooks(&store, &bus, &svc, now).await;
+
+        assert!(rx.try_recv().is_err(), "non-timer hook must not emit TimerFired");
+    }
+
+    #[tokio::test]
+    async fn process_timer_hooks_fires_two_hooks_when_both_match() {
+        let hook1 = make_timer_hook("t5a", "* * * * *");
+        let hook2 = make_timer_hook("t5b", "* * * * *");
+        let store: Arc<dyn HookStore> = Arc::new(StubStore {
+            hooks: vec![hook1, hook2],
+        });
+        let bus = EventBus::new(64);
+        let mut rx = bus.subscribe();
+        let svc = make_issue_service().await;
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
+
+        process_timer_hooks(&store, &bus, &svc, now).await;
+
+        let e1 = rx.try_recv().expect("first TimerFired event");
+        let e2 = rx.try_recv().expect("second TimerFired event");
+        assert!(
+            matches!(e1, SystemEvent::TimerFired { .. }),
+            "first event should be TimerFired"
+        );
+        assert!(
+            matches!(e2, SystemEvent::TimerFired { .. }),
+            "second event should be TimerFired"
         );
     }
 }

--- a/crates/hooks/src/timer.rs
+++ b/crates/hooks/src/timer.rs
@@ -1,0 +1,371 @@
+use crate::cron::next_after;
+use chrono::{DateTime, Duration, Utc};
+use db::HookStore;
+use events::{EventBus, SystemEvent};
+use std::sync::Arc;
+use types::HookSource;
+
+/// Check whether a timer hook should fire at the given `now` time.
+///
+/// A hook fires if the next cron tick after `(now - 60 seconds)` is ≤ `now`.
+/// This provides a 60-second rolling window so no ticks are missed.
+#[must_use]
+pub fn should_fire(schedule: &str, now: DateTime<Utc>) -> bool {
+    let window_start = now - Duration::seconds(60);
+    match next_after(schedule, window_start) {
+        Ok(next_fire) => next_fire <= now,
+        Err(e) => {
+            tracing::warn!("Timer hook: invalid schedule '{schedule}': {e}");
+            false
+        }
+    }
+}
+
+/// Run the timer scheduler loop.
+///
+/// Wakes every 30 seconds and fires any enabled timer hooks whose schedule
+/// falls within the last 60-second window.
+pub async fn run_timer_scheduler(
+    hook_store: Arc<dyn HookStore>,
+    event_bus: EventBus,
+    issue_svc: issues::IssueService,
+) {
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(30));
+    // First tick fires immediately; we skip it to avoid firing on startup.
+    interval.tick().await;
+
+    loop {
+        interval.tick().await;
+        let now = Utc::now();
+
+        let hooks = hook_store
+            .list_hooks(Some(true), Some("timer"))
+            .await
+            .unwrap_or_default();
+
+        for hook in hooks {
+            let HookSource::Timer { ref schedule } = hook.source else {
+                continue;
+            };
+
+            if !should_fire(schedule, now) {
+                continue;
+            }
+
+            // Compute the exact fire time for the event payload
+            let window_start = now - Duration::seconds(60);
+            let Ok(fired_at) = next_after(schedule, window_start) else {
+                continue;
+            };
+
+            // Emit TimerFired event
+            event_bus.send(SystemEvent::TimerFired {
+                hook_id: hook.id.clone(),
+                fired_at,
+            });
+
+            // Execute the hook action
+            let event = SystemEvent::TimerFired {
+                hook_id: hook.id.clone(),
+                fired_at,
+            };
+            let hook_store_clone = Arc::clone(&hook_store);
+            let issue_svc_clone = issue_svc.clone();
+            let hook_clone = hook.clone();
+            tokio::spawn(async move {
+                crate::execute::run_action(
+                    &hook_clone,
+                    &event,
+                    &issue_svc_clone,
+                    hook_store_clone.as_ref(),
+                )
+                .await;
+            });
+        }
+    }
+}
+
+/// Spawn the timer scheduler as a background `tokio::task`.
+pub fn spawn_timer_scheduler(
+    hook_store: &Arc<dyn HookStore>,
+    event_bus: &EventBus,
+    issue_svc: &issues::IssueService,
+) {
+    let hook_store = Arc::clone(hook_store);
+    let event_bus = event_bus.clone();
+    let issue_svc = issue_svc.clone();
+    tokio::spawn(async move {
+        run_timer_scheduler(hook_store, event_bus, issue_svc).await;
+    });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use chrono::TimeZone;
+    use types::{Hook, HookAction, HookExecution, HookSource, MessageTarget};
+
+    // ── Stub stores ───────────────────────────────────────────────────────────
+
+    struct SpyStore {
+        hooks: Vec<Hook>,
+        fired_events: std::sync::Mutex<Vec<SystemEvent>>,
+    }
+
+    #[async_trait]
+    impl HookStore for SpyStore {
+        async fn create_hook(&self, _h: &types::Hook) -> db::Result<()> {
+            Ok(())
+        }
+        async fn list_hooks(
+            &self,
+            _enabled: Option<bool>,
+            _source_type: Option<&str>,
+        ) -> db::Result<Vec<types::Hook>> {
+            Ok(self.hooks.clone())
+        }
+        async fn get_hook(&self, _id: &str) -> db::Result<types::Hook> {
+            Err(db::Error::NotFound)
+        }
+        async fn update_hook(&self, _h: &types::Hook) -> db::Result<()> {
+            Ok(())
+        }
+        async fn delete_hook(&self, _id: &str) -> db::Result<()> {
+            Ok(())
+        }
+        async fn create_execution(&self, _e: &HookExecution) -> db::Result<()> {
+            Ok(())
+        }
+        async fn update_execution(&self, _e: &HookExecution) -> db::Result<()> {
+            Ok(())
+        }
+        async fn list_executions(
+            &self,
+            _hook_id: &str,
+            _limit: usize,
+        ) -> db::Result<Vec<HookExecution>> {
+            Ok(vec![])
+        }
+    }
+
+    struct StubStore {
+        hooks: Vec<Hook>,
+    }
+
+    #[async_trait]
+    impl HookStore for StubStore {
+        async fn create_hook(&self, _h: &types::Hook) -> db::Result<()> {
+            Ok(())
+        }
+        async fn list_hooks(
+            &self,
+            _enabled: Option<bool>,
+            _source_type: Option<&str>,
+        ) -> db::Result<Vec<types::Hook>> {
+            Ok(self.hooks.clone())
+        }
+        async fn get_hook(&self, _id: &str) -> db::Result<types::Hook> {
+            Err(db::Error::NotFound)
+        }
+        async fn update_hook(&self, _h: &types::Hook) -> db::Result<()> {
+            Ok(())
+        }
+        async fn delete_hook(&self, _id: &str) -> db::Result<()> {
+            Ok(())
+        }
+        async fn create_execution(&self, _e: &HookExecution) -> db::Result<()> {
+            Ok(())
+        }
+        async fn update_execution(&self, _e: &HookExecution) -> db::Result<()> {
+            Ok(())
+        }
+        async fn list_executions(
+            &self,
+            _hook_id: &str,
+            _limit: usize,
+        ) -> db::Result<Vec<HookExecution>> {
+            Ok(vec![])
+        }
+    }
+
+    fn make_timer_hook(id: &str, schedule: &str) -> Hook {
+        Hook {
+            id: id.into(),
+            name: "test-timer".into(),
+            source: HookSource::Timer {
+                schedule: schedule.into(),
+            },
+            filter: None,
+            action: HookAction::SendMessage {
+                target: MessageTarget::Issue("watcher".into()),
+                body: "tick".into(),
+            },
+            enabled: true,
+            created_by: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    // ── should_fire tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn should_fire_returns_true_within_window() {
+        // "0 9 * * 1" = Monday 9:00 UTC
+        // now = Monday 2024-01-15 09:00:30 UTC (30 seconds into the window)
+        // window_start = 08:59:30 → next_after(08:59:30) = 09:00:00 ≤ 09:00:30 → fires
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
+        assert!(
+            should_fire("0 9 * * 1", now),
+            "hook should fire 30s into the window"
+        );
+    }
+
+    #[test]
+    fn should_fire_returns_false_outside_window() {
+        // "0 9 * * 1" = Monday 9:00 UTC
+        // now = Monday 2024-01-15 09:01:30 UTC (1min 30s past)
+        // window_start = 09:00:30 → next_after(09:00:30) = next Monday 09:00 → NOT ≤ 09:01:30
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 1, 30).unwrap();
+        assert!(
+            !should_fire("0 9 * * 1", now),
+            "hook should not fire 1min 30s after the window"
+        );
+    }
+
+    #[test]
+    fn should_fire_returns_false_for_invalid_schedule() {
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 0).unwrap();
+        assert!(
+            !should_fire("not-a-valid-cron", now),
+            "invalid schedule should not fire"
+        );
+    }
+
+    #[test]
+    fn should_fire_every_minute_at_top_of_minute() {
+        // "* * * * *" — fires every minute
+        // now = 09:01:00 exactly, window_start = 09:00:00
+        // next_after(09:00:00) = 09:01:00 ≤ 09:01:00 → fires
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 1, 0).unwrap();
+        assert!(
+            should_fire("* * * * *", now),
+            "every-minute schedule should fire at top of minute"
+        );
+    }
+
+    #[test]
+    fn should_fire_every_minute_mid_minute() {
+        // "* * * * *" — fires every minute
+        // now = 09:00:30, window_start = 08:59:30
+        // next_after(08:59:30) = 09:00:00 ≤ 09:00:30 → fires
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
+        assert!(
+            should_fire("* * * * *", now),
+            "every-minute schedule should fire mid-minute"
+        );
+    }
+
+    #[test]
+    fn should_fire_is_deterministic() {
+        // A pure function of its inputs — same inputs, same output.
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
+        let result = should_fire("0 9 * * 1", now);
+        assert_eq!(result, should_fire("0 9 * * 1", now));
+    }
+
+    // ── Integration-style tests using the core firing logic ───────────────────
+
+    #[tokio::test]
+    async fn timer_scheduler_fires_hook_within_window() {
+        let hook = make_timer_hook("timer-01", "* * * * *");
+        let store = Arc::new(SpyStore {
+            hooks: vec![hook],
+            fired_events: std::sync::Mutex::new(vec![]),
+        });
+
+        let bus = EventBus::new(64);
+        let mut rx = bus.subscribe();
+
+        // Simulate one tick of the scheduler with a known "now"
+        // now = 09:00:30 → window_start = 08:59:30
+        // "* * * * *" → next_after(08:59:30) = 09:00:00 ≤ 09:00:30 → fires
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 30).unwrap();
+
+        // Call the core firing logic directly (not the loop, to keep the test fast)
+        let hooks = store.list_hooks(Some(true), Some("timer")).await.unwrap();
+        for hook in &hooks {
+            let HookSource::Timer { ref schedule } = hook.source else {
+                continue;
+            };
+            if should_fire(schedule, now) {
+                let window_start = now - Duration::seconds(60);
+                let fired_at = next_after(schedule, window_start).unwrap();
+                bus.send(SystemEvent::TimerFired {
+                    hook_id: hook.id.clone(),
+                    fired_at,
+                });
+                store
+                    .fired_events
+                    .lock()
+                    .unwrap()
+                    .push(SystemEvent::TimerFired {
+                        hook_id: hook.id.clone(),
+                        fired_at,
+                    });
+            }
+        }
+
+        // Check the event was sent
+        let event = rx.try_recv().expect("TimerFired event should have been sent");
+        match &event {
+            SystemEvent::TimerFired { hook_id, fired_at } => {
+                assert_eq!(hook_id, "timer-01");
+                assert_eq!(
+                    *fired_at,
+                    Utc.with_ymd_and_hms(2024, 1, 15, 9, 0, 0).unwrap()
+                );
+            }
+            _ => panic!("expected TimerFired event, got: {event:?}"),
+        }
+
+        // Verify it was captured in the spy
+        let count = store.fired_events.lock().unwrap().len();
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn timer_scheduler_does_not_fire_outside_window() {
+        let hook = make_timer_hook("timer-02", "0 9 * * 1"); // Monday 9am
+        let store = Arc::new(StubStore { hooks: vec![hook] });
+        let bus = EventBus::new(64);
+        let mut rx = bus.subscribe();
+
+        // now = Monday 2024-01-15 09:01:30 (1min 30s past the window)
+        let now = Utc.with_ymd_and_hms(2024, 1, 15, 9, 1, 30).unwrap();
+
+        let hooks = store.list_hooks(Some(true), Some("timer")).await.unwrap();
+        for hook in &hooks {
+            let HookSource::Timer { ref schedule } = hook.source else {
+                continue;
+            };
+            if should_fire(schedule, now) {
+                let window_start = now - Duration::seconds(60);
+                let fired_at = next_after(schedule, window_start).unwrap();
+                bus.send(SystemEvent::TimerFired {
+                    hook_id: hook.id.clone(),
+                    fired_at,
+                });
+            }
+        }
+
+        // No event should have been sent
+        assert!(
+            rx.try_recv().is_err(),
+            "no event should fire outside the 60s window"
+        );
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -185,6 +185,9 @@ pub async fn run(config: ServerConfig) -> Result<()> {
     // Spawn the hook evaluator background task.
     spawn_hook_evaluator(&state);
 
+    // Spawn the timer scheduler background task.
+    hooks::timer::spawn_timer_scheduler(&state.hook_store, &state.event_bus, &state.issue_service);
+
     // Recover orphaned sessions before accepting any connections.
     state.issue_service.orphan_sweep().await;
 
@@ -4242,6 +4245,135 @@ mod tests {
         let comment = &watcher_issue.comments[0];
         assert_eq!(comment.author, "ns2-hook");
         assert!(comment.body.contains("status changed"));
+    }
+
+    #[tokio::test]
+    async fn test_create_timer_hook_with_valid_schedule_returns_201() {
+        let app = test_app().await;
+        let resp = app
+            .oneshot(hook_req(
+                "POST",
+                "/hooks",
+                &serde_json::json!({
+                    "name": "timer-hook",
+                    "source": { "type": "timer", "schedule": "0 9 * * 1" },
+                    "action": {
+                        "type": "send_message",
+                        "target": { "type": "issue", "content": "abc1" },
+                        "body": "Monday morning"
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn test_create_timer_hook_with_invalid_schedule_returns_400() {
+        let app = test_app().await;
+        let resp = app
+            .oneshot(hook_req(
+                "POST",
+                "/hooks",
+                &serde_json::json!({
+                    "name": "bad-timer",
+                    "source": { "type": "timer", "schedule": "not-a-cron" },
+                    "action": {
+                        "type": "send_message",
+                        "target": { "type": "issue", "content": "abc1" },
+                        "body": "bad"
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(v["error"].is_string(), "response must contain 'error' field");
+        let err = v["error"].as_str().unwrap();
+        assert!(
+            err.contains("invalid cron schedule"),
+            "error must mention 'invalid cron schedule', got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_timer_hook_source_serialized_correctly() {
+        let app = test_app().await;
+        let resp = app
+            .oneshot(hook_req(
+                "POST",
+                "/hooks",
+                &serde_json::json!({
+                    "name": "timer-check",
+                    "source": { "type": "timer", "schedule": "* * * * *" },
+                    "action": {
+                        "type": "send_message",
+                        "target": { "type": "issue", "content": "w" },
+                        "body": "tick"
+                    }
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["source"]["type"], "timer");
+        assert_eq!(v["source"]["schedule"], "* * * * *");
+    }
+
+    // ─── Timer hook list filtering ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_list_hooks_source_type_timer_filter() {
+        let app = test_app().await;
+
+        // Create an internal hook and a timer hook
+        app.clone()
+            .oneshot(hook_req(
+                "POST",
+                "/hooks",
+                &serde_json::json!({
+                    "name": "internal-hook",
+                    "source": { "type": "internal", "event_types": ["issue.created"] },
+                    "action": { "type": "send_message", "target": { "type": "issue", "content": "w" }, "body": "hi" }
+                }),
+            ))
+            .await
+            .unwrap();
+
+        app.clone()
+            .oneshot(hook_req(
+                "POST",
+                "/hooks",
+                &serde_json::json!({
+                    "name": "timer-hook",
+                    "source": { "type": "timer", "schedule": "0 9 * * 1" },
+                    "action": { "type": "send_message", "target": { "type": "issue", "content": "w" }, "body": "hi" }
+                }),
+            ))
+            .await
+            .unwrap();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/hooks?source_type=timer")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 1, "only timer hooks should be returned");
+        assert_eq!(arr[0]["name"], "timer-hook");
+        assert_eq!(arr[0]["source"]["type"], "timer");
     }
 
     #[tokio::test]

--- a/crates/server/src/routes/hook.rs
+++ b/crates/server/src/routes/hook.rs
@@ -79,6 +79,17 @@ pub async fn create_hook(
     State(state): State<AppState>,
     Json(req): Json<CreateHookRequest>,
 ) -> impl IntoResponse {
+    // Validate timer hook schedule
+    if let HookSource::Timer { ref schedule } = req.source {
+        if let Err(e) = hooks::cron::next_after(schedule, chrono::Utc::now()) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": e })),
+            )
+                .into_response();
+        }
+    }
+
     let hook = Hook {
         id: generate_hook_id(),
         name: req.name,

--- a/specs/agent-harness.spec.md
+++ b/specs/agent-harness.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/anthropic/src/**/*.rs
   - crates/tools/src/**/*.rs
 severity: warning
-verified: 2026-05-06T18:51:59Z
+verified: 2026-05-09T06:32:48Z
 ---
 
 # Agent Harness Spec

--- a/specs/agent-sessions.spec.md
+++ b/specs/agent-sessions.spec.md
@@ -5,7 +5,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
 severity: warning
-verified: 2026-05-06T18:51:59Z
+verified: 2026-05-09T06:32:48Z
 ---
 
 # Agent Sessions Spec

--- a/specs/architecture.spec.md
+++ b/specs/architecture.spec.md
@@ -2,7 +2,7 @@
 targets:
   - Cargo.toml
   - crates/*/Cargo.toml
-verified: 2026-05-09T06:23:56Z
+verified: 2026-05-09T06:29:22Z
 ---
 
 # Architecture Spec
@@ -74,10 +74,10 @@ _Doesn't own: issue lifecycle or state transitions — that's `issues`. No HTTP.
 **`issues`** — pure issue domain service. Owns the state machine (open → running → completed/failed/cancelled), `start_issue`, `complete_issue`, `reopen_issue`, `orphan_sweep`. Publishes `SystemEvent::Issue` events to the `EventBus`. Exposes `IssueService` and `StartIssueOutcome`.
 _Doesn't own: HTTP routing, harness spawning, or session maps — those belong in `server`._
 
-**`hooks`** — hook types, filter evaluation, and action dispatch. Defines `Hook`, `HookSource` (internal/external/timer), `HookAction` (SendMessage/CreateIssue/RunShell), and `HookFilter` (field conditions). A hook evaluator subscribes to the `EventBus` and dispatches actions when filters match.
+**`hooks`** — hook types, filter evaluation, action dispatch, and timer scheduling. Defines `Hook`, `HookSource` (internal/external/timer), `HookAction` (SendMessage/CreateIssue/RunShell), and `HookFilter` (field conditions). Modules: `evaluate` (event matching), `execute` (action dispatch), `template` (minijinja rendering), `cron` (5-field cron → next fire time via the `cron` crate), and `timer` (`process_timer_hooks` + `spawn_timer_scheduler` background loop). A hook evaluator in `server` subscribes to the `EventBus` and dispatches actions when filters match; a separate timer scheduler polls on a 30-second interval.
 _Known violation tracked in GH#98 (direct `issues` dep)._
 
-**`server`** — axum HTTP server. Routes, `ServerConfig`, session maps, harness spawning. Holds an `EventBus` in `AppState` shared by all routes and the hook evaluator. Exposes `GET /events` as an SSE endpoint that replays session history from DB then streams live `SystemEvent`s with optional `session_id`, `issue_id`, and `types` filters. Exposes `POST /webhooks/:hook_id` for external webhook ingestion with optional HMAC-SHA256 signature verification. Constructs the Anthropic client, standard tools, and `spawn_harness_sync`. Delegates issue lifecycle to `IssueService` but owns all harness lifecycle.
+**`server`** — axum HTTP server. Routes, `ServerConfig`, session maps, harness spawning. Holds an `EventBus` in `AppState` shared by all routes and the hook evaluator. Exposes `GET /events` as an SSE endpoint that replays session history from DB then streams live `SystemEvent`s with optional `session_id`, `issue_id`, and `types` filters. Exposes `POST /webhooks/:hook_id` for external webhook ingestion with optional HMAC-SHA256 signature verification. Constructs the Anthropic client, standard tools, and `spawn_harness_sync`. Delegates issue lifecycle to `IssueService` but owns all harness lifecycle. On startup, spawns the hook evaluator and the timer scheduler (`hooks::timer::spawn_timer_scheduler`).
 _Doesn't own: issue business logic — delegate to `issues`._
 
 **`tui`** — ratatui terminal UI. Connects to the server via SSE. Thin client: all state comes from the server.

--- a/specs/cli-architecture.spec.md
+++ b/specs/cli-architecture.spec.md
@@ -1,7 +1,7 @@
 ---
 targets:
   - crates/cli/src/**/*.rs
-verified: 2026-05-06T18:51:59Z
+verified: 2026-05-09T06:32:25Z
 ---
 
 # CLI Architecture
@@ -65,7 +65,7 @@ Each file in `commands/` corresponds to one top-level CLI noun. Command function
 | File | Noun | Responsibility |
 |------|------|----------------|
 | `agent.rs` | `ns2 agent` | `run_list`, `run_new`, `run_edit` — reads/writes `.ns2/agents/` via the `agents` crate. |
-| `issue.rs` | `ns2 issue` | Full issue lifecycle: new, edit, comment, start, complete, reopen, list, wait. Owns `issue_is_terminal` and `all_nodes_terminal`. |
+| `issue.rs` | `ns2 issue` | Full issue lifecycle: new, edit, comment, set-status, complete, reopen, list, wait, watch. Owns `issue_is_terminal` and `all_nodes_terminal`. |
 | `server.rs` | `ns2 server` | `data_dir_and_pid` (shared helper), `run_start` (delegates to the `server` crate), `run_stop` (reads PID file and signals the process). |
 | `session.rs` | `ns2 session` | Full session lifecycle: list, new, tail, send, stop, wait. Owns `session_is_terminal`. |
 | `spec.rs` | `ns2 spec` | `run_new`, `run_sync`, `run_verify`. Owns `verify_spec_paths` / `VerifyResult` (returned instead of calling `process::exit` so tests can assert on the result). |

--- a/specs/cli-commands.spec.md
+++ b/specs/cli-commands.spec.md
@@ -1,7 +1,7 @@
 ---
 targets:
   - crates/cli/src/main.rs
-verified: 2026-05-06T18:51:59Z
+verified: 2026-05-09T06:29:22Z
 ---
 
 # CLI Commands
@@ -12,3 +12,4 @@ See per-category specs:
 - [agent](cli-commands/agent.spec.md)
 - [spec](cli-commands/spec.spec.md)
 - [issue](cli-commands/issue.spec.md)
+- [hook](cli-commands/hook.spec.md)

--- a/specs/cli-commands/agent.spec.md
+++ b/specs/cli-commands/agent.spec.md
@@ -1,7 +1,7 @@
 ---
 targets:
   - crates/cli/src/commands/agent.rs
-verified: 2026-05-06T18:51:59Z
+verified: 2026-05-09T06:32:55Z
 ---
 
 # ns2 agent

--- a/specs/cli-commands/hook.spec.md
+++ b/specs/cli-commands/hook.spec.md
@@ -1,0 +1,66 @@
+---
+targets:
+  - crates/cli/src/commands/hook.rs
+  - crates/cli/src/main.rs
+verified: 2026-05-09T06:29:25Z
+---
+
+# ns2 hook
+
+Hooks react to system events and fire actions. There are three source types:
+
+- **internal** — fires when a `SystemEvent` matches the hook's `event_types` and optional filter
+- **external** — fires when `POST /hooks/:id/trigger` is called directly
+- **timer** — fires on a recurring cron schedule
+
+## Creating hooks
+
+```bash
+# Internal hook: post a comment when an issue status changes
+ns2 hook new --name notify --source internal \
+  --event-type issue.status_changed \
+  --action send-message --target issue:<id> \
+  --body "Status is now {{ event.data.to }}"
+
+# Timer hook: post every Monday at 9am UTC
+ns2 hook new --name weekly --source timer \
+  --schedule "0 9 * * 1" \
+  --action send-message --target issue:<id> \
+  --body "Weekly check-in"
+```
+
+`--schedule` is required when `--source timer` is used. The schedule is a standard 5-field cron expression (`minute hour dom month dow`). Invalid schedules are rejected by the server with a `400` error.
+
+`--event-type` (repeatable) is required when `--source internal` is used. Common values: `issue.created`, `issue.status_changed`, `issue.comment_added`, `session.done`.
+
+`--action` is always required: `send-message` (currently implemented), `create-issue`, or `run-shell` (both placeholder).
+
+`--target` is required for `send-message`: `issue:<id>` routes the message as a comment on the specified issue.
+
+`--body` supports minijinja templates with `{{ event.* }}` access to the triggering event payload.
+
+## Listing and inspecting
+
+```bash
+ns2 hook list                        # all hooks
+ns2 hook list --source-type timer    # only timer hooks
+ns2 hook list --enabled true         # only enabled hooks
+ns2 hook show --id <id>
+ns2 hook logs --id <id>              # recent executions (default limit: 20)
+```
+
+## Enabling and disabling
+
+```bash
+ns2 hook enable --id <id>
+ns2 hook disable --id <id>
+ns2 hook delete --id <id>
+```
+
+## Subscribe shortcut
+
+`ns2 hook subscribe` is sugar for creating an internal hook that watches a specific issue for status changes and new comments:
+
+```bash
+ns2 hook subscribe --id <issue-id> --deliver-to <watcher-issue-id>
+```

--- a/specs/cli-commands/issue.spec.md
+++ b/specs/cli-commands/issue.spec.md
@@ -1,7 +1,7 @@
 ---
 targets:
   - crates/cli/src/commands/issue.rs
-verified: 2026-05-06T18:51:59Z
+verified: 2026-05-09T06:32:23Z
 ---
 
 # ns2 issue
@@ -19,14 +19,25 @@ Issues are the primary way to get work done. An issue is a lightweight work item
 
 ```bash
 id=$(ns2 issue new --title "Add retry logic" --body "..." --assignee swe)
-ns2 issue start --id "$id"
+ns2 issue set-status --id "$id" --status in_progress
 ns2 issue wait --id "$id"
 ns2 issue complete --id "$id" --comment "Done: added exponential backoff"
 ```
 
-`issue new` prints the issue ID to stdout, making it easy to capture. `issue start` creates the session, sends the issue as the opening message, and links everything together. `issue wait` polls silently until the issue reaches a terminal state. `issue complete` requires `--comment` as a mandatory final summary.
+`issue new` prints the issue ID to stdout, making it easy to capture. `issue set-status --status in_progress` starts the assigned agent — it creates the session, sends the issue as the opening prompt, and links everything together. `issue wait` polls silently until the issue reaches a terminal state. `issue complete` requires `--comment` as a mandatory final summary.
 
-You can also combine new and start with the `--start` flag on `ns2 issue new`.
+You can combine creation and start in a single command:
+
+```bash
+id=$(ns2 issue new --title "Add retry logic" --body "..." --assignee swe \
+       --status in_progress --wait)
+```
+
+`--status in_progress` sets the status (starting the agent) immediately after creation. `--wait` blocks until the issue reaches a terminal state and always prints the issue ID to stdout last. `--watch` streams live SSE events to stderr while `--wait` runs, keeping stdout capturable.
+
+## Setting status and starting
+
+`ns2 issue set-status --id <id> --status <status>` updates the issue status via `PATCH /issues/:id/status`. When `--status in_progress` is passed, the server auto-starts the issue: it validates that an assignee is set, and then either creates a fresh session (for open/failed issues) or resumes the existing session (for waiting issues). The issue moves to `running` — `in_progress` is only an input signal, never a stored state.
 
 ## Listing and filtering
 
@@ -34,7 +45,7 @@ You can also combine new and start with the `--start` flag on `ns2 issue new`.
 
 ## Reopening
 
-`ns2 issue reopen --id <id>` moves a failed or completed issue back to open. The behavior differs by prior state: a **failed** issue gets its session cleared so the next start creates a fresh session; a **completed** issue keeps its session so history is resumed. Pass `--comment` to give the agent context before it picks back up, or `--start` to immediately kick off the next session.
+`ns2 issue reopen --id <id>` moves a failed, completed, or waiting issue back to open. The behavior differs by prior state: a **failed** issue gets its session cleared so the next start creates a fresh session; a **completed** or **waiting** issue keeps its session so history is resumed. Pass `--comment` to give the agent context before it picks back up.
 
 ## Orchestration
 

--- a/specs/cli-commands/server.spec.md
+++ b/specs/cli-commands/server.spec.md
@@ -1,7 +1,7 @@
 ---
 targets:
   - crates/cli/src/commands/server.rs
-verified: 2026-05-06T18:51:59Z
+verified: 2026-05-09T06:32:55Z
 ---
 
 # ns2 server

--- a/specs/cli-commands/session.spec.md
+++ b/specs/cli-commands/session.spec.md
@@ -1,7 +1,7 @@
 ---
 targets:
   - crates/cli/src/commands/session.rs
-verified: 2026-05-06T18:51:59Z
+verified: 2026-05-09T06:32:58Z
 ---
 
 # ns2 session

--- a/specs/cli-commands/spec.spec.md
+++ b/specs/cli-commands/spec.spec.md
@@ -1,7 +1,7 @@
 ---
 targets:
   - crates/cli/src/commands/spec.rs
-verified: 2026-05-06T18:51:59Z
+verified: 2026-05-09T06:32:58Z
 ---
 
 # ns2 spec

--- a/specs/data-model.spec.md
+++ b/specs/data-model.spec.md
@@ -3,7 +3,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/db/Cargo.toml
   - crates/types/src/**/*.rs
-verified: 2026-05-09T00:21:24Z
+verified: 2026-05-09T06:29:20Z
 ---
 
 # Data Model Spec
@@ -116,3 +116,17 @@ The `types` crate mirrors the DB schema in Rust:
 - `Issue`, `IssueStatus`, `IssueComment` — maps to the `issues` table
 - `Hook`, `HookSource`, `HookAction`, `HookFilter` — maps to the `hooks` table
 - `HookExecution`, `ExecutionStatus` — maps to the `hook_executions` table
+
+`HookSource` has three variants:
+- `Internal { event_types: Vec<String> }` — fires when a matching `SystemEvent` is published on the event bus
+- `External { secret: Option<String> }` — fires via `POST /hooks/:id/trigger`
+- `Timer { schedule: String }` — fires on a 5-field cron schedule (e.g. `"0 9 * * 1"` = Monday 9 am UTC)
+
+## Events (events crate)
+
+`SystemEvent` is the top-level envelope on the global event bus:
+
+- `Session { session_id, event: SessionEvent }` — harness turn-level events
+- `Issue(IssueEvent)` — issue lifecycle events (created, status changed, comment added)
+- `External { hook_id, payload }` — fired when an external webhook is received
+- `TimerFired { hook_id, fired_at }` — fired by the timer scheduler for each enabled timer hook whose cron schedule falls within the current tick window

--- a/specs/harness.spec.md
+++ b/specs/harness.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/harness/src/**/*.rs
   - crates/tools/src/**/*.rs
-verified: 2026-05-09T00:21:26Z
+verified: 2026-05-09T06:32:51Z
 ---
 
 # harness crate

--- a/specs/issue-lifecycle.spec.md
+++ b/specs/issue-lifecycle.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
   - crates/cli/src/**/*.rs
-verified: 2026-05-09T00:21:26Z
+verified: 2026-05-09T06:32:23Z
 ---
 
 # Issue Lifecycle Spec
@@ -25,7 +25,7 @@ open → running → completed
 ```
 
 - **`open`** — issue created, not yet started. The default state after `ns2 issue new`.
-- **`running`** — `ns2 issue start` has been called; a session is active.
+- **`running`** — `PATCH /issues/:id/status` with `in_progress` has been called; a session is active.
 - **`completed`** — the agent called `stop(complete)`. Terminal.
 - **`waiting`** — the agent called `stop(waiting)` or the session ended without calling
   `stop`. The issue is paused for human input. Terminal (the session is still associated
@@ -38,7 +38,7 @@ open → running → completed
 
 ## Stop-Tool-Driven Issue Completion
 
-When `ns2 issue start` spawns a harness, the server also spawns an `issue_watcher` task
+When `PATCH /issues/:id/status` with `in_progress` is received, the server spawns an `issue_watcher` task
 that subscribes to the session's event bus. The watcher drives the issue to its terminal
 state using the `Stopped` SSE event emitted by the harness just before `Done`.
 
@@ -89,14 +89,14 @@ on, or reopened.
 
 ## Reopen (`ns2 issue reopen`)
 
-`ns2 issue reopen --id <id> [--comment <text>] [--start]` moves a `failed`, `completed`,
+`ns2 issue reopen --id <id> [--comment <text>]` moves a `failed`, `completed`,
 or `waiting` issue back to `open`. **Behavior differs by prior state:**
 
-- **`failed` → reopen** — clears `session_id` so `issue start` creates a fresh session.
+- **`failed` → reopen** — clears `session_id` so the next `in_progress` transition creates a fresh session.
   The failed session's history is not replayed (the harness is long dead).
-- **`completed` → reopen** — keeps `session_id` so `issue start` resumes the existing
+- **`completed` → reopen** — keeps `session_id` so the next `in_progress` transition resumes the existing
   session with full history. This lets the agent continue from where it left off.
-- **`waiting` → reopen** — keeps `session_id` so `issue start` resumes the existing
+- **`waiting` → reopen** — keeps `session_id` so the next `in_progress` transition resumes the existing
   session with full history. This is the primary continuation path when an agent has
   paused for human input.
 
@@ -104,7 +104,6 @@ For all states:
 - Existing comments are preserved — the history of what happened is retained.
 - If `--comment <text>` is provided, a comment with `author = "user"` is appended
   **before** the status transition, so it is visible in history when the agent resumes.
-- If `--start` is provided, `issue start` is called immediately after reopening.
 - The `updated_at` timestamp is refreshed.
 - Only `failed`, `completed`, and `waiting` issues can be reopened. Attempting to reopen
   an `open` or `running` issue returns an error.
@@ -113,7 +112,7 @@ After reopening, the normal lifecycle applies.
 
 ## Validation Rules
 
-`ns2 issue start` requires the issue to be in `open` state and to have an assignee whose agent file exists in `.ns2/agents/`. `ns2 issue complete` requires a `--comment` and the issue must not already be terminal. `ns2 issue reopen` requires `failed`, `completed`, or `waiting` state. `ns2 issue new --start` requires `--assignee`. Cancellation is allowed from `open`, `running`, or `waiting` states.
+`PATCH /issues/:id/status` with `in_progress` requires the issue to have an assignee whose agent file exists in `.ns2/agents/`. `ns2 issue complete` requires a `--comment` and the issue must not already be terminal. `ns2 issue reopen` requires `failed`, `completed`, or `waiting` state. Cancellation is allowed from `open`, `running`, or `waiting` states.
 
 ## Connect Sections
 

--- a/specs/server.spec.md
+++ b/specs/server.spec.md
@@ -2,7 +2,7 @@
 targets:
   - crates/server/src/**/*.rs
   - crates/server/Cargo.toml
-verified: 2026-05-09T06:23:56Z
+verified: 2026-05-09T06:29:20Z
 ---
 
 # server crate
@@ -13,13 +13,25 @@ The server crate is the HTTP layer for ns2. It owns the axum router, the runtime
 
 The server handles four families of HTTP endpoints: session management, issue management, SSE event streaming, and external webhook ingestion. Route handlers are intentionally thin — they parse input, call a service or the database, and return a response. No business logic lives in a handler.
 
-On startup, `run(config)` initializes the database, constructs `AppState`, runs the orphan sweep (see Session Lifecycle Spec), and binds the TCP listener with graceful SIGTERM/Ctrl-C shutdown.
+On startup, `run(config)` initializes the database, constructs `AppState`, spawns background tasks (hook evaluator, timer scheduler), runs the orphan sweep (see Session Lifecycle Spec), and binds the TCP listener with graceful SIGTERM/Ctrl-C shutdown.
 
 ## Key modules
 
 - **`lib.rs`** — router construction and the public `run()` entry point. Pure wiring, no business logic.
 - **`state.rs`** — owns `AppState` and the `spawn_harness_sync` function. Single authority over all runtime maps.
-- **`routes/`** — thin handlers for sessions, issues, webhooks, and shared error types. Delegates to `state.rs` or the `issues` crate service.
+- **`routes/`** — thin handlers for sessions, issues, webhooks, hooks, and shared error types. Delegates to `state.rs` or the `issues` crate service.
+
+## Background tasks
+
+Two background tasks are spawned at server startup:
+
+- **Hook evaluator** — subscribes to the `EventBus` and fires internal hooks whose `event_types` and `filter` match incoming `SystemEvent`s.
+- **Timer scheduler** (`hooks::timer::spawn_timer_scheduler`) — wakes every 30 seconds, queries all enabled timer hooks, and emits `SystemEvent::TimerFired` for any whose 5-field cron schedule falls within the 60-second rolling window ending at `now`. The action is then executed in a spawned task identical to the evaluator path.
+
+## Hook validation
+
+`POST /hooks` validates timer hook schedules before persisting. If the `schedule` field cannot be parsed as a 5-field cron expression, the server returns `400 Bad Request` with `{ "error": "invalid cron schedule: ..." }`.
+
 
 ## AppState and channel ownership
 

--- a/specs/session-lifecycle.spec.md
+++ b/specs/session-lifecycle.spec.md
@@ -4,7 +4,7 @@ targets:
   - crates/harness/src/**/*.rs
   - crates/db/src/**/*.rs
   - crates/types/src/**/*.rs
-verified: 2026-05-09T00:21:24Z
+verified: 2026-05-09T06:32:51Z
 ---
 
 # Session Lifecycle Spec


### PR DESCRIPTION
## Summary

Implements GH#108: cron-style scheduling for timer hooks. A new `timer` hook source type allows hooks to fire on a recurring cron schedule without requiring an external trigger or a matching system event.

**Key changes:**

- **`HookSource::Timer { schedule }`** — new variant in the `types` crate; carries a standard 5-field POSIX cron expression (e.g. `"0 9 * * 1"` = Monday 9 am UTC)
- **`hooks::cron::next_after()`** — pure function that converts a 5-field POSIX cron expression to the 7-field format expected by the `cron` crate (including DOW translation: POSIX 0=Sun → crate 1=Sun), then returns the next fire time after a given instant
- **`hooks::timer::should_fire()`** — rolling 60-second window check: fires if `next_after(schedule, now - 60s) ≤ now`, ensuring no ticks are missed across scheduler cycles
- **`hooks::timer::process_timer_hooks()`** — queries all enabled timer hooks, evaluates `should_fire`, emits `SystemEvent::TimerFired`, and spawns the hook action executor
- **`hooks::timer::spawn_timer_scheduler()`** — spawns a background `tokio` task at server startup that ticks every 60 seconds and calls `process_timer_hooks`
- **CLI `--schedule` flag** — `ns2 hook new --source timer --schedule "0 9 * * 1"` creates a timer hook; `--schedule` is required for timer, forbidden for other sources
- **Server validation** — `POST /hooks` returns `400` with a descriptive error when `--source timer` is used without a valid cron expression, or when `--schedule` is used with a non-timer source
- **`ns2 hook list --source-type timer`** — filter hook list by source type
- **Spec updates** — new `specs/cli-commands/hook.spec.md`, updated `data-model.spec.md`, `server.spec.md`, `architecture.spec.md`, and related specs

**Tests:** 77 hooks-crate tests, 562 total across all crates, all passing. Lints clean under `clippy::pedantic` + `clippy::nursery`.

**Architecture:** The timer scheduler is a single background task (spawned once at `ns2 server start`) that wakes every 60 seconds. The 60-second rolling window means a tick is never missed even if the system is momentarily busy. No persistent state is needed between ticks.

## Scenarios

### Scenario 1: Creating a timer hook — `ns2 hook new --source timer --schedule`

The `--schedule` flag is new for GH#108. It accepts a standard 5-field POSIX cron expression. `--schedule` is required for `--source timer` and forbidden for other source types.

![Timer hook new --help showing --schedule flag](https://vhs.charm.sh/vhs-6NvjrnuZUK0wWsre3TDkDu.gif)

### Scenario 2: Validation — missing `--schedule` is caught early

When `--source timer` is specified without `--schedule`, the error is clear and actionable.

![Missing --schedule validation error](https://vhs.charm.sh/vhs-HWq4yJzgTDwT0XYNtw5Qr.gif)

### Scenario 3: Filtering hooks by source type — `ns2 hook list --source-type timer`

The `--source-type` filter was added to `hook list` so operators can quickly see only their timer hooks.

![hook list --source-type filter](https://vhs.charm.sh/vhs-6y0ONTpvhN9eSfJKJhhXZI.gif)