### PR TITLE
feat(cli): add --subscribe flag to 'ns2 issue new' (GH#133)

### DIFF
--- a/crates/cli/src/commands/issue.rs
+++ b/crates/cli/src/commands/issue.rs
@@ -87,8 +87,10 @@ pub async fn run_new(
     }
 
     // If --subscribe was provided, create a hook subscription now.
+    // Pass `print_id_to_stdout: false` so the hook ID stays on stderr only —
+    // stdout must remain a single line (the issue ID) for `id=$(ns2 issue new …)`.
     if let Some(deliver_to) = subscribe {
-        run_subscribe(server, issue_id.clone(), deliver_to).await;
+        run_subscribe(server, issue_id.clone(), deliver_to, "--subscribe", false).await;
     }
 
     // If --watch, start streaming SSE events to stderr in the background
@@ -643,7 +645,21 @@ async fn run_watch_to(server: &str, id: String, to_stderr: bool) {
 ///
 /// Sugar for creating an internal hook that delivers a notification comment
 /// whenever issue X has a status change or a comment added.
-pub async fn run_subscribe(server: &str, id: String, deliver_to: String) {
+///
+/// `flag_name` is the CLI flag name used at the call site (e.g. `--deliver-to` or
+/// `--subscribe`) — it appears in the error message so users see the flag they typed.
+///
+/// `print_id_to_stdout` controls whether the created hook ID is printed to stdout.
+/// Pass `true` when invoked as the top-level `issue subscribe` subcommand (callers
+/// capture the hook ID via `id=$(ns2 issue subscribe …)`).  Pass `false` when called
+/// from `run_new` so that stdout remains a single line — the issue ID.
+pub async fn run_subscribe(
+    server: &str,
+    id: String,
+    deliver_to: String,
+    flag_name: &str,
+    print_id_to_stdout: bool,
+) {
     let client = reqwest::Client::new();
     let url = format!("{server}/hooks");
 
@@ -654,7 +670,7 @@ pub async fn run_subscribe(server: &str, id: String, deliver_to: String) {
     } else if let Some(rest) = deliver_to.strip_prefix("session:") {
         ("session", rest.to_string())
     } else {
-        eprintln!("Error: --deliver-to must be 'issue:<id>' or 'session:<id>', got: {deliver_to}");
+        eprintln!("Error: {flag_name} must be 'issue:<id>' or 'session:<id>', got: {deliver_to}");
         std::process::exit(1);
     };
 
@@ -700,7 +716,9 @@ pub async fn run_subscribe(server: &str, id: String, deliver_to: String) {
         hook["name"].as_str().unwrap_or(""),
         hook_id
     );
-    println!("{hook_id}");
+    if print_id_to_stdout {
+        println!("{hook_id}");
+    }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/issue.rs
+++ b/crates/cli/src/commands/issue.rs
@@ -36,6 +36,7 @@ pub async fn run_new(
     status: Option<String>,
     wait: bool,
     watch: bool,
+    subscribe: Option<String>,
 ) {
     // Validate: --wait requires --status in_progress
     if wait && status.as_deref() != Some("in_progress") {
@@ -83,6 +84,11 @@ pub async fn run_new(
     // If --status was provided, set it now.
     if let Some(ref s) = status {
         run_set_status(server, issue_id.clone(), s.clone()).await;
+    }
+
+    // If --subscribe was provided, create a hook subscription now.
+    if let Some(deliver_to) = subscribe {
+        run_subscribe(server, issue_id.clone(), deliver_to).await;
     }
 
     // If --watch, start streaming SSE events to stderr in the background

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -409,6 +409,8 @@ enum IssueAction {
         wait: bool,
         #[arg(long, help = "Stream live events for this issue. Works with any status.")]
         watch: bool,
+        #[arg(long, help = "Subscribe to status/comment events on this issue. Value: 'issue:<id>' or 'session:<id>'.")]
+        subscribe: Option<String>,
     },
     #[command(
         about = "Edit an existing issue.",
@@ -696,6 +698,7 @@ async fn main() {
                 status,
                 wait,
                 watch,
+                subscribe,
             } => {
                 commands::issue::run_new(
                     &cli.server,
@@ -708,6 +711,7 @@ async fn main() {
                     status,
                     wait,
                     watch,
+                    subscribe,
                 )
                 .await;
             }
@@ -3073,6 +3077,74 @@ mod tests {
                 assert_eq!(status.as_deref(), Some("in_progress"));
                 assert!(wait);
                 assert!(watch);
+            }
+            _ => panic!("expected issue new command"),
+        }
+    }
+
+    // ─── Scenario A: --subscribe parses correctly in CLI ─────────────────────
+
+    #[test]
+    fn issue_new_subscribe_with_issue_target_parses() {
+        let cli = Cli::try_parse_from([
+            "ns2",
+            "issue",
+            "new",
+            "--title",
+            "T",
+            "--body",
+            "B",
+            "--subscribe",
+            "issue:ab12",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Issue {
+                action: IssueAction::New { subscribe, .. },
+            } => {
+                assert_eq!(subscribe.as_deref(), Some("issue:ab12"));
+            }
+            _ => panic!("expected issue new command"),
+        }
+    }
+
+    // ─── Scenario B: --subscribe is optional (None when not provided) ─────────
+
+    #[test]
+    fn issue_new_no_subscribe_flag_is_none() {
+        let cli =
+            Cli::try_parse_from(["ns2", "issue", "new", "--title", "T", "--body", "B"]).unwrap();
+        match cli.command {
+            Command::Issue {
+                action: IssueAction::New { subscribe, .. },
+            } => {
+                assert!(subscribe.is_none());
+            }
+            _ => panic!("expected issue new command"),
+        }
+    }
+
+    // ─── Scenario C: --subscribe with session target parses ──────────────────
+
+    #[test]
+    fn issue_new_subscribe_with_session_target_parses() {
+        let cli = Cli::try_parse_from([
+            "ns2",
+            "issue",
+            "new",
+            "--title",
+            "T",
+            "--body",
+            "B",
+            "--subscribe",
+            "session:some-uuid",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Issue {
+                action: IssueAction::New { subscribe, .. },
+            } => {
+                assert_eq!(subscribe.as_deref(), Some("session:some-uuid"));
             }
             _ => panic!("expected issue new command"),
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -769,7 +769,8 @@ async fn main() {
                 commands::issue::run_watch(&cli.server, id).await;
             }
             IssueAction::Subscribe { id, deliver_to } => {
-                commands::issue::run_subscribe(&cli.server, id, deliver_to).await;
+                commands::issue::run_subscribe(&cli.server, id, deliver_to, "--deliver-to", true)
+                    .await;
             }
         },
         Command::Hook { action } => match action {

--- a/crates/cli/tests/issue_crud.rs
+++ b/crates/cli/tests/issue_crud.rs
@@ -859,3 +859,86 @@ fn issue_new_watch_prints_id_to_stdout() {
     let json = h.http_get(&format!("/issues/{id}"));
     assert!(json.contains("\"Watch Issue\""), "issue should be created");
 }
+
+// ─── GH#133: --subscribe flag on `issue new` ─────────────────────────────────
+
+// Scenario D: --subscribe causes a POST to /hooks after POST to /issues
+#[test]
+fn issue_new_subscribe_creates_hook() {
+    let mut h = TestHarness::new();
+    h.start_server();
+
+    // Capture both stdout lines: issue id on line 1, hook id on line 2
+    let out = h
+        .ns2()
+        .args([
+            "issue", "new", "--title", "Subscribed", "--body", "b", "--subscribe", "issue:ab12",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "issue new --subscribe should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+
+    assert_eq!(lines.len(), 2, "stdout should have 2 lines: hook id and issue id, got: {stdout:?}");
+
+    let hook_id = lines[0].trim();
+    let issue_id = lines[1].trim();
+
+    // Verify the issue was created
+    let issue_json = h.http_get(&format!("/issues/{issue_id}"));
+    assert!(issue_json.contains("\"Subscribed\""), "issue should be created");
+
+    // Verify the hook was created
+    let hooks_json = h.http_get("/hooks");
+    assert!(hooks_json.contains(hook_id), "hook id should appear in hooks list");
+    assert!(
+        hooks_json.contains(&format!("subscribe-{issue_id}")),
+        "hook name should reference the issue id"
+    );
+}
+
+// Scenario E: without --subscribe, only one POST to /issues (no hook created)
+#[test]
+fn issue_new_without_subscribe_creates_no_hook() {
+    let mut h = TestHarness::new();
+    h.start_server();
+
+    let id = h.ns2_stdout(&["issue", "new", "--title", "No Sub", "--body", "b"]);
+
+    // Verify the issue was created
+    let issue_json = h.http_get(&format!("/issues/{id}"));
+    assert!(issue_json.contains("\"No Sub\""), "issue should be created");
+
+    // stdout should be exactly the issue id (one line), not two lines
+    // We already captured only the id above, verifying no hook id was printed
+
+    // Verify no hooks were created
+    let hooks_json = h.http_get("/hooks");
+    // The hooks list should be empty (no subscribe hook for this issue)
+    assert!(
+        !hooks_json.contains(&format!("subscribe-{id}")),
+        "no hook should be created when --subscribe is absent"
+    );
+}
+
+// Scenario F: --subscribe with invalid target format errors
+#[test]
+fn issue_new_subscribe_invalid_target_format_fails() {
+    let mut h = TestHarness::new();
+    h.start_server();
+
+    h.ns2()
+        .args([
+            "issue", "new", "--title", "T", "--body", "B", "--subscribe", "bad-format",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("'issue:<id>' or 'session:<id>'"));
+}

--- a/crates/cli/tests/issue_crud.rs
+++ b/crates/cli/tests/issue_crud.rs
@@ -946,6 +946,13 @@ fn issue_new_subscribe_hook_id_on_stderr_not_stdout() {
     let stdout = String::from_utf8(out.stdout).unwrap();
     let stderr = String::from_utf8(out.stderr).unwrap();
 
+    // Fail fast if the hook ID could not be extracted — the guard below would
+    // silently pass and the test would give a false green.
+    assert!(
+        hook_id.is_some(),
+        "could not extract hook id from hooks JSON: {hooks_json}"
+    );
+
     // hook id must NOT appear on stdout
     if let Some(hid) = hook_id {
         assert!(
@@ -1018,13 +1025,13 @@ fn issue_new_subscribe_invalid_target_format_fails() {
     );
 }
 
-// Scenario G: --subscribe combined with --wait — issue ID (not hook ID) on stdout,
-// hook is visible in /hooks before the wait loop begins.
+// Scenario G: --subscribe combined with --status — issue ID (not hook ID) on stdout,
+// hook is visible in /hooks. Note: --wait is NOT exercised here; this only confirms
+// the stdout contract holds when both --subscribe and --status flags coexist.
 #[test]
-fn issue_new_subscribe_with_wait_stdout_is_issue_id() {
+fn issue_new_subscribe_with_status_stdout_is_issue_id() {
     let mut h = TestHarness::new();
     h.start_server();
-    write_agent(&h, "swe");
 
     // Use --status open (not in_progress) so --wait is NOT triggered — we just
     // want to confirm the stdout contract holds when both flags coexist structurally.
@@ -1068,5 +1075,148 @@ fn issue_new_subscribe_with_wait_stdout_is_issue_id() {
     assert!(
         hooks_json.contains(&format!("subscribe-{issue_id}")),
         "hook should be named subscribe-{{issue_id}}; hooks: {hooks_json}"
+    );
+}
+
+// Issue 3: Hook payload shape verification.
+// Verifies that the hook created by --subscribe has the correct event_types,
+// filter condition (issue ID match), and action fields.
+#[test]
+fn issue_new_subscribe_hook_payload_shape() {
+    let mut h = TestHarness::new();
+    h.start_server();
+
+    let out = h
+        .ns2()
+        .args([
+            "issue",
+            "new",
+            "--title",
+            "Shape Test",
+            "--body",
+            "b",
+            "--subscribe",
+            "issue:ab12",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "issue new --subscribe should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let issue_id = stdout.trim();
+
+    // Fetch the hooks list and parse as JSON
+    let hooks_json = h.http_get("/hooks");
+    let hooks: serde_json::Value =
+        serde_json::from_str(&hooks_json).expect("GET /hooks should return valid JSON");
+
+    // Find the hook named subscribe-{issue_id}
+    let hook = hooks
+        .as_array()
+        .expect("hooks response should be a JSON array")
+        .iter()
+        .find(|h| h["name"].as_str() == Some(&format!("subscribe-{issue_id}")))
+        .unwrap_or_else(|| panic!("hook named subscribe-{issue_id} should exist in the hooks list"));
+
+    // Verify event_types contains both required event types
+    let event_types = hook["source"]["event_types"]
+        .as_array()
+        .expect("source.event_types should be an array");
+    let event_type_strings: Vec<&str> = event_types
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert!(
+        event_type_strings.contains(&"issue.status_changed"),
+        "event_types should contain 'issue.status_changed'; got: {event_types:?}"
+    );
+    assert!(
+        event_type_strings.contains(&"issue.comment_added"),
+        "event_types should contain 'issue.comment_added'; got: {event_types:?}"
+    );
+
+    // Verify filter condition matches the issue ID
+    let conditions = hook["filter"]["conditions"]
+        .as_array()
+        .expect("filter.conditions should be an array");
+    assert!(
+        !conditions.is_empty(),
+        "filter.conditions should have at least one condition"
+    );
+    let condition_value = conditions[0]["value"].as_str().unwrap_or("");
+    assert_eq!(
+        condition_value, issue_id,
+        "filter.conditions[0].value should equal the issue ID"
+    );
+}
+
+// Issue 4: session: target integration test.
+// Verifies that --subscribe with a session: target creates a hook with session target type.
+#[test]
+fn issue_new_subscribe_with_session_target_creates_hook() {
+    let mut h = TestHarness::new();
+    h.start_server();
+
+    let out = h
+        .ns2()
+        .args([
+            "issue",
+            "new",
+            "--title",
+            "Session Sub",
+            "--body",
+            "b",
+            "--subscribe",
+            "session:abc123",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "issue new --subscribe session:abc123 should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+
+    // stdout must be exactly ONE line: the issue ID
+    assert_eq!(
+        lines.len(),
+        1,
+        "stdout should have exactly 1 line (the issue ID), got: {stdout:?}"
+    );
+    let issue_id = lines[0].trim();
+    assert_eq!(issue_id.len(), 4, "issue ID should be 4 chars, got: {issue_id}");
+
+    // Verify the hook was created for this issue
+    let hooks_json = h.http_get("/hooks");
+    let hooks: serde_json::Value =
+        serde_json::from_str(&hooks_json).expect("GET /hooks should return valid JSON");
+
+    let hook = hooks
+        .as_array()
+        .expect("hooks response should be a JSON array")
+        .iter()
+        .find(|h| h["name"].as_str() == Some(&format!("subscribe-{issue_id}")))
+        .unwrap_or_else(|| panic!("hook named subscribe-{issue_id} should exist"));
+
+    // Verify action target type is "session" and content is "abc123"
+    let action_target = &hook["action"]["target"];
+    assert_eq!(
+        action_target["type"].as_str().unwrap_or(""),
+        "session",
+        "action.target.type should be 'session' for session: subscribe target"
+    );
+    assert_eq!(
+        action_target["content"].as_str().unwrap_or(""),
+        "abc123",
+        "action.target.content should be 'abc123'"
     );
 }

--- a/crates/cli/tests/issue_crud.rs
+++ b/crates/cli/tests/issue_crud.rs
@@ -862,13 +862,14 @@ fn issue_new_watch_prints_id_to_stdout() {
 
 // ─── GH#133: --subscribe flag on `issue new` ─────────────────────────────────
 
-// Scenario D: --subscribe causes a POST to /hooks after POST to /issues
+// Scenario D: --subscribe causes a POST to /hooks after POST to /issues.
+// stdout must remain exactly one line — the issue ID — so that
+// `id=$(ns2 issue new --subscribe ...)` captures the right value.
 #[test]
 fn issue_new_subscribe_creates_hook() {
     let mut h = TestHarness::new();
     h.start_server();
 
-    // Capture both stdout lines: issue id on line 1, hook id on line 2
     let out = h
         .ns2()
         .args([
@@ -886,22 +887,77 @@ fn issue_new_subscribe_creates_hook() {
     let stdout = String::from_utf8(out.stdout).unwrap();
     let lines: Vec<&str> = stdout.trim().lines().collect();
 
-    assert_eq!(lines.len(), 2, "stdout should have 2 lines: hook id and issue id, got: {stdout:?}");
+    // stdout must be exactly ONE line: the issue ID.
+    // The hook ID belongs on stderr (like "Created hook: …"), not stdout.
+    assert_eq!(
+        lines.len(),
+        1,
+        "stdout should have exactly 1 line (the issue ID), got: {stdout:?}"
+    );
 
-    let hook_id = lines[0].trim();
-    let issue_id = lines[1].trim();
+    let issue_id = lines[0].trim();
+    assert_eq!(
+        issue_id.len(),
+        4,
+        "issue ID should be 4 chars, got: {issue_id}"
+    );
+    assert!(
+        issue_id.chars().all(|c| c.is_ascii_alphanumeric()),
+        "issue ID should be alphanumeric, got: {issue_id}"
+    );
 
     // Verify the issue was created
     let issue_json = h.http_get(&format!("/issues/{issue_id}"));
     assert!(issue_json.contains("\"Subscribed\""), "issue should be created");
 
-    // Verify the hook was created
+    // Verify the hook was created and named after the issue
     let hooks_json = h.http_get("/hooks");
-    assert!(hooks_json.contains(hook_id), "hook id should appear in hooks list");
     assert!(
         hooks_json.contains(&format!("subscribe-{issue_id}")),
-        "hook name should reference the issue id"
+        "hook name should reference the issue id; hooks: {hooks_json}"
     );
+}
+
+// Scenario D2: the hook ID appears on stderr (not stdout) when --subscribe is used.
+#[test]
+fn issue_new_subscribe_hook_id_on_stderr_not_stdout() {
+    let mut h = TestHarness::new();
+    h.start_server();
+
+    let out = h
+        .ns2()
+        .args([
+            "issue", "new", "--title", "Sub Stderr", "--body", "b", "--subscribe", "issue:ab12",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(out.status.success());
+
+    // Fetch the hook that was created
+    let hooks_json = h.http_get("/hooks");
+    // Extract the hook id from the hooks list
+    let hook_id_start = hooks_json.find("\"id\":\"").map(|i| i + 6);
+    let hook_id = hook_id_start.map(|start| {
+        let end = hooks_json[start..].find('"').unwrap() + start;
+        &hooks_json[start..end]
+    });
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+
+    // hook id must NOT appear on stdout
+    if let Some(hid) = hook_id {
+        assert!(
+            !stdout.contains(hid),
+            "hook id {hid:?} must not appear on stdout; stdout: {stdout:?}"
+        );
+        // hook id MUST appear on stderr (in the "Created hook: …" line)
+        assert!(
+            stderr.contains(hid),
+            "hook id {hid:?} must appear on stderr; stderr: {stderr:?}"
+        );
+    }
 }
 
 // Scenario E: without --subscribe, only one POST to /issues (no hook created)
@@ -928,17 +984,89 @@ fn issue_new_without_subscribe_creates_no_hook() {
     );
 }
 
-// Scenario F: --subscribe with invalid target format errors
+// Scenario F: --subscribe with invalid target format errors.
+// The error message must refer to --subscribe (the actual flag), not --deliver-to
+// (the flag name used by the standalone `issue subscribe` subcommand).
 #[test]
 fn issue_new_subscribe_invalid_target_format_fails() {
     let mut h = TestHarness::new();
     h.start_server();
 
-    h.ns2()
+    let out = h
+        .ns2()
         .args([
             "issue", "new", "--title", "T", "--body", "B", "--subscribe", "bad-format",
         ])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("'issue:<id>' or 'session:<id>'"));
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success(), "bad --subscribe value should fail");
+
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("'issue:<id>' or 'session:<id>'"),
+        "stderr should describe valid format; got: {stderr:?}"
+    );
+    // Must name the flag the user actually typed, not the internal flag name
+    assert!(
+        stderr.contains("--subscribe"),
+        "error must reference --subscribe, not --deliver-to; got: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("--deliver-to"),
+        "error must not reference --deliver-to when invoked via --subscribe; got: {stderr:?}"
+    );
+}
+
+// Scenario G: --subscribe combined with --wait — issue ID (not hook ID) on stdout,
+// hook is visible in /hooks before the wait loop begins.
+#[test]
+fn issue_new_subscribe_with_wait_stdout_is_issue_id() {
+    let mut h = TestHarness::new();
+    h.start_server();
+    write_agent(&h, "swe");
+
+    // Use --status open (not in_progress) so --wait is NOT triggered — we just
+    // want to confirm the stdout contract holds when both flags coexist structurally.
+    // (A full --wait + --subscribe integration test would require a live agent.)
+    let out = h
+        .ns2()
+        .args([
+            "issue",
+            "new",
+            "--title",
+            "Sub+Status",
+            "--body",
+            "b",
+            "--subscribe",
+            "issue:ab12",
+            "--status",
+            "open",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "subscribe + status should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+
+    assert_eq!(
+        lines.len(),
+        1,
+        "stdout must be exactly 1 line (the issue ID) even with --subscribe, got: {stdout:?}"
+    );
+    let issue_id = lines[0].trim();
+    assert_eq!(issue_id.len(), 4, "must be a 4-char issue ID, got: {issue_id}");
+
+    // Confirm hook exists and is named after the issue
+    let hooks_json = h.http_get("/hooks");
+    assert!(
+        hooks_json.contains(&format!("subscribe-{issue_id}")),
+        "hook should be named subscribe-{{issue_id}}; hooks: {hooks_json}"
+    );
 }

--- a/specs/architecture.spec.md
+++ b/specs/architecture.spec.md
@@ -83,4 +83,7 @@ _Doesn't own: issue business logic — delegate to `issues`._
 **`tui`** — ratatui terminal UI. Connects to the server via SSE. Thin client: all state comes from the server.
 
 **`cli`** — the `ns2` binary. Wires crates; contains no logic of its own. Depends directly on `server` to start the in-process server, and on `types` for shared domain types. Uses `reqwest` directly for HTTP calls to the local ns2 server (health checks, issue/session/hook CRUD, SSE streaming).
+
+`ns2 issue new` accepts a `--subscribe <target>` flag (where target is `issue:<id>` or `session:<id>`). When provided, it calls the same `run_subscribe` function used by `ns2 issue subscribe`, immediately after creating the issue. This creates a hook that delivers notifications on `issue.status_changed` and `issue.comment_added` events. Stdout from `issue new` still only contains the issue ID; the hook ID goes to stderr.
+
 _Doesn't own: Anthropic client init or harness instantiation — that's `server`'s job._

--- a/specs/cli-architecture.spec.md
+++ b/specs/cli-architecture.spec.md
@@ -65,7 +65,7 @@ Each file in `commands/` corresponds to one top-level CLI noun. Command function
 | File | Noun | Responsibility |
 |------|------|----------------|
 | `agent.rs` | `ns2 agent` | `run_list`, `run_new`, `run_edit` — reads/writes `.ns2/agents/` via the `agents` crate. |
-| `issue.rs` | `ns2 issue` | Full issue lifecycle: new, edit, comment, set-status, complete, reopen, list, wait, watch. Owns `issue_is_terminal` and `all_nodes_terminal`. |
+| `issue.rs` | `ns2 issue` | Full issue lifecycle: new, edit, comment, set-status, complete, reopen, list, wait, watch, subscribe. Owns `issue_is_terminal`, `all_nodes_terminal`, and `run_subscribe` (shared by both `issue subscribe` and the `--subscribe` flag on `issue new`). |
 | `server.rs` | `ns2 server` | `data_dir_and_pid` (shared helper), `run_start` (delegates to the `server` crate), `run_stop` (reads PID file and signals the process). |
 | `session.rs` | `ns2 session` | Full session lifecycle: list, new, tail, send, stop, wait. Owns `session_is_terminal`. |
 | `spec.rs` | `ns2 spec` | `run_new`, `run_sync`, `run_verify`. Owns `verify_spec_paths` / `VerifyResult` (returned instead of calling `process::exit` so tests can assert on the result). |

--- a/specs/cli-commands/hook.spec.md
+++ b/specs/cli-commands/hook.spec.md
@@ -59,8 +59,8 @@ ns2 hook delete --id <id>
 
 ## Subscribe shortcut
 
-`ns2 hook subscribe` is sugar for creating an internal hook that watches a specific issue for status changes and new comments:
+`ns2 issue subscribe` is sugar for creating an internal hook that watches a specific issue for status changes and new comments:
 
 ```bash
-ns2 hook subscribe --id <issue-id> --deliver-to <watcher-issue-id>
+ns2 issue subscribe --id <issue-id> --deliver-to issue:<watcher-issue-id>
 ```

--- a/specs/cli-commands/issue.spec.md
+++ b/specs/cli-commands/issue.spec.md
@@ -35,6 +35,8 @@ id=$(ns2 issue new --title "Add retry logic" --body "..." --assignee swe \
 
 `--status in_progress` sets the status (starting the agent) immediately after creation. `--wait` blocks until the issue reaches a terminal state and always prints the issue ID to stdout last. `--watch` streams live SSE events to stderr while `--wait` runs, keeping stdout capturable.
 
+`--subscribe issue:<id>` (or `--subscribe session:<id>`) creates a hook immediately after the issue is created that delivers notifications on `issue.status_changed` and `issue.comment_added` events. The hook ID goes to stderr; stdout still only contains the issue ID. This calls the same logic as `ns2 issue subscribe`, ensuring no drift between the two paths.
+
 ## Setting status and starting
 
 `ns2 issue set-status --id <id> --status <status>` updates the issue status via `PATCH /issues/:id/status`. When `--status in_progress` is passed, the server auto-starts the issue: it validates that an assignee is set, and then either creates a fresh session (for open/failed issues) or resumes the existing session (for waiting issues). The issue moves to `running` — `in_progress` is only an input signal, never a stored state.


### PR DESCRIPTION
## Summary

- Added `--subscribe <target>` flag to `ns2 issue new` that creates a hook subscription immediately after issue creation
- Reuses the exact same `run_subscribe` function as `ns2 issue subscribe` — zero drift
- Target format: `issue:<id>` or `session:<id>`
- **stdout contract preserved**: issue ID is the only thing on stdout; hook ID goes to stderr
- 7 new integration tests + 3 new CLI parse unit tests

## Scenarios

### Scenario 1: Create issue + subscribe in one command

`ns2 issue new --subscribe issue:<watcher-id>` creates both the issue and the hook in one step.

![subscribe-basic](https://vhs.charm.sh/vhs-4ewkzJztpK9kIP48mtPC6W.gif)

### Scenario 2: stdout only contains the issue ID

`id=$(ns2 issue new --subscribe ...)` correctly captures only the issue ID. Hook creation messages go to stderr.

![subscribe-stdout](https://vhs.charm.sh/vhs-28cpYVYFj02k6vfohbeUBf.gif)

## Files changed
- `crates/cli/src/main.rs` — added `subscribe: Option<String>` to `IssueAction::New`
- `crates/cli/src/commands/issue.rs` — updated `run_new` and `run_subscribe` signatures; `run_subscribe` gains `flag_name` + `print_id_to_stdout` params to support both callers without drift
- `crates/cli/tests/issue_crud.rs` — 7 new integration tests
- `specs/` — architecture, cli-commands/issue, cli-architecture, hook specs updated

## Tests (46 total, 7 new)
| Test | What it covers |
|---|---|
| `issue_new_subscribe_creates_hook` | Hook created after issue via --subscribe |
| `issue_new_subscribe_hook_id_on_stderr_not_stdout` | stdout contract: only issue ID |
| `issue_new_without_subscribe_creates_no_hook` | No hook when flag absent |
| `issue_new_subscribe_invalid_target_format_fails` | Error message says `--subscribe`, not `--deliver-to` |
| `issue_new_subscribe_with_status_stdout_is_issue_id` | Combined with `--status` |
| `issue_new_subscribe_with_session_target_creates_hook` | `session:` target format |
| `issue_new_subscribe_hook_payload_shape` | Verifies event_types and filter conditions |