### PR TITLE
fix: event bus alignment, test isolation, and flakiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,6 +2294,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,6 +24,10 @@ futures = "0.3"
 uuid = { workspace = true }
 chrono = { workspace = true }
 
+[[test]]
+name = "integration"
+path = "tests/integration_tests.rs"
+
 [dev-dependencies]
 tempfile = "3"
 assert_cmd = "2"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -462,7 +462,7 @@ enum IssueAction {
         blocked_on: Option<Vec<String>>,
         #[arg(long, help = "New git branch name for this issue.")]
         branch: Option<String>,
-        #[arg(long, help = "Set the issue status. Only 'in_progress' is accepted here; use dedicated commands for other transitions (cancel, complete, reopen).")]
+        #[arg(long, help = "Set the issue status (e.g. in_progress to auto-start, open, cancelled).")]
         status: Option<String>,
     },
     #[command(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -462,7 +462,7 @@ enum IssueAction {
         blocked_on: Option<Vec<String>>,
         #[arg(long, help = "New git branch name for this issue.")]
         branch: Option<String>,
-        #[arg(long, help = "Set the issue status (e.g. in_progress to auto-start, open, waiting, etc.).")]
+        #[arg(long, help = "Set the issue status. Only 'in_progress' is accepted here; use dedicated commands for other transitions (cancel, complete, reopen).")]
         status: Option<String>,
     },
     #[command(

--- a/crates/cli/tests/cli/agent_commands.rs
+++ b/crates/cli/tests/cli/agent_commands.rs
@@ -1,10 +1,8 @@
-mod common;
-
 use predicates::prelude::*;
 
 #[test]
 fn agent_list_when_no_agents_dir_shows_message() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args(["agent", "list"])
@@ -15,7 +13,7 @@ fn agent_list_when_no_agents_dir_shows_message() {
 
 #[test]
 fn agent_new_creates_file_with_correct_content() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -41,7 +39,7 @@ fn agent_new_creates_file_with_correct_content() {
 
 #[test]
 fn agent_list_shows_created_agent() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -68,7 +66,7 @@ fn agent_list_shows_created_agent() {
 
 #[test]
 fn agent_list_sorted_alphabetically() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -109,7 +107,7 @@ fn agent_list_sorted_alphabetically() {
 
 #[test]
 fn agent_edit_description_only_preserves_body() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -146,7 +144,7 @@ fn agent_edit_description_only_preserves_body() {
 
 #[test]
 fn agent_edit_body_only_preserves_description() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -183,7 +181,7 @@ fn agent_edit_body_only_preserves_description() {
 
 #[test]
 fn agent_edit_without_flags_fails() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -209,7 +207,7 @@ fn agent_edit_without_flags_fails() {
 
 #[test]
 fn agent_new_duplicate_name_fails() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -244,7 +242,7 @@ fn agent_new_duplicate_name_fails() {
 
 #[test]
 fn agent_new_requires_name() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args(["agent", "new", "--description", "desc", "--body", "body"])

--- a/crates/cli/tests/cli/issue_crud.rs
+++ b/crates/cli/tests/cli/issue_crud.rs
@@ -1,6 +1,4 @@
-mod common;
-
-use common::TestHarness;
+use super::common::TestHarness;
 use predicates::prelude::*;
 
 // ─── Flow 55: issue wait --timeout ───────────────────────────────────────────

--- a/crates/cli/tests/cli/orphan_recovery.rs
+++ b/crates/cli/tests/cli/orphan_recovery.rs
@@ -1,8 +1,6 @@
-mod common;
-
 use predicates::prelude::*;
 
-fn write_swe_agent(h: &common::TestHarness) {
+fn write_swe_agent(h: &super::common::TestHarness) {
     let agents_dir = h.repo_dir.path().join(".ns2/agents");
     std::fs::create_dir_all(&agents_dir).unwrap();
     std::fs::write(
@@ -16,7 +14,7 @@ fn write_swe_agent(h: &common::TestHarness) {
 
 #[test]
 fn orphan_session_marked_failed_on_restart() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     let uuid = h.ns2_stdout(&["session", "new", "--message", "hello"]);
@@ -39,7 +37,7 @@ fn orphan_session_marked_failed_on_restart() {
 
 #[test]
 fn orphan_session_with_linked_issue_posts_comment_and_fails_issue() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     write_swe_agent(&h);
     h.start_server();
 
@@ -92,7 +90,7 @@ fn orphan_session_with_linked_issue_posts_comment_and_fails_issue() {
 
 #[test]
 fn reopen_failed_issue_transitions_to_open() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     write_swe_agent(&h);
     h.start_server();
 
@@ -157,7 +155,7 @@ fn reopen_failed_issue_transitions_to_open() {
 
 #[test]
 fn reopen_open_issue_fails() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     write_swe_agent(&h);
     h.start_server();
 
@@ -171,7 +169,7 @@ fn reopen_open_issue_fails() {
 
 #[test]
 fn reopen_nonexistent_issue_fails() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     h.ns2()

--- a/crates/cli/tests/cli/server_lifecycle.rs
+++ b/crates/cli/tests/cli/server_lifecycle.rs
@@ -1,6 +1,4 @@
-mod common;
-
-use common::TestHarness;
+use super::common::TestHarness;
 
 #[test]
 fn server_starts_and_health_responds_ok() {

--- a/crates/cli/tests/cli/server_offline.rs
+++ b/crates/cli/tests/cli/server_offline.rs
@@ -1,6 +1,4 @@
-mod common;
-
-use common::TestHarness;
+use super::common::TestHarness;
 use predicates::prelude::*;
 
 #[test]

--- a/crates/cli/tests/cli/session_advanced.rs
+++ b/crates/cli/tests/cli/session_advanced.rs
@@ -1,10 +1,8 @@
-mod common;
-
 #[allow(unused_imports)]
 use predicates::prelude::*;
 
 fn write_agent(
-    h: &common::TestHarness,
+    h: &super::common::TestHarness,
     name: &str,
     body: &str,
     include_project_config: bool,
@@ -33,7 +31,7 @@ fn write_agent(
 
 #[test]
 fn session_with_include_project_config_completes() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     std::fs::write(
         h.repo_dir.path().join("CLAUDE.md"),
@@ -57,7 +55,7 @@ fn session_with_include_project_config_completes() {
 
 #[test]
 fn session_without_include_project_config_ignores_claude_md() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     std::fs::write(
         h.repo_dir.path().join("CLAUDE.md"),
@@ -81,7 +79,7 @@ fn session_without_include_project_config_ignores_claude_md() {
 
 #[test]
 fn missing_claude_md_with_include_project_config_still_completes() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     write_agent(&h, "proj-agent", "You are helpful.", true, "");
     let uuid = h.ns2_stdout(&[
@@ -100,7 +98,7 @@ fn missing_claude_md_with_include_project_config_still_completes() {
 
 #[test]
 fn invalid_import_in_claude_md_produces_warning_not_abort() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     std::fs::write(
         h.repo_dir.path().join("CLAUDE.md"),
@@ -126,7 +124,7 @@ fn invalid_import_in_claude_md_produces_warning_not_abort() {
 
 #[test]
 fn stop_hook_fires_on_session_completion() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     let log_path = h.repo_dir.path().join("stop-hook-log.txt");
     let script_path = h.repo_dir.path().join("stop-hook.sh");
@@ -169,7 +167,7 @@ exit 0
 
 #[test]
 fn project_level_stop_hook_inherited_when_include_project_config() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     let log_path = h.repo_dir.path().join("project-hook-log.txt");
     let script_path = h.repo_dir.path().join("project-hook.sh");
@@ -217,7 +215,7 @@ exit 0
 
 #[test]
 fn commit_guard_exits_zero_on_clean_tree() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     let hooks_dir = h.repo_dir.path().join(".claude/hooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();
@@ -252,7 +250,7 @@ exit 0
 
 #[test]
 fn commit_guard_exits_nonzero_on_dirty_tree() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     let hooks_dir = h.repo_dir.path().join(".claude/hooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();
@@ -297,7 +295,7 @@ exit 0
 
 #[test]
 fn commit_guard_exits_nonzero_on_staged_changes() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     let hooks_dir = h.repo_dir.path().join(".claude/hooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();
@@ -343,7 +341,7 @@ exit 0
 
 #[test]
 fn commit_guard_exits_nonzero_on_unpushed_commits() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
     h.setup_origin();
     // Push initial state so the local branch tracks origin

--- a/crates/cli/tests/cli/session_crud.rs
+++ b/crates/cli/tests/cli/session_crud.rs
@@ -1,12 +1,10 @@
-mod common;
-
 use predicates::prelude::*;
 
 // ─── Flow 55: --timeout flag ──────────────────────────────────────────────────
 
 #[test]
 fn session_wait_timeout_exits_nonzero_on_non_terminal_session() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     // A session without a message stays in 'created' — never finishes.
@@ -22,7 +20,7 @@ fn session_wait_timeout_exits_nonzero_on_non_terminal_session() {
 
 #[test]
 fn session_new_without_message_has_created_status() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     h.ns2_stdout(&["session", "new"]);
@@ -36,7 +34,7 @@ fn session_new_without_message_has_created_status() {
 
 #[test]
 fn session_new_with_name_shows_in_list() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     h.ns2_stdout(&["session", "new", "--name", "my-session"]);
@@ -50,7 +48,7 @@ fn session_new_with_name_shows_in_list() {
 
 #[test]
 fn session_list_empty_shows_no_sessions() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     let out = h.ns2_stdout(&["session", "list"]);
@@ -59,7 +57,7 @@ fn session_list_empty_shows_no_sessions() {
 
 #[test]
 fn session_list_filter_by_status_running_returns_empty() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     h.ns2_stdout(&["session", "new"]);
@@ -70,7 +68,7 @@ fn session_list_filter_by_status_running_returns_empty() {
 
 #[test]
 fn session_list_filter_by_id() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     let uuid1 = h.ns2_stdout(&["session", "new", "--name", "first"]);
@@ -91,7 +89,7 @@ fn session_list_filter_by_id() {
 
 #[test]
 fn session_wait_completes_when_stub_finishes() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     let uuid = h.ns2_stdout(&["session", "new", "--message", "hello"]);
@@ -106,7 +104,7 @@ fn session_wait_completes_when_stub_finishes() {
 
 #[test]
 fn session_wait_on_already_terminal_session_returns_immediately() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     let uuid = h.ns2_stdout(&["session", "new", "--message", "hello"]);
@@ -122,7 +120,7 @@ fn session_wait_on_already_terminal_session_returns_immediately() {
 
 #[test]
 fn session_wait_multiple_sessions() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     let uuid1 = h.ns2_stdout(&["session", "new", "--message", "task one"]);
@@ -146,7 +144,7 @@ fn session_wait_multiple_sessions() {
 
 #[test]
 fn session_wait_failed_session_exits_nonzero() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     let uuid = h.ns2_stdout(&["session", "new", "--message", "hello"]);
@@ -166,7 +164,7 @@ fn session_wait_failed_session_exits_nonzero() {
 
 #[test]
 fn session_wait_cancelled_session_exits_zero() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     let uuid = h.ns2_stdout(&["session", "new", "--message", "hello"]);
@@ -194,7 +192,7 @@ fn session_wait_cancelled_session_exits_zero() {
 
 #[test]
 fn session_wait_nonexistent_id_exits_nonzero() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     h.ns2()
@@ -213,7 +211,7 @@ fn session_wait_nonexistent_id_exits_nonzero() {
 
 #[test]
 fn session_wait_no_ids_exits_nonzero() {
-    let mut h = common::TestHarness::new();
+    let mut h = super::common::TestHarness::new();
     h.start_server();
 
     h.ns2().args(["session", "wait"]).assert().failure();

--- a/crates/cli/tests/cli/spec_commands.rs
+++ b/crates/cli/tests/cli/spec_commands.rs
@@ -1,12 +1,10 @@
-mod common;
-
 use predicates::prelude::*;
 
 // ── Flow 10: spec new ────────────────────────────────────────────────────────
 
 #[test]
 fn spec_new_creates_file_with_targets() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -31,7 +29,7 @@ fn spec_new_creates_file_with_targets() {
 
 #[test]
 fn spec_new_multiple_targets() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -53,7 +51,7 @@ fn spec_new_multiple_targets() {
 
 #[test]
 fn spec_new_on_existing_path_fails() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -81,7 +79,7 @@ fn spec_new_on_existing_path_fails() {
 
 #[test]
 fn spec_new_without_target_fails() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args(["spec", "new", "notarget.spec.md"])
@@ -93,7 +91,7 @@ fn spec_new_without_target_fails() {
 
 #[test]
 fn spec_sync_clean_exits_zero() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness.setup_codebase_layout();
 
     let main_rs = harness.repo_dir.path().join("crates/cli/src/main.rs");
@@ -135,7 +133,7 @@ fn spec_sync_clean_exits_zero() {
 
 #[test]
 fn spec_sync_stale_after_touch_exits_nonzero() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness.setup_codebase_layout();
 
     let main_rs = harness.repo_dir.path().join("crates/cli/src/main.rs");
@@ -175,7 +173,7 @@ fn spec_sync_stale_after_touch_exits_nonzero() {
 
 #[test]
 fn spec_sync_no_path_finds_all_specs() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness.setup_codebase_layout();
 
     let main_rs = harness.repo_dir.path().join("crates/cli/src/main.rs");
@@ -214,7 +212,7 @@ fn spec_sync_no_path_finds_all_specs() {
 
 #[test]
 fn spec_sync_unverified_spec_treats_all_files_stale() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness.setup_codebase_layout();
 
     harness
@@ -238,7 +236,7 @@ fn spec_sync_unverified_spec_treats_all_files_stale() {
 
 #[test]
 fn spec_sync_skips_specs_without_targets() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness.setup_codebase_layout();
 
     harness.ns2().args(["spec", "sync"]).assert().success();
@@ -248,7 +246,7 @@ fn spec_sync_skips_specs_without_targets() {
 
 #[test]
 fn spec_verify_writes_verified_timestamp() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -277,7 +275,7 @@ fn spec_verify_writes_verified_timestamp() {
 
 #[test]
 fn spec_verify_updates_existing_timestamp() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -327,7 +325,7 @@ fn spec_verify_updates_existing_timestamp() {
 #[test]
 fn spec_verify_preserves_body_and_targets() {
     use std::io::Write;
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -370,7 +368,7 @@ fn spec_verify_preserves_body_and_targets() {
 
 #[test]
 fn spec_verify_multiple_paths_at_once() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     for name in &["a.spec.md", "b.spec.md", "c.spec.md"] {
         harness
             .ns2()
@@ -396,7 +394,7 @@ fn spec_verify_multiple_paths_at_once() {
 
 #[test]
 fn spec_verify_partial_failure_still_verifies_valid() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args([
@@ -443,7 +441,7 @@ fn spec_verify_partial_failure_still_verifies_valid() {
 
 #[test]
 fn spec_verify_nonexistent_path_fails() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     harness
         .ns2()
         .args(["spec", "verify", "does-not-exist.spec.md"])
@@ -453,7 +451,7 @@ fn spec_verify_nonexistent_path_fails() {
 
 #[test]
 fn spec_verify_file_without_targets_fails() {
-    let harness = common::TestHarness::new();
+    let harness = super::common::TestHarness::new();
     let plain = harness.repo_dir.path().join("plain.md");
     std::fs::write(&plain, "# Just a plain markdown file\n\nNo frontmatter.\n").unwrap();
 

--- a/crates/cli/tests/cli/worktree.rs
+++ b/crates/cli/tests/cli/worktree.rs
@@ -1,6 +1,4 @@
-mod common;
-
-use common::TestHarness;
+use super::common::TestHarness;
 
 fn write_agent(h: &TestHarness, name: &str) {
     let dir = h.repo_dir.path().join(".ns2/agents");

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,6 +1,5 @@
 use assert_cmd::cargo::cargo_bin;
 use std::collections::HashSet;
-use std::io::{BufRead, BufReader};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -31,28 +30,28 @@ impl TestHarness {
 
     /// Start the ns2 server on `self.port` and block until it is ready.
     pub fn start_server(&mut self) {
-        let mut proc = Command::new(cargo_bin("ns2"))
+        let proc = Command::new(cargo_bin("ns2"))
             .args(["server", "start", "--port", &self.port.to_string()])
             .env("HOME", self.home_dir.path())
             .env_remove("ANTHROPIC_API_KEY")
             .current_dir(self.repo_dir.path())
-            .stdout(Stdio::piped())
+            .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .expect("failed to spawn ns2 server");
 
-        let stdout = proc.stdout.take().unwrap();
-        let mut reader = BufReader::new(stdout);
-        let mut line = String::new();
+        let addr = format!("127.0.0.1:{}", self.port);
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(10);
         loop {
-            line.clear();
-            assert!(
-                reader.read_line(&mut line).unwrap() != 0,
-                "ns2 server exited before printing 'Listening on'"
-            );
-            if line.contains("Listening on") {
+            if std::net::TcpStream::connect(&addr).is_ok() {
                 break;
             }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "server did not accept connections within 10s on {addr}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
         }
         self.server = Some(proc);
     }

--- a/crates/cli/tests/integration_tests.rs
+++ b/crates/cli/tests/integration_tests.rs
@@ -1,0 +1,20 @@
+mod common;
+
+#[path = "cli/agent_commands.rs"]
+mod agent_commands;
+#[path = "cli/issue_crud.rs"]
+mod issue_crud;
+#[path = "cli/orphan_recovery.rs"]
+mod orphan_recovery;
+#[path = "cli/server_lifecycle.rs"]
+mod server_lifecycle;
+#[path = "cli/server_offline.rs"]
+mod server_offline;
+#[path = "cli/session_advanced.rs"]
+mod session_advanced;
+#[path = "cli/session_crud.rs"]
+mod session_crud;
+#[path = "cli/spec_commands.rs"]
+mod spec_commands;
+#[path = "cli/worktree.rs"]
+mod worktree;

--- a/crates/cli/tests/issue_crud.rs
+++ b/crates/cli/tests/issue_crud.rs
@@ -776,31 +776,23 @@ fn issue_new_wait_with_status_open_fails() {
 }
 
 // Scenario 6: --status without --wait (just sets status, no blocking)
-// The issue should be created and its status set to in_progress, but no blocking.
-// Without a real agent running, the status will be "in_progress" or "running" briefly
-// then fail — but the key is the command exits immediately with the issue ID on stdout.
+// Without --wait the command exits immediately after creating the issue and printing its ID.
 #[test]
 fn issue_new_status_without_wait_exits_immediately_and_prints_id() {
     let mut h = TestHarness::new();
     h.start_server();
-    write_agent(&h, "swe");
 
-    // This may fail at status-setting if it can't auto-start (no agent binary) but
-    // the test verifies that without --wait it returns quickly.
+    // No --status flag: create the issue and exit immediately.
     // We only care that stdout contains a 4-char ID.
-    // We use --status open (which just sets status, doesn't auto-start) to avoid
-    // triggering harness issues in test environment.
     let out = h
         .ns2()
-        .args([
-            "issue", "new", "--title", "Status Test", "--body", "b", "--status", "open",
-        ])
+        .args(["issue", "new", "--title", "Status Test", "--body", "b"])
         .output()
         .unwrap();
 
     assert!(
         out.status.success(),
-        "should succeed with --status open: {}",
+        "issue new without --status should succeed: {}",
         String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8(out.stdout).unwrap().trim().to_string();
@@ -815,20 +807,18 @@ fn issue_new_status_without_wait_exits_immediately_and_prints_id() {
     );
 }
 
-// Verify that --status sets the issue status as expected (using a non-auto-start status)
+// Verify that a newly-created issue starts in the 'open' state (no --status flag needed).
 #[test]
-fn issue_new_with_status_flag_sets_status() {
+fn issue_new_default_status_is_open() {
     let mut h = TestHarness::new();
     h.start_server();
 
-    // Use --status open which is a no-op transition (issue starts as open)
-    let id = h.ns2_stdout(&[
-        "issue", "new", "--title", "Status Test", "--body", "b", "--status", "open",
-    ]);
+    // Issues default to 'open' on creation — no --status flag required.
+    let id = h.ns2_stdout(&["issue", "new", "--title", "Status Test", "--body", "b"]);
     let json = h.http_get(&format!("/issues/{id}"));
     assert!(
         json.contains("\"open\""),
-        "issue should have status 'open', got: {json}"
+        "issue should have default status 'open', got: {json}"
     );
 }
 
@@ -1044,17 +1034,17 @@ fn issue_new_subscribe_invalid_target_format_fails() {
     );
 }
 
-// Scenario G: --subscribe combined with --status — issue ID (not hook ID) on stdout,
+// Scenario G: --subscribe combined with no --status — issue ID (not hook ID) on stdout,
 // hook is visible in /hooks. Note: --wait is NOT exercised here; this only confirms
-// the stdout contract holds when both --subscribe and --status flags coexist.
+// the stdout contract holds when --subscribe is provided without --wait.
 #[test]
 fn issue_new_subscribe_with_status_stdout_is_issue_id() {
     let mut h = TestHarness::new();
     h.start_server();
 
-    // Use --status open (not in_progress) so --wait is NOT triggered — we just
-    // want to confirm the stdout contract holds when both flags coexist structurally.
-    // (A full --wait + --subscribe integration test would require a live agent.)
+    // No --status flag — just verify the stdout contract holds when --subscribe is
+    // provided without --wait. A full --wait + --subscribe integration test would
+    // require a live agent.
     let out = h
         .ns2()
         .args([
@@ -1066,8 +1056,6 @@ fn issue_new_subscribe_with_status_stdout_is_issue_id() {
             "b",
             "--subscribe",
             "issue:ab12",
-            "--status",
-            "open",
         ])
         .output()
         .unwrap();

--- a/crates/cli/tests/orphan_recovery.rs
+++ b/crates/cli/tests/orphan_recovery.rs
@@ -107,9 +107,39 @@ fn reopen_failed_issue_transitions_to_open() {
         "swe",
     ]);
 
+    // Start the issue so it gets a linked session, then wait for it to finish.
+    h.ns2_stdout(&["issue", "edit", "--id", &issue_id, "--status", "in_progress"]);
+    h.ns2_stdout(&["issue", "wait", "--id", &issue_id]);
+
+    // Fetch the session_id so we can force it back to running for the orphan sweep.
+    let issue_json = h.http_get(&format!("/issues/{issue_id}"));
+    let session_id = {
+        let v: serde_json::Value = serde_json::from_str(&issue_json).unwrap();
+        v["session_id"].as_str().unwrap().to_string()
+    };
+
+    // Simulate the server crashing mid-run by forcing session and issue back to
+    // running/in_progress, then restarting the server. The orphan sweep will
+    // transition the issue to `failed`.
+    h.http_patch(
+        &format!("/sessions/{session_id}/status"),
+        r#"{"status":"running"}"#,
+    );
     h.http_patch(
         &format!("/issues/{issue_id}/status"),
-        r#"{"status":"failed"}"#,
+        r#"{"status":"in_progress"}"#,
+    );
+
+    h.stop_server();
+    h.start_server();
+
+    // Give the orphan sweep a moment to run.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    let body = h.http_get(&format!("/issues/{issue_id}"));
+    assert!(
+        body.contains(r#""status":"failed""#) || body.contains(r#""status": "failed""#),
+        "issue must be 'failed' after orphan sweep, got: {body}",
     );
 
     h.ns2()

--- a/crates/issues/src/lib.rs
+++ b/crates/issues/src/lib.rs
@@ -637,16 +637,11 @@ impl IssueService {
                 }
             };
 
-            for mut issue in issues {
-                issue.comments.push(IssueComment {
-                    author: "system".into(),
-                    body: "session lost on server restart".into(),
-                    created_at: Utc::now(),
-                });
-                issue.status = types::IssueStatus::Failed;
-                issue.updated_at = Utc::now();
-
-                if let Err(e) = self.db.update_issue(&issue).await {
+            for issue in issues {
+                if let Err(e) = self
+                    .fail_issue(&issue.id, "session lost on server restart".to_string())
+                    .await
+                {
                     eprintln!(
                         "[orphan_sweep] failed to update issue {} to failed: {e}",
                         issue.id
@@ -1059,6 +1054,61 @@ mod tests {
             fetched_issue.comments[0].body,
             "session lost on server restart"
         );
+    }
+
+    #[tokio::test]
+    async fn orphan_sweep_emits_comment_added_and_status_changed_events() {
+        let db = Arc::new(MemoryDb::new());
+        let now = Utc::now();
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "orphan-session".into(),
+            status: SessionStatus::Running,
+            agent: None,
+            created_at: now,
+            updated_at: now,
+        };
+        db.create_session(&session).await.unwrap();
+
+        let mut issue = open_issue("ab12");
+        issue.status = IssueStatus::InProgress;
+        issue.session_id = Some(session.id);
+        db.create_issue(&issue).await.unwrap();
+
+        let (svc, bus) =
+            make_service_with_bus(&(Arc::clone(&db) as Arc<dyn db::Db>));
+        let mut rx = bus.subscribe();
+
+        svc.orphan_sweep().await;
+
+        let ev1 = rx.try_recv().expect("should have received CommentAdded event");
+        assert!(
+            matches!(
+                ev1,
+                events::SystemEvent::Issue(events::IssueEvent::CommentAdded {
+                    ref comment,
+                    ..
+                }) if comment.body == "session lost on server restart"
+            ),
+            "first event should be CommentAdded with restart body, got: {ev1:?}"
+        );
+
+        let ev2 = rx
+            .try_recv()
+            .expect("should have received StatusChanged event");
+        assert!(
+            matches!(
+                ev2,
+                events::SystemEvent::Issue(events::IssueEvent::StatusChanged {
+                    to: IssueStatus::Failed,
+                    ..
+                })
+            ),
+            "second event should be StatusChanged->Failed, got: {ev2:?}"
+        );
+
+        let fetched_issue = db.get_issue("ab12".into()).await.unwrap();
+        assert_eq!(fetched_issue.status, IssueStatus::Failed);
     }
 
     // --- create_issue ---

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -32,3 +32,4 @@ hex = "0.4"
 
 [dev-dependencies]
 http-body-util = "0.1"
+tempfile = "3"

--- a/crates/server/src/harness_spawn.rs
+++ b/crates/server/src/harness_spawn.rs
@@ -34,7 +34,7 @@ pub fn spawn_harness_sync(
         session: session_clone.clone(),
         model,
         tools,
-        git_root: None,
+        git_root: state.git_root.clone(),
         cwd: None,
     };
 

--- a/crates/server/src/harness_spawn.rs
+++ b/crates/server/src/harness_spawn.rs
@@ -105,8 +105,8 @@ pub fn spawn_harness_sync(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use events::{SessionEvent, StopEventStatus, SystemEvent};
+    use std::collections::HashMap;
     use types::{IssueStatus, Session, SessionStatus};
     use uuid::Uuid;
 
@@ -149,55 +149,39 @@ mod tests {
         issue
     }
 
-    /// Helper: wait for an issue to reach `target_status` within 3 seconds.
-    async fn wait_for_status(
-        state: &crate::state::AppState,
-        issue_id: &str,
-        target_status: IssueStatus,
-    ) {
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
-        loop {
-            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
-            let fetched = state.db.get_issue(issue_id.to_string()).await.unwrap();
-            if fetched.status == target_status {
-                return;
-            }
-            assert!(
-                tokio::time::Instant::now() <= deadline,
-                "issue {issue_id} did not become {target_status} within 3s (current: {})",
-                fetched.status
-            );
-        }
-    }
-
     /// Scenario 7a: Stopped{Complete, comment} then Done → issue Completed with comment.
-    /// The global subscriber (`spawn_issue_lifecycle_subscriber`) handles the transition.
+    /// Calls `process_lifecycle_event` directly — no background tasks, no sleeps.
     #[tokio::test]
     async fn test_stopped_complete_with_comment_marks_issue_completed() {
         let state = crate::tests::test_state().await;
-        // Start the global subscriber
-        crate::spawn_issue_lifecycle_subscriber(&state);
 
         let session1 = make_session(&state).await;
         make_linked_issue(&state, "sw-c1", session1.id).await;
 
-        let _tx = spawn_harness_sync(&state, session1.clone());
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        let mut stop_map = HashMap::new();
 
-        // Emit Stopped{Complete, "done"} then Done
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session1.id,
-            event: SessionEvent::Stopped {
-                status: StopEventStatus::Complete,
-                comment: Some("done".into()),
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session1.id,
+                event: SessionEvent::Stopped {
+                    status: StopEventStatus::Complete,
+                    comment: Some("done".into()),
+                },
             },
-        });
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session1.id,
-            event: SessionEvent::Done,
-        });
+        )
+        .await;
 
-        wait_for_status(&state, "sw-c1", IssueStatus::Completed).await;
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session1.id,
+                event: SessionEvent::Done,
+            },
+        )
+        .await;
 
         let issue = state.db.get_issue("sw-c1".into()).await.unwrap();
         assert_eq!(issue.status, IssueStatus::Completed);
@@ -212,27 +196,34 @@ mod tests {
     #[tokio::test]
     async fn test_stopped_waiting_marks_issue_waiting_no_comment() {
         let state = crate::tests::test_state().await;
-        crate::spawn_issue_lifecycle_subscriber(&state);
 
         let session1 = make_session(&state).await;
         make_linked_issue(&state, "sw-w1", session1.id).await;
 
-        let _tx = spawn_harness_sync(&state, session1.clone());
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        let mut stop_map = HashMap::new();
 
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session1.id,
-            event: SessionEvent::Stopped {
-                status: StopEventStatus::Waiting,
-                comment: None,
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session1.id,
+                event: SessionEvent::Stopped {
+                    status: StopEventStatus::Waiting,
+                    comment: None,
+                },
             },
-        });
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session1.id,
-            event: SessionEvent::Done,
-        });
+        )
+        .await;
 
-        wait_for_status(&state, "sw-w1", IssueStatus::Waiting).await;
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session1.id,
+                event: SessionEvent::Done,
+            },
+        )
+        .await;
 
         let issue = state.db.get_issue("sw-w1".into()).await.unwrap();
         assert_eq!(issue.status, IssueStatus::Waiting);
@@ -243,20 +234,21 @@ mod tests {
     #[tokio::test]
     async fn test_done_without_stopped_marks_issue_waiting() {
         let state = crate::tests::test_state().await;
-        crate::spawn_issue_lifecycle_subscriber(&state);
 
         let session1 = make_session(&state).await;
         make_linked_issue(&state, "sw-d1", session1.id).await;
 
-        let _tx = spawn_harness_sync(&state, session1.clone());
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        let mut stop_map = HashMap::new();
 
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session1.id,
-            event: SessionEvent::Done,
-        });
-
-        wait_for_status(&state, "sw-d1", IssueStatus::Waiting).await;
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session1.id,
+                event: SessionEvent::Done,
+            },
+        )
+        .await;
 
         let issue = state.db.get_issue("sw-d1".into()).await.unwrap();
         assert_eq!(issue.status, IssueStatus::Waiting);
@@ -267,7 +259,6 @@ mod tests {
     #[tokio::test]
     async fn test_harness_spawn_done_only_finishes_own_issue() {
         let state = crate::tests::test_state().await;
-        crate::spawn_issue_lifecycle_subscriber(&state);
 
         // Create two sessions and two issues linked to each session.
         let session1 = make_session(&state).await;
@@ -275,22 +266,20 @@ mod tests {
         make_linked_issue(&state, "hs-d-i1", session1.id).await;
         make_linked_issue(&state, "hs-d-i2", session2.id).await;
 
-        let _tx1 = spawn_harness_sync(&state, session1.clone());
-        let _tx2 = spawn_harness_sync(&state, session2.clone());
+        let mut stop_map = HashMap::new();
 
-        // Give the subscriber a moment.
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        // Process Done for session2 — issue1 must NOT be affected.
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session2.id,
+                event: SessionEvent::Done,
+            },
+        )
+        .await;
 
-        // Emit Done for session2 — issue1 must NOT be affected.
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session2.id,
-            event: SessionEvent::Done,
-        });
-
-        // Brief pause to let the event propagate.
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
-        // issue1 must still be InProgress.
+        // issue1 must still be InProgress (synchronous check, no sleep needed).
         let issue1 = state.db.get_issue("hs-d-i1".into()).await.unwrap();
         assert_eq!(
             issue1.status,
@@ -298,13 +287,16 @@ mod tests {
             "issue1 must remain InProgress after a Done event for a different session"
         );
 
-        // Emit Done for session1 — now issue1 should transition to Waiting.
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session1.id,
-            event: SessionEvent::Done,
-        });
-
-        wait_for_status(&state, "hs-d-i1", IssueStatus::Waiting).await;
+        // Process Done for session1 — now issue1 should transition to Waiting.
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session1.id,
+                event: SessionEvent::Done,
+            },
+        )
+        .await;
 
         let issue1_final = state.db.get_issue("hs-d-i1".into()).await.unwrap();
         assert_eq!(
@@ -326,26 +318,27 @@ mod tests {
     #[tokio::test]
     async fn test_harness_spawn_error_only_fails_own_issue() {
         let state = crate::tests::test_state().await;
-        crate::spawn_issue_lifecycle_subscriber(&state);
 
         let session1 = make_session(&state).await;
         let session2 = make_session(&state).await;
         make_linked_issue(&state, "hs-e-i1", session1.id).await;
 
-        let _tx1 = spawn_harness_sync(&state, session1.clone());
+        let mut stop_map = HashMap::new();
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-
-        // Emit Error for the unrelated session2 — issue1 must NOT be affected.
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session2.id,
-            event: SessionEvent::Error {
-                message: "error from unrelated session".into(),
+        // Process Error for the unrelated session2 — issue1 must NOT be affected.
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session2.id,
+                event: SessionEvent::Error {
+                    message: "error from unrelated session".into(),
+                },
             },
-        });
+        )
+        .await;
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
+        // Synchronous check — no sleep needed.
         let issue1 = state.db.get_issue("hs-e-i1".into()).await.unwrap();
         assert_eq!(
             issue1.status,
@@ -353,15 +346,18 @@ mod tests {
             "issue1 must remain InProgress after an Error event for a different session"
         );
 
-        // Emit Error for session1 — issue1 should fail.
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session1.id,
-            event: SessionEvent::Error {
-                message: "real failure".into(),
+        // Process Error for session1 — issue1 should fail.
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session1.id,
+                event: SessionEvent::Error {
+                    message: "real failure".into(),
+                },
             },
-        });
-
-        wait_for_status(&state, "hs-e-i1", IssueStatus::Failed).await;
+        )
+        .await;
 
         let issue1_final = state.db.get_issue("hs-e-i1".into()).await.unwrap();
         assert_eq!(
@@ -375,31 +371,37 @@ mod tests {
     #[tokio::test]
     async fn test_stopped_event_only_applies_to_own_session() {
         let state = crate::tests::test_state().await;
-        crate::spawn_issue_lifecycle_subscriber(&state);
 
         let session1 = make_session(&state).await;
         let session2 = make_session(&state).await;
         make_linked_issue(&state, "sw-s1", session1.id).await;
 
-        let _tx1 = spawn_harness_sync(&state, session1.clone());
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        let mut stop_map = HashMap::new();
 
-        // Emit Stopped for session2 (should be ignored for issue linked to session1)
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session2.id,
-            event: SessionEvent::Stopped {
-                status: StopEventStatus::Complete,
-                comment: Some("should be ignored".into()),
+        // Process Stopped for session2 (should be ignored for issue linked to session1)
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session2.id,
+                event: SessionEvent::Stopped {
+                    status: StopEventStatus::Complete,
+                    comment: Some("should be ignored".into()),
+                },
             },
-        });
+        )
+        .await;
 
-        // Now emit Done for session1 (without Stopped → Waiting)
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session1.id,
-            event: SessionEvent::Done,
-        });
-
-        wait_for_status(&state, "sw-s1", IssueStatus::Waiting).await;
+        // Process Done for session1 (without Stopped → Waiting)
+        crate::process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session1.id,
+                event: SessionEvent::Done,
+            },
+        )
+        .await;
 
         let issue = state.db.get_issue("sw-s1".into()).await.unwrap();
         assert_eq!(issue.status, IssueStatus::Waiting);

--- a/crates/server/src/harness_spawn.rs
+++ b/crates/server/src/harness_spawn.rs
@@ -135,7 +135,7 @@ mod tests {
             title: "Test issue".to_string(),
             body: "body".to_string(),
             status: IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "test-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: Some(session_id),
             parent_id: None,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5868,6 +5868,127 @@ mod tests {
         );
     }
 
+    // ─── POST /issues/:id/cancel route tests ─────────────────────────────────
+
+    /// POST /issues/:id/cancel must return the cancelled issue and, via the
+    /// lifecycle subscriber, drop the session `msg_sender` and mark the session
+    /// Cancelled in the DB.  The route itself must NOT touch `msg_senders`
+    /// directly — all session cleanup is delegated to the subscriber.
+    #[tokio::test]
+    async fn test_cancel_issue_route_delegates_cleanup_to_subscriber() {
+        // test_app_with_state spawns both the hook evaluator and the lifecycle
+        // subscriber, so cleanup happens through the event bus path.
+        let (app, state) = test_app_with_state().await;
+
+        // Create a Running session.
+        let session_id = Uuid::new_v4();
+        let session = types::Session {
+            id: session_id,
+            name: "route-cancel-test".into(),
+            status: types::SessionStatus::Running,
+            agent: Some("bot".into()),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&session).await.unwrap();
+
+        // Create an InProgress issue linked to the session.
+        let issue = types::Issue {
+            id: "rc-c1".to_string(),
+            title: "Route cancel test".to_string(),
+            body: "body".to_string(),
+            status: types::IssueStatus::InProgress,
+            branch: String::new(),
+            assignee: Some("bot".to_string()),
+            session_id: Some(session_id),
+            parent_id: None,
+            ancestor_ids: vec![],
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        // Insert a msg_sender so we can detect removal.
+        let (tx, _rx) = tokio::sync::mpsc::channel::<String>(1);
+        {
+            let mut senders = state.msg_senders.lock().await;
+            senders.insert(session_id, tx);
+        }
+
+        // Confirm sender is present before cancel.
+        {
+            let senders = state.msg_senders.lock().await;
+            assert!(
+                senders.contains_key(&session_id),
+                "msg_sender must be present before cancel"
+            );
+            drop(senders);
+        }
+
+        // POST /issues/rc-c1/cancel
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/issues/rc-c1/cancel")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "cancel_issue must return 200"
+        );
+
+        // Verify the returned issue is Cancelled.
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            v["status"], "cancelled",
+            "returned issue must have status=cancelled"
+        );
+
+        // Wait for the lifecycle subscriber to remove the msg_sender and update
+        // the session status (subscriber is async, so we poll with a deadline).
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let senders = state.msg_senders.lock().await;
+            let still_present = senders.contains_key(&session_id);
+            drop(senders);
+            if !still_present {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() <= deadline,
+                "msg_sender was not removed within 3 s after cancel_issue"
+            );
+        }
+
+        // Verify msg_sender is gone.
+        {
+            let senders = state.msg_senders.lock().await;
+            assert!(
+                !senders.contains_key(&session_id),
+                "msg_sender must be removed after cancel_issue"
+            );
+            drop(senders);
+        }
+
+        // Verify session is Cancelled in DB.
+        let db_session = state.db.get_session(session_id).await.unwrap();
+        assert_eq!(
+            db_session.status,
+            types::SessionStatus::Cancelled,
+            "session must be marked Cancelled in DB after cancel_issue"
+        );
+    }
+
     // ─── /named-events route integration tests ────────────────────────────────
 
     fn named_event_req(method: &str, uri: &str, body: &serde_json::Value) -> Request<Body> {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -318,6 +318,7 @@ pub async fn run(config: ServerConfig) -> Result<()> {
         event_bus,
         hook_store,
         event_store,
+        git_root: None,
     };
 
     // Spawn the hook evaluator background task.
@@ -398,6 +399,46 @@ mod tests {
         }
     }
 
+    /// Create an isolated temporary git root for tests that spawn a harness.
+    ///
+    /// Sets up a minimal `.ns2/agents/` directory with stub agent files for every
+    /// agent name used in the server test suite, so the harness never reads from
+    /// the real repository's `.ns2/agents/` directory.
+    ///
+    /// The `TempDir` is leaked so the directory stays alive for the duration of the
+    /// test process.  Memory is reclaimed by the OS at process exit.
+    pub fn make_isolated_git_root() -> std::path::PathBuf {
+        let tmp = tempfile::TempDir::new().expect("TempDir::new");
+        let root = tmp.path().to_owned();
+        let agents_dir = root.join(".ns2").join("agents");
+        std::fs::create_dir_all(&agents_dir).expect("create .ns2/agents");
+
+        // Write minimal stub agent files for every name used in server tests.
+        // All stubs have include_project_config: false so no further filesystem
+        // reads (CLAUDE.md, .claude/settings.json) occur during tests.
+        for name in &[
+            "bot",
+            "product-manager",
+            "swe-agent",
+            "swe",
+            "test-agent",
+            "test-agent-no-disk-def",
+        ] {
+            std::fs::write(
+                agents_dir.join(format!("{name}.md")),
+                format!(
+                    "---\nname: {name}\ndescription: stub for server tests\ninclude_project_config: false\n---\n\nStub agent.\n"
+                ),
+            )
+            .expect("write stub agent");
+        }
+
+        // Leak the TempDir: this keeps the directory alive until the test process
+        // exits, at which point the OS cleans it up.
+        Box::leak(Box::new(tmp));
+        root
+    }
+
     pub async fn test_state() -> AppState {
         let (db, hook_store, event_store) = db::connect("sqlite::memory:").await.unwrap();
         let client = Arc::new(TestClient) as Arc<dyn anthropic::AnthropicClient>;
@@ -415,6 +456,7 @@ mod tests {
             event_bus,
             hook_store,
             event_store,
+            git_root: Some(make_isolated_git_root()),
         }
     }
 
@@ -2327,7 +2369,7 @@ mod tests {
                 "POST",
                 "/issues",
                 &serde_json::json!({
-                    "title": "Has assignee", "body": "B", "assignee": "swe"
+                    "title": "Has assignee", "body": "B", "branch": "", "assignee": "swe"
                 }),
             ))
             .await
@@ -2444,7 +2486,7 @@ mod tests {
         let create_resp = app
             .clone()
             .oneshot(issue_req("POST", "/issues", &serde_json::json!({
-                "title": "Auto complete test", "body": "body", "assignee": "test-agent-no-disk-def"
+                "title": "Auto complete test", "body": "body", "branch": "", "assignee": "test-agent-no-disk-def"
             })))
             .await
             .unwrap();
@@ -3383,6 +3425,7 @@ mod tests {
             event_bus,
             hook_store,
             event_store,
+            git_root: Some(make_isolated_git_root()),
         };
         spawn_issue_lifecycle_subscriber(&state);
         let app = build_router(state.clone());
@@ -3395,6 +3438,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "My Title",
                     "body": "My Body",
+                    "branch": "",
                     "assignee": "test-agent"
                 }),
             ))
@@ -3497,6 +3541,7 @@ mod tests {
             event_bus,
             hook_store,
             event_store,
+            git_root: Some(make_isolated_git_root()),
         };
         spawn_issue_lifecycle_subscriber(&state);
         let app = build_router(state.clone());
@@ -3509,6 +3554,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "PM Task",
                     "body": "Do the thing",
+                    "branch": "",
                     "assignee": "product-manager"
                 }),
             ))
@@ -3627,6 +3673,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "Watcher waiting test",
                     "body": "Please respond",
+                    "branch": "",
                     "assignee": "swe-agent"
                 }),
             ))
@@ -3708,6 +3755,7 @@ mod tests {
             event_bus,
             hook_store,
             event_store,
+            git_root: Some(make_isolated_git_root()),
         };
         spawn_issue_lifecycle_subscriber(&state);
         let app = build_router(state.clone());
@@ -3720,6 +3768,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "Error test issue",
                     "body": "trigger an error",
+                    "branch": "",
                     "assignee": "swe-agent"
                 }),
             ))
@@ -4842,7 +4891,7 @@ mod tests {
                 "POST",
                 "/issues",
                 &serde_json::json!({
-                    "title": "Work", "body": "do work", "assignee": "test-agent"
+                    "title": "Work", "body": "do work", "branch": "", "assignee": "test-agent"
                 }),
             ))
             .await
@@ -4948,6 +4997,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "Lifecycle test",
                     "body": "body",
+                    "branch": "",
                     "assignee": "test-agent"
                 }),
             ))

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1749,6 +1749,103 @@ mod tests {
         );
     }
 
+    /// Cancelling a session that has a linked `InProgress` issue must emit
+    /// `IssueEvent::CommentAdded` and `IssueEvent::StatusChanged { to: Failed }`
+    /// through the event bus (by routing through `IssueService::fail_issue`).
+    #[tokio::test]
+    async fn test_cancel_session_emits_issue_events_for_linked_issue() {
+        use events::{IssueEvent, SystemEvent};
+
+        let (app, state) = test_app_with_state().await;
+
+        // Subscribe to the event bus BEFORE sending the cancel request.
+        let mut rx = state.event_bus.subscribe();
+
+        // Create a session in Created state.
+        let session = Session {
+            id: Uuid::new_v4(),
+            name: "cancel-event-test".into(),
+            status: SessionStatus::Created,
+            agent: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_session(&session).await.unwrap();
+
+        // Create an InProgress issue linked to this session.
+        let issue = types::Issue {
+            id: "cancel-evt-01".to_string(),
+            title: "Linked issue".to_string(),
+            body: "body".to_string(),
+            status: IssueStatus::InProgress,
+            branch: String::new(),
+            assignee: Some("bot".to_string()),
+            session_id: Some(session.id),
+            parent_id: None,
+            ancestor_ids: vec![],
+            blocked_on: vec![],
+            comments: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        state.db.create_issue(&issue).await.unwrap();
+
+        // POST /sessions/:id/cancel
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/sessions/{}/cancel", session.id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "cancel_session should return 200 for a Created session"
+        );
+
+        // Drain the event bus and collect all IssueEvents.
+        let mut comment_added = false;
+        let mut status_changed_to_failed = false;
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                SystemEvent::Issue(IssueEvent::CommentAdded { ref issue, ref comment })
+                    if issue.id == "cancel-evt-01" && comment.body == "session cancelled" =>
+                {
+                    comment_added = true;
+                }
+                SystemEvent::Issue(IssueEvent::StatusChanged {
+                    ref issue,
+                    to: IssueStatus::Failed,
+                    ..
+                }) if issue.id == "cancel-evt-01" => {
+                    status_changed_to_failed = true;
+                }
+                _ => {}
+            }
+        }
+
+        assert!(
+            comment_added,
+            "IssueEvent::CommentAdded must be emitted when a session is cancelled"
+        );
+        assert!(
+            status_changed_to_failed,
+            "IssueEvent::StatusChanged {{ to: Failed }} must be emitted when a session is cancelled"
+        );
+
+        // The issue must be Failed in the DB.
+        let fetched = state.db.get_issue("cancel-evt-01".to_string()).await.unwrap();
+        assert_eq!(
+            fetched.status,
+            IssueStatus::Failed,
+            "linked issue must be Failed in the DB after session cancel"
+        );
+    }
+
     /// Resuming a Waiting session via POST /sessions/:id/messages must spawn
     /// a harness with the linked issue's ID so the issue watcher is active.
     ///

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5716,9 +5716,13 @@ mod tests {
     }
 
 
+    /// `PATCH /issues/:id/status` with any status other than `in_progress` must
+    /// return 400 — those transitions have dedicated endpoints (`cancel`, `complete`,
+    /// `reopen`).  The direct DB write path was removed because it bypassed event
+    /// emission, session cleanup, and hooks.
     #[tokio::test]
-    async fn test_patch_issue_status_non_in_progress_updates_field() {
-        let (app, state) = test_app_with_state().await;
+    async fn test_patch_issue_status_non_in_progress_returns_400() {
+        let (app, _state) = test_app_with_state().await;
 
         // Create an open issue.
         let create_resp = app
@@ -5737,38 +5741,28 @@ mod tests {
         let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let issue_id = created["id"].as_str().unwrap().to_string();
 
-        // PATCH /issues/{id}/status with {"status": "waiting"}.
-        let resp = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("PATCH")
-                    .uri(format!("/issues/{issue_id}/status"))
-                    .header("content-type", "application/json")
-                    .body(Body::from(serde_json::to_vec(&serde_json::json!({"status": "waiting"})).unwrap()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(
-            resp.status(),
-            StatusCode::OK,
-            "PATCH with non-in_progress status must return 200"
-        );
-        let body = response_body_bytes(resp).await;
-        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(
-            v["status"], "waiting",
-            "returned issue must have the new status"
-        );
-
-        // Confirm persistence: fetch from DB directly.
-        let persisted = state.db.get_issue(issue_id).await.unwrap();
-        assert_eq!(
-            persisted.status,
-            types::IssueStatus::Waiting,
-            "DB must persist the new status"
-        );
+        // Each non-in_progress status must be rejected with 400.
+        for status in ["waiting", "completed", "failed", "cancelled", "open"] {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("PATCH")
+                        .uri(format!("/issues/{issue_id}/status"))
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            serde_json::to_vec(&serde_json::json!({"status": status})).unwrap(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::BAD_REQUEST,
+                "PATCH /status with status={status} must return 400"
+            );
+        }
     }
 
     // ── lifecycle subscriber Cancelled arm test ───────────────────────────────

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -143,6 +143,109 @@ async fn handle_in_progress(state: &AppState, issue: types::Issue) {
     }
 }
 
+/// Process a single lifecycle event, updating issue/session state accordingly.
+///
+/// This is the core logic extracted from the subscriber loop so tests can
+/// call it directly without timing assumptions.
+///
+/// `stop_map` tracks per-session stop info: `session_id → (status, optional
+/// comment)`.  Entries are inserted on `Stopped` and removed on `Done` or
+/// `Error`.
+pub(crate) async fn process_lifecycle_event(
+    state: &AppState,
+    stop_map: &mut std::collections::HashMap<uuid::Uuid, (events::StopEventStatus, Option<String>)>,
+    event: events::SystemEvent,
+) {
+    use events::{IssueEvent, SessionEvent, StopEventStatus, SystemEvent};
+    use types::IssueStatus;
+
+    match event {
+        // ── Session events → issue state ─────────────────────────
+
+        SystemEvent::Session {
+            session_id,
+            event: SessionEvent::Stopped { status, comment },
+        } => {
+            stop_map.insert(session_id, (status, comment));
+        }
+
+        SystemEvent::Session {
+            session_id,
+            event: SessionEvent::Done,
+        } => {
+            let issues = state
+                .db
+                .list_issues_by_session_id(session_id)
+                .await
+                .unwrap_or_default();
+            for issue in issues {
+                let (park_status, comment) =
+                    if let Some((stop_status, stop_comment)) = stop_map.remove(&session_id) {
+                        let ps = if matches!(stop_status, StopEventStatus::Complete) {
+                            IssueStatus::Completed
+                        } else {
+                            IssueStatus::Waiting
+                        };
+                        (ps, stop_comment)
+                    } else {
+                        (IssueStatus::Waiting, None)
+                    };
+                let _ = state
+                    .issue_service
+                    .park_issue(&issue.id, park_status, comment, None)
+                    .await;
+            }
+        }
+
+        SystemEvent::Session {
+            session_id,
+            event: SessionEvent::Error { message },
+        } => {
+            stop_map.remove(&session_id);
+            let issues = state
+                .db
+                .list_issues_by_session_id(session_id)
+                .await
+                .unwrap_or_default();
+            for issue in issues {
+                let _ = state
+                    .issue_service
+                    .fail_issue(&issue.id, message.clone())
+                    .await;
+            }
+        }
+
+        // ── Issue state → session actions ─────────────────────────
+
+        SystemEvent::Issue(IssueEvent::StatusChanged {
+            issue,
+            to: IssueStatus::InProgress,
+            ..
+        }) => {
+            handle_in_progress(state, issue).await;
+        }
+
+        SystemEvent::Issue(IssueEvent::StatusChanged {
+            issue,
+            to: IssueStatus::Cancelled,
+            ..
+        }) => {
+            // Kill the active session if any
+            if let Some(session_id) = issue.session_id {
+                let mut senders = state.msg_senders.lock().await;
+                senders.remove(&session_id);
+                drop(senders);
+                let _ = state
+                    .db
+                    .update_session_status(session_id, types::SessionStatus::Cancelled)
+                    .await;
+            }
+        }
+
+        _ => {}
+    }
+}
+
 /// Spawn the global issue lifecycle subscriber.
 ///
 /// This single long-lived task handles all cross-cutting session→issue and
@@ -157,10 +260,8 @@ async fn handle_in_progress(state: &AppState, issue: types::Issue) {
 /// - `IssueEvent::StatusChanged { to: InProgress }` — start or resume harness
 /// - `IssueEvent::StatusChanged { to: Cancelled }`  — drop msg sender to kill harness
 pub fn spawn_issue_lifecycle_subscriber(state: &AppState) {
-    use events::{IssueEvent, SessionEvent, StopEventStatus, SystemEvent};
-    use std::collections::HashMap;
+    use events::StopEventStatus;
     use tokio::sync::broadcast::error::RecvError;
-    use types::IssueStatus;
 
     let mut rx = state.event_bus.subscribe();
     let state = state.clone();
@@ -175,97 +276,12 @@ pub fn spawn_issue_lifecycle_subscriber(state: &AppState) {
         // typically short-lived relative to session count, and each entry is
         // tiny (~50 bytes).  A periodic sweep could be added if this becomes
         // a concern.
-        let mut stop_map: HashMap<uuid::Uuid, (StopEventStatus, Option<String>)> = HashMap::new();
+        let mut stop_map: std::collections::HashMap<uuid::Uuid, (StopEventStatus, Option<String>)> =
+            std::collections::HashMap::new();
 
         loop {
             match rx.recv().await {
-                Ok(event) => match event {
-                    // ── Session events → issue state ─────────────────────────
-
-                    SystemEvent::Session {
-                        session_id,
-                        event: SessionEvent::Stopped { status, comment },
-                    } => {
-                        stop_map.insert(session_id, (status, comment));
-                    }
-
-                    SystemEvent::Session {
-                        session_id,
-                        event: SessionEvent::Done,
-                    } => {
-                        let issues = state
-                            .db
-                            .list_issues_by_session_id(session_id)
-                            .await
-                            .unwrap_or_default();
-                        for issue in issues {
-                            let (park_status, comment) =
-                                if let Some((stop_status, stop_comment)) =
-                                    stop_map.remove(&session_id)
-                                {
-                                    let ps = if matches!(stop_status, StopEventStatus::Complete) {
-                                        IssueStatus::Completed
-                                    } else {
-                                        IssueStatus::Waiting
-                                    };
-                                    (ps, stop_comment)
-                                } else {
-                                    (IssueStatus::Waiting, None)
-                                };
-                            let _ = state
-                                .issue_service
-                                .park_issue(&issue.id, park_status, comment, None)
-                                .await;
-                        }
-                    }
-
-                    SystemEvent::Session {
-                        session_id,
-                        event: SessionEvent::Error { message },
-                    } => {
-                        stop_map.remove(&session_id);
-                        let issues = state
-                            .db
-                            .list_issues_by_session_id(session_id)
-                            .await
-                            .unwrap_or_default();
-                        for issue in issues {
-                            let _ = state
-                                .issue_service
-                                .fail_issue(&issue.id, message.clone())
-                                .await;
-                        }
-                    }
-
-                    // ── Issue state → session actions ─────────────────────────
-
-                    SystemEvent::Issue(IssueEvent::StatusChanged {
-                        issue,
-                        to: IssueStatus::InProgress,
-                        ..
-                    }) => {
-                        handle_in_progress(&state, issue).await;
-                    }
-
-                    SystemEvent::Issue(IssueEvent::StatusChanged {
-                        issue,
-                        to: IssueStatus::Cancelled,
-                        ..
-                    }) => {
-                        // Kill the active session if any
-                        if let Some(session_id) = issue.session_id {
-                            let mut senders = state.msg_senders.lock().await;
-                            senders.remove(&session_id);
-                            drop(senders);
-                            let _ = state
-                                .db
-                                .update_session_status(session_id, types::SessionStatus::Cancelled)
-                                .await;
-                        }
-                    }
-
-                    _ => {}
-                },
+                Ok(event) => process_lifecycle_event(&state, &mut stop_map, event).await,
                 Err(RecvError::Lagged(n)) => {
                     tracing::warn!("Issue lifecycle subscriber lagged by {n} messages");
                 }
@@ -854,7 +870,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_message_to_running_session_returns_200() {
-        let (app, _state) = test_app_with_state().await;
+        let (app, state) = test_app_with_state().await;
 
         let create_resp = app
             .clone()
@@ -867,8 +883,22 @@ mod tests {
         let body = response_body_bytes(create_resp).await;
         let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let id = created["id"].as_str().unwrap().to_owned();
+        let session_id: Uuid = id.parse().unwrap();
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        // Poll until the harness has registered its sender in msg_senders.
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let senders = state.msg_senders.lock().await;
+            if senders.contains_key(&session_id) {
+                break;
+            }
+            drop(senders);
+            assert!(
+                tokio::time::Instant::now() <= deadline,
+                "harness never registered sender within 3s"
+            );
+        }
 
         let resp = app
             .oneshot(
@@ -929,7 +959,21 @@ mod tests {
         assert_eq!(r1.unwrap().status(), StatusCode::OK);
         assert_eq!(r2.unwrap().status(), StatusCode::OK);
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        // Poll until at least one sender is registered (at most one harness must
+        // have been spawned for this session).
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let senders = state.msg_senders.lock().await;
+            if senders.contains_key(&session_id) {
+                break;
+            }
+            drop(senders);
+            assert!(
+                tokio::time::Instant::now() <= deadline,
+                "harness never registered sender within 3s"
+            );
+        }
 
         let senders = state.msg_senders.lock().await;
         let sender_count = i32::from(senders.contains_key(&session_id));
@@ -978,7 +1022,10 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::CREATED);
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        // The create request is synchronous — if no harness was spawned, the
+        // msg_senders map must be empty immediately (no need to sleep).
+        // Yield once to allow any spurious async work to settle.
+        tokio::task::yield_now().await;
 
         let senders = state.msg_senders.lock().await;
         let is_empty = senders.is_empty();
@@ -1001,7 +1048,20 @@ mod tests {
         let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let session_id: Uuid = created["id"].as_str().unwrap().parse().unwrap();
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        // Poll until the harness registers its sender in msg_senders.
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let senders = state.msg_senders.lock().await;
+            if senders.contains_key(&session_id) {
+                break;
+            }
+            drop(senders);
+            assert!(
+                tokio::time::Instant::now() <= deadline,
+                "harness never registered sender within 3s"
+            );
+        }
 
         let senders = state.msg_senders.lock().await;
         let has_key = senders.contains_key(&session_id);
@@ -2989,8 +3049,8 @@ mod tests {
             "in_progress on a Running session issue must return 400"
         );
 
-        // msg_senders must not have grown.
-        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+        // The request was rejected synchronously with 400, so no harness can have
+        // been spawned.  Check msg_senders immediately — no sleep needed.
         let final_count = {
             let senders = state.msg_senders.lock().await;
             let count = senders.len();
@@ -3010,13 +3070,15 @@ mod tests {
     /// entry from `stop_map`. If Done arrives later for the same session,
     /// the issue must transition to Waiting (not Completed), proving
     /// the `stop_map` was cleared by the Error handler.
+    ///
+    /// Calls `process_lifecycle_event` directly — no background tasks, no sleeps.
     #[tokio::test]
     async fn test_error_clears_stop_map_so_done_produces_waiting() {
         use events::{SessionEvent, StopEventStatus, SystemEvent};
+        use std::collections::HashMap;
         use types::{IssueStatus, Session, SessionStatus};
 
         let state = test_state().await;
-        spawn_issue_lifecycle_subscriber(&state);
 
         // Create a session and an issue linked to it.
         let session = Session {
@@ -3046,73 +3108,60 @@ mod tests {
         };
         state.db.create_issue(&issue).await.unwrap();
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        let mut stop_map = HashMap::new();
 
-        // Emit Stopped{Complete} — would mark the issue Completed on Done
+        // Process Stopped{Complete} — would mark the issue Completed on Done
         // if the stop_map entry were retained.
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session.id,
-            event: SessionEvent::Stopped {
-                status: StopEventStatus::Complete,
-                comment: None,
+        process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session.id,
+                event: SessionEvent::Stopped {
+                    status: StopEventStatus::Complete,
+                    comment: None,
+                },
             },
-        });
+        )
+        .await;
 
-        // Emit Error — global subscriber should fail the issue AND clear the
-        // stop_map entry for this session.
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session.id,
-            event: SessionEvent::Error {
-                message: "simulated error".into(),
+        // Process Error — should fail the issue AND clear the stop_map entry.
+        process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session.id,
+                event: SessionEvent::Error {
+                    message: "simulated error".into(),
+                },
             },
-        });
+        )
+        .await;
 
-        // Wait for the issue to become Failed.
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
-        loop {
-            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
-            let fetched = state.db.get_issue("ecsm01".to_string()).await.unwrap();
-            if fetched.status == IssueStatus::Failed {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() <= deadline,
-                "issue did not become Failed within 3s (status={})",
-                fetched.status
-            );
-        }
+        let fetched = state.db.get_issue("ecsm01".to_string()).await.unwrap();
+        assert_eq!(
+            fetched.status,
+            IssueStatus::Failed,
+            "issue must be Failed after Error event"
+        );
 
         // Reset issue back to InProgress so it can transition again.
         let mut reset_issue = state.db.get_issue("ecsm01".to_string()).await.unwrap();
         reset_issue.status = IssueStatus::InProgress;
         state.db.update_issue(&reset_issue).await.unwrap();
 
-        // Now emit Done WITHOUT a preceding Stopped for this session.
+        // Process Done WITHOUT a preceding Stopped for this session.
         // Because Error already cleared the stop_map entry, the subscriber
         // must park the issue as Waiting (not Completed).
-        state.event_bus.send(SystemEvent::Session {
-            session_id: session.id,
-            event: SessionEvent::Done,
-        });
-
-        let deadline2 = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
-        loop {
-            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
-            let fetched = state.db.get_issue("ecsm01".to_string()).await.unwrap();
-            if fetched.status == IssueStatus::Waiting {
-                break;
-            }
-            assert_ne!(
-                fetched.status,
-                IssueStatus::Completed,
-                "issue became Completed — stop_map entry was not cleared by Error"
-            );
-            assert!(
-                tokio::time::Instant::now() <= deadline2,
-                "issue did not become Waiting within 3s after Done (status={})",
-                fetched.status
-            );
-        }
+        process_lifecycle_event(
+            &state,
+            &mut stop_map,
+            SystemEvent::Session {
+                session_id: session.id,
+                event: SessionEvent::Done,
+            },
+        )
+        .await;
 
         let final_issue = state.db.get_issue("ecsm01".to_string()).await.unwrap();
         assert_eq!(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -417,15 +417,97 @@ mod tests {
 
     /// Create an isolated temporary git root for tests that spawn a harness.
     ///
-    /// Sets up a minimal `.ns2/agents/` directory with stub agent files for every
-    /// agent name used in the server test suite, so the harness never reads from
-    /// the real repository's `.ns2/agents/` directory.
+    /// Sets up:
+    /// - A bare origin git repository + a local clone with an initial commit, so
+    ///   that `ensure_worktree` (called by `resolve_session_cwd`) can create real
+    ///   worktrees inside the temp directory rather than requiring a live remote.
+    /// - A `ns2.toml` that sets `worktrees.path` to a `worktrees/` subdirectory
+    ///   inside the temp root, keeping all worktrees isolated from the real repo.
+    /// - A minimal `.ns2/agents/` directory with stub agent files for every agent
+    ///   name used in the server test suite, so the harness never reads from the
+    ///   real repository's `.ns2/agents/` directory.
     ///
-    /// The `TempDir` is leaked so the directory stays alive for the duration of the
-    /// test process.  Memory is reclaimed by the OS at process exit.
+    /// The `TempDir` handles are leaked so the directories stay alive for the
+    /// duration of the test process.  Memory is reclaimed by the OS at process exit.
     pub fn make_isolated_git_root() -> std::path::PathBuf {
         let tmp = tempfile::TempDir::new().expect("TempDir::new");
         let root = tmp.path().to_owned();
+
+        // ── bare origin ────────────────────────────────────────────────────────
+        let origin_tmp = tempfile::TempDir::new().expect("TempDir::new for origin");
+        let origin_path = origin_tmp.path().to_owned();
+        std::process::Command::new("git")
+            .args(["init", "--bare", "-b", "main"])
+            .current_dir(&origin_path)
+            .status()
+            .expect("git init --bare for test origin");
+
+        // ── initialise the local clone ─────────────────────────────────────────
+        std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(&root)
+            .status()
+            .expect("git init for test root");
+
+        std::process::Command::new("git")
+            .args(["remote", "add", "origin", &origin_path.to_string_lossy()])
+            .current_dir(&root)
+            .status()
+            .expect("git remote add origin");
+
+        for (k, v) in &[("user.email", "test@test.com"), ("user.name", "Test")] {
+            std::process::Command::new("git")
+                .args(["config", k, v])
+                .current_dir(&root)
+                .status()
+                .unwrap();
+        }
+
+        // Write a placeholder commit so `origin/main` exists and `ensure_worktree`
+        // can use it as the start point when creating new worktree branches.
+        std::fs::write(root.join(".gitkeep"), "").expect("write .gitkeep");
+        std::process::Command::new("git")
+            .args(["add", ".gitkeep"])
+            .current_dir(&root)
+            .status()
+            .expect("git add .gitkeep");
+        std::process::Command::new("git")
+            .args(["-c", "commit.gpgsign=false", "commit", "-m", "init"])
+            .current_dir(&root)
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .status()
+            .expect("git commit init");
+        std::process::Command::new("git")
+            .args(["push", "origin", "main"])
+            .current_dir(&root)
+            .status()
+            .expect("git push origin main");
+
+        // Set origin/HEAD so `detect_remote_default_branch` works.
+        std::process::Command::new("git")
+            .args(["remote", "set-head", "origin", "--auto"])
+            .current_dir(&root)
+            .status()
+            .expect("git remote set-head");
+
+        // ── worktrees config ───────────────────────────────────────────────────
+        // Point worktrees.path at a subdirectory inside the temp root so all
+        // worktrees created during tests are fully isolated.
+        let worktrees_dir = root.join("worktrees");
+        std::fs::create_dir_all(&worktrees_dir).expect("create worktrees dir");
+        std::fs::write(
+            root.join("ns2.toml"),
+            format!(
+                "[worktrees]\npath = \"{}\"\n",
+                worktrees_dir.to_string_lossy()
+            ),
+        )
+        .expect("write ns2.toml");
+
+        // ── stub agents ────────────────────────────────────────────────────────
         let agents_dir = root.join(".ns2").join("agents");
         std::fs::create_dir_all(&agents_dir).expect("create .ns2/agents");
 
@@ -449,8 +531,9 @@ mod tests {
             .expect("write stub agent");
         }
 
-        // Leak the TempDir: this keeps the directory alive until the test process
-        // exits, at which point the OS cleans it up.
+        // Leak both TempDirs: this keeps the directories alive until the test
+        // process exits, at which point the OS cleans them up.
+        Box::leak(Box::new(origin_tmp));
         Box::leak(Box::new(tmp));
         root
     }
@@ -1880,7 +1963,7 @@ mod tests {
             title: "Linked issue".to_string(),
             body: "body".to_string(),
             status: IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: Some(session.id),
             parent_id: None,
@@ -1982,7 +2065,7 @@ mod tests {
             title: "Waiting issue".to_string(),
             body: "body".to_string(),
             status: types::IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: Some(session.id),
             parent_id: None,
@@ -2429,7 +2512,7 @@ mod tests {
                 "POST",
                 "/issues",
                 &serde_json::json!({
-                    "title": "Has assignee", "body": "B", "branch": "", "assignee": "swe"
+                    "title": "Has assignee", "body": "B", "branch": "issue-branch", "assignee": "swe"
                 }),
             ))
             .await
@@ -2546,7 +2629,7 @@ mod tests {
         let create_resp = app
             .clone()
             .oneshot(issue_req("POST", "/issues", &serde_json::json!({
-                "title": "Auto complete test", "body": "body", "branch": "", "assignee": "test-agent-no-disk-def"
+                "title": "Auto complete test", "body": "body", "branch": "issue-branch", "assignee": "test-agent-no-disk-def"
             })))
             .await
             .unwrap();
@@ -2796,7 +2879,7 @@ mod tests {
             title: "Test issue".into(),
             body: "body".into(),
             status: types::IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: None,
             session_id: Some(session.id),
             parent_id: None,
@@ -2919,7 +3002,7 @@ mod tests {
             title: "Issue A".to_string(),
             body: "body".to_string(),
             status: IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: Some(session.id),
             parent_id: None,
@@ -2934,7 +3017,7 @@ mod tests {
             title: "Issue B".to_string(),
             body: "body".to_string(),
             status: IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: Some(session.id),
             parent_id: None,
@@ -3011,7 +3094,7 @@ mod tests {
             title: "Already Running Issue".to_string(),
             body: "body".to_string(),
             status: IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("test-agent".to_string()),
             session_id: Some(running_session_id),
             parent_id: None,
@@ -3096,7 +3179,7 @@ mod tests {
             title: "Error clears stop map".to_string(),
             body: "body".to_string(),
             status: IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: Some(session.id),
             parent_id: None,
@@ -3180,7 +3263,7 @@ mod tests {
             title: "Test issue".into(),
             body: "body".into(),
             status,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: None,
             session_id: Some(Uuid::new_v4()),
             parent_id: None,
@@ -3487,7 +3570,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "My Title",
                     "body": "My Body",
-                    "branch": "",
+                    "branch": "issue-branch",
                     "assignee": "test-agent"
                 }),
             ))
@@ -3603,7 +3686,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "PM Task",
                     "body": "Do the thing",
-                    "branch": "",
+                    "branch": "issue-branch",
                     "assignee": "product-manager"
                 }),
             ))
@@ -3722,7 +3805,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "Watcher waiting test",
                     "body": "Please respond",
-                    "branch": "",
+                    "branch": "issue-branch",
                     "assignee": "swe-agent"
                 }),
             ))
@@ -3817,7 +3900,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "Error test issue",
                     "body": "trigger an error",
-                    "branch": "",
+                    "branch": "issue-branch",
                     "assignee": "swe-agent"
                 }),
             ))
@@ -3887,7 +3970,7 @@ mod tests {
             title: "Multi-turn test".to_string(),
             body: "body".to_string(),
             status: IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: None,
             parent_id: None,
@@ -4415,7 +4498,7 @@ mod tests {
             title: "No text test".to_string(),
             body: "body".to_string(),
             status: IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: None,
             parent_id: None,
@@ -4940,7 +5023,7 @@ mod tests {
                 "POST",
                 "/issues",
                 &serde_json::json!({
-                    "title": "Work", "body": "do work", "branch": "", "assignee": "test-agent"
+                    "title": "Work", "body": "do work", "branch": "issue-branch", "assignee": "test-agent"
                 }),
             ))
             .await
@@ -5046,7 +5129,7 @@ mod tests {
                 &serde_json::json!({
                     "title": "Lifecycle test",
                     "body": "body",
-                    "branch": "",
+                    "branch": "issue-branch",
                     "assignee": "test-agent"
                 }),
             ))
@@ -5170,7 +5253,7 @@ mod tests {
             title: "Failed issue".to_string(),
             body: "body".to_string(),
             status: types::IssueStatus::Failed,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("test-agent".to_string()),
             session_id: Some(old_session_id),
             parent_id: None,
@@ -5239,7 +5322,7 @@ mod tests {
             title: "Waiting issue".to_string(),
             body: "body".to_string(),
             status: types::IssueStatus::Waiting,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("test-agent".to_string()),
             session_id: Some(waiting_session_id),
             parent_id: None,
@@ -5323,7 +5406,7 @@ mod tests {
             title: "Cancelled issue".to_string(),
             body: "body".to_string(),
             status: types::IssueStatus::Cancelled,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("test-agent".to_string()),
             session_id: None,
             parent_id: None,
@@ -5374,7 +5457,7 @@ mod tests {
             title: "Cancelled issue with session".to_string(),
             body: "body".to_string(),
             status: types::IssueStatus::Cancelled,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("test-agent".to_string()),
             session_id: Some(cancelled_session_id),
             parent_id: None,
@@ -5425,7 +5508,7 @@ mod tests {
             title: "Running issue".to_string(),
             body: "body".to_string(),
             status: types::IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("test-agent".to_string()),
             session_id: Some(running_session_id),
             parent_id: None,
@@ -5465,7 +5548,7 @@ mod tests {
             title: "Waiting no-session issue".to_string(),
             body: "body".to_string(),
             status: types::IssueStatus::Waiting,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("test-agent".to_string()),
             session_id: None,
             parent_id: None,
@@ -5815,39 +5898,109 @@ mod tests {
     }
 
 
-    /// `PATCH /issues/:id/status` with any status other than `in_progress` must
-    /// return 400 — those transitions have dedicated endpoints (`cancel`, `complete`,
-    /// `reopen`).  The direct DB write path was removed because it bypassed event
-    /// emission, session cleanup, and hooks.
+    /// `PATCH /issues/:id/status` routes `cancelled` and `open` through the service
+    /// (emitting events), while `waiting`, `failed`, and `completed` return 400.
     #[tokio::test]
-    async fn test_patch_issue_status_non_in_progress_returns_400() {
-        let (app, _state) = test_app_with_state().await;
+    #[allow(clippy::too_many_lines)]
+    async fn test_patch_issue_status_routing() {
+        let (app, state) = test_app_with_state().await;
 
-        // Create an open issue.
+        // ── cancelled: must succeed and return status=cancelled ───────────────
+        // Create a fresh open issue.
         let create_resp = app
             .clone()
             .oneshot(issue_req(
                 "POST",
                 "/issues",
-                &serde_json::json!({
-                    "title": "Status update test",
-                    "body": "body"
-                }),
+                &serde_json::json!({"title": "Status routing test", "body": "body"}),
             ))
             .await
             .unwrap();
-        let body = response_body_bytes(create_resp).await;
-        let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let issue_id = created["id"].as_str().unwrap().to_string();
+        let b = response_body_bytes(create_resp).await;
+        let created: serde_json::Value = serde_json::from_slice(&b).unwrap();
+        let id1 = created["id"].as_str().unwrap().to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/issues/{id1}/status"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"status": "cancelled"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "PATCH /status cancelled must return 200"
+        );
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "cancelled", "issue must be cancelled");
+        // Verify the DB was updated via the service (not a raw write).
+        let db_issue = state.db.get_issue(id1.clone()).await.unwrap();
+        assert_eq!(
+            db_issue.status,
+            types::IssueStatus::Cancelled,
+            "DB must reflect cancelled status"
+        );
 
-        // Each non-in_progress status must be rejected with 400.
-        for status in ["waiting", "completed", "failed", "cancelled", "open"] {
+        // ── open: must succeed and return status=open (reopen a cancelled issue) ─
+        // The issue is now cancelled; reopening it should set it back to open.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/issues/{id1}/status"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"status": "open"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "PATCH /status open (reopen) must return 200"
+        );
+        let body = response_body_bytes(resp).await;
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "open", "issue must be open after reopen");
+        let db_issue = state.db.get_issue(id1.clone()).await.unwrap();
+        assert_eq!(
+            db_issue.status,
+            types::IssueStatus::Open,
+            "DB must reflect open status after reopen"
+        );
+
+        // ── waiting / failed / completed: must return 400 ─────────────────────
+        // Create a fresh open issue for the 400 checks.
+        let create_resp2 = app
+            .clone()
+            .oneshot(issue_req(
+                "POST",
+                "/issues",
+                &serde_json::json!({"title": "Status routing test 2", "body": "body"}),
+            ))
+            .await
+            .unwrap();
+        let b2 = response_body_bytes(create_resp2).await;
+        let created2: serde_json::Value = serde_json::from_slice(&b2).unwrap();
+        let id2 = created2["id"].as_str().unwrap().to_string();
+        for status in ["waiting", "failed", "completed"] {
             let resp = app
                 .clone()
                 .oneshot(
                     Request::builder()
                         .method("PATCH")
-                        .uri(format!("/issues/{issue_id}/status"))
+                        .uri(format!("/issues/{id2}/status"))
                         .header("content-type", "application/json")
                         .body(Body::from(
                             serde_json::to_vec(&serde_json::json!({"status": status})).unwrap(),
@@ -5889,7 +6042,7 @@ mod tests {
             title: "Cancel test".to_string(),
             body: "body".to_string(),
             status: types::IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: Some(session.id),
             parent_id: None,
@@ -5991,7 +6144,7 @@ mod tests {
             title: "Route cancel test".to_string(),
             body: "body".to_string(),
             status: types::IssueStatus::InProgress,
-            branch: String::new(),
+            branch: "issue-branch".to_string(),
             assignee: Some("bot".to_string()),
             session_id: Some(session_id),
             parent_id: None,

--- a/crates/server/src/routes/issue.rs
+++ b/crates/server/src/routes/issue.rs
@@ -211,28 +211,16 @@ pub async fn reopen_issue(
 
 /// POST /issues/:id/cancel — cancel a running or open issue.
 ///
-/// Marks the issue `cancelled`. If the issue has a linked session, also drops
-/// the session's msg sender (terminating the harness) and marks the session
-/// `cancelled` in the DB.
+/// Marks the issue `cancelled` and returns it.  All session cleanup
+/// (dropping the msg sender, marking the session Cancelled in the DB) is
+/// handled by the global issue lifecycle subscriber when it receives the
+/// `IssueEvent::StatusChanged { to: Cancelled }` event emitted by
+/// `issue_service.cancel_issue()`.
 pub async fn cancel_issue(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> std::result::Result<Json<Issue>, Error> {
     let issue = state.issue_service.cancel_issue(id).await?;
-
-    if let Some(session_id) = issue.session_id {
-        // Drop the msg sender so the harness exits cleanly.
-        {
-            let mut senders = state.msg_senders.lock().await;
-            senders.remove(&session_id);
-        }
-        // Update session status to cancelled.
-        let _ = state
-            .db
-            .update_session_status(session_id, types::SessionStatus::Cancelled)
-            .await;
-    }
-
     Ok(Json(issue))
 }
 

--- a/crates/server/src/routes/issue.rs
+++ b/crates/server/src/routes/issue.rs
@@ -226,16 +226,19 @@ pub async fn cancel_issue(
 
 /// PATCH /issues/:id/status — update an issue's status.
 ///
-/// When the new status is `in_progress`, this handler:
+/// Only `in_progress` is accepted.  When the new status is `in_progress`, this handler:
 /// 1. Checks the issue has an assignee (returns 400 if not).
 /// 2. If the issue has a linked session in `Failed` state, marks that session
 ///    `Cancelled` and clears the `session_id` on the issue.
-/// 3. If the issue is in `Waiting` state (has an existing session), directly
-///    spawns the harness against the existing session (resume mode).
-/// 4. Otherwise calls `issue_service.start_issue()` and spawns the harness.
+/// 3. If the issue is in `Waiting` state (has an existing session), calls
+///    `issue_service.resume_issue()` so the lifecycle subscriber can resume the harness.
+/// 4. Otherwise calls `issue_service.start_issue()` and the lifecycle subscriber spawns
+///    the harness.
 /// 5. Returns the issue in `in_progress` state.
 ///
-/// For any other status the issue's status is updated directly in the DB.
+/// All other status values return `400 Bad Request` — they each have a dedicated
+/// endpoint (`cancel`, `complete`, `reopen`) that correctly handles session cleanup
+/// and event emission.
 pub async fn update_issue_status(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -304,10 +307,31 @@ pub async fn update_issue_status(
         return do_start_issue(&state, id).await;
     }
 
-    // For all other statuses: simple field update.
-    let mut issue = state.db.get_issue(id.clone()).await?;
-    issue.status = new_status;
-    state.db.update_issue(&issue).await?;
-    let updated = state.db.get_issue(id).await?;
-    Ok(Json(updated))
+    // All other status values are rejected.  Each has a dedicated endpoint:
+    //   cancelled  → POST /issues/:id/cancel
+    //   completed  → POST /issues/:id/complete
+    //   failed     → set only by the harness error path or orphan sweep
+    //   waiting    → set only by the lifecycle subscriber (stop(waiting))
+    //   open       → POST /issues/:id/reopen
+    //
+    // Routing these through a raw DB write would bypass event emission, session
+    // cleanup, and hooks, so we return 400 with a helpful message instead.
+    let hint = match new_status {
+        IssueStatus::Cancelled => {
+            "use `POST /issues/:id/cancel` (or `ns2 issue cancel --id <id>`)".to_string()
+        }
+        IssueStatus::Completed => {
+            "use `POST /issues/:id/complete` (or `ns2 issue complete --id <id> --comment <text>`)".to_string()
+        }
+        IssueStatus::Open => {
+            "use `POST /issues/:id/reopen` (or `ns2 issue reopen --id <id>`)".to_string()
+        }
+        IssueStatus::Failed | IssueStatus::Waiting => {
+            format!("'{new_status}' is set automatically by the server; it cannot be set via PATCH")
+        }
+        IssueStatus::InProgress => unreachable!("in_progress handled above"),
+    };
+    Err(Error::BadRequest(format!(
+        "PATCH /issues/:id/status only accepts 'in_progress'; {hint}"
+    )))
 }

--- a/crates/server/src/routes/issue.rs
+++ b/crates/server/src/routes/issue.rs
@@ -226,19 +226,27 @@ pub async fn cancel_issue(
 
 /// PATCH /issues/:id/status — update an issue's status.
 ///
-/// Only `in_progress` is accepted.  When the new status is `in_progress`, this handler:
-/// 1. Checks the issue has an assignee (returns 400 if not).
-/// 2. If the issue has a linked session in `Failed` state, marks that session
-///    `Cancelled` and clears the `session_id` on the issue.
-/// 3. If the issue is in `Waiting` state (has an existing session), calls
-///    `issue_service.resume_issue()` so the lifecycle subscriber can resume the harness.
-/// 4. Otherwise calls `issue_service.start_issue()` and the lifecycle subscriber spawns
-///    the harness.
-/// 5. Returns the issue in `in_progress` state.
+/// Accepted status values and their behaviour:
 ///
-/// All other status values return `400 Bad Request` — they each have a dedicated
-/// endpoint (`cancel`, `complete`, `reopen`) that correctly handles session cleanup
-/// and event emission.
+/// - `in_progress` — starts or resumes the issue:
+///   1. Checks the issue has an assignee (returns 400 if not).
+///   2. If the issue has a linked session in `Failed` state, marks that session
+///      `Cancelled` and clears the `session_id` on the issue.
+///   3. If the issue is in `Waiting` state (has an existing session), calls
+///      `issue_service.resume_issue()` so the lifecycle subscriber can resume the harness.
+///   4. Otherwise calls `issue_service.start_issue()` and the lifecycle subscriber spawns
+///      the harness.
+///   5. Returns the issue in `in_progress` state.
+///
+/// - `cancelled` — routes through `issue_service.cancel_issue()`, which emits events
+///   and handles session cleanup via the lifecycle subscriber.
+///
+/// - `open` — routes through `issue_service.reopen_issue(id, None)`, which emits events.
+///   No comment is added. Use `POST /issues/:id/reopen` to reopen with a comment.
+///
+/// - `waiting` — returns 400: set automatically by the server, cannot be set via PATCH.
+/// - `failed` — returns 400: set automatically by the server, cannot be set via PATCH.
+/// - `completed` — returns 400: use `POST /issues/:id/complete` (requires `--comment`).
 pub async fn update_issue_status(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -307,31 +315,34 @@ pub async fn update_issue_status(
         return do_start_issue(&state, id).await;
     }
 
-    // All other status values are rejected.  Each has a dedicated endpoint:
-    //   cancelled  → POST /issues/:id/cancel
-    //   completed  → POST /issues/:id/complete
-    //   failed     → set only by the harness error path or orphan sweep
-    //   waiting    → set only by the lifecycle subscriber (stop(waiting))
-    //   open       → POST /issues/:id/reopen
-    //
-    // Routing these through a raw DB write would bypass event emission, session
-    // cleanup, and hooks, so we return 400 with a helpful message instead.
+    // `cancelled` and `open` are routed through the service so that event
+    // emission, session cleanup, and hooks all fire correctly.
+    if new_status == IssueStatus::Cancelled {
+        let issue = state.issue_service.cancel_issue(id).await?;
+        return Ok(Json(issue));
+    }
+
+    if new_status == IssueStatus::Open {
+        let issue = state.issue_service.reopen_issue(id, None).await?;
+        return Ok(Json(issue));
+    }
+
+    // The remaining statuses (`waiting`, `failed`, `completed`) cannot be set
+    // via PATCH — they are either set automatically by the server or require a
+    // dedicated endpoint with additional required input.
     let hint = match new_status {
-        IssueStatus::Cancelled => {
-            "use `POST /issues/:id/cancel` (or `ns2 issue cancel --id <id>`)".to_string()
-        }
         IssueStatus::Completed => {
-            "use `POST /issues/:id/complete` (or `ns2 issue complete --id <id> --comment <text>`)".to_string()
+            "use `POST /issues/:id/complete` (requires --comment)".to_string()
         }
-        IssueStatus::Open => {
-            "use `POST /issues/:id/reopen` (or `ns2 issue reopen --id <id>`)".to_string()
+        IssueStatus::Waiting => {
+            "'waiting' is set automatically by the server and cannot be set via PATCH".to_string()
         }
-        IssueStatus::Failed | IssueStatus::Waiting => {
-            format!("'{new_status}' is set automatically by the server; it cannot be set via PATCH")
+        IssueStatus::Failed => {
+            "'failed' is set automatically by the server and cannot be set via PATCH".to_string()
         }
-        IssueStatus::InProgress => unreachable!("in_progress handled above"),
+        IssueStatus::InProgress | IssueStatus::Cancelled | IssueStatus::Open => {
+            unreachable!("handled above")
+        }
     };
-    Err(Error::BadRequest(format!(
-        "PATCH /issues/:id/status only accepts 'in_progress'; {hint}"
-    )))
+    Err(Error::BadRequest(hint))
 }

--- a/crates/server/src/routes/session.rs
+++ b/crates/server/src/routes/session.rs
@@ -276,22 +276,20 @@ pub async fn cancel_session(
         .await?;
 
     // Mark any linked issue as failed (the issue wasn't explicitly cancelled).
+    // Route through issue_service so that IssueEvent::CommentAdded and
+    // IssueEvent::StatusChanged { to: Failed } are emitted on the event bus.
     let linked_issues = state
         .db
         .list_issues_by_session_id(id)
         .await
         .unwrap_or_default();
-    for mut issue in linked_issues {
-        use types::{IssueComment, IssueStatus};
+    for issue in linked_issues {
+        use types::IssueStatus;
         if matches!(issue.status, IssueStatus::InProgress | IssueStatus::Open) {
-            issue.comments.push(IssueComment {
-                author: "system".to_string(),
-                created_at: chrono::Utc::now(),
-                body: "session cancelled".to_string(),
-            });
-            issue.status = IssueStatus::Failed;
-            issue.updated_at = chrono::Utc::now();
-            let _ = state.db.update_issue(&issue).await;
+            let _ = state
+                .issue_service
+                .fail_issue(&issue.id, "session cancelled".to_string())
+                .await;
         }
     }
 

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -30,4 +30,8 @@ pub struct AppState {
     pub(crate) hook_store: Arc<dyn HookStore>,
     /// Event store for CRUD operations on named events.
     pub(crate) event_store: Arc<dyn db::EventStore>,
+    /// Injectable git root for the harness.  `None` in production (the harness
+    /// discovers the real root via `workspace::git_root()`).  Tests set this to
+    /// an isolated temp directory so harness tasks never touch the real repo.
+    pub(crate) git_root: Option<std::path::PathBuf>,
 }


### PR DESCRIPTION
## Summary

Post-merge audit of GH#129 (global event bus), GH#132 (named events), and GH#148 (ancestor_ids) found several places where old direct-DB patterns survived alongside the new event-driven architecture, plus three test quality issues.

### Bug fixes

- **`cancel_session` bypassed the event bus** — `POST /sessions/:id/cancel` was writing linked issues to `Failed` directly in the DB, skipping `IssueService`. Now calls `fail_issue()` so `IssueEvent::CommentAdded` and `IssueEvent::StatusChanged` are emitted and hooks fire correctly.
- **`cancel_issue` route duplicated lifecycle subscriber** — the route was directly removing from `msg_senders` and updating session status after calling `cancel_issue()`, while the lifecycle subscriber was also doing both on receiving the `StatusChanged { to: Cancelled }` event. Removed the direct cleanup from the route; the subscriber now owns it exclusively.
- **`PATCH /issues/:id/status` bypassed the event bus for `open`/`cancelled`** — the fallback path wrote directly to the DB. Now routes `cancelled` through `cancel_issue()` and `open` through `reopen_issue()` so events fire. `waiting`, `failed`, and `completed` return 400 with a pointer to their dedicated endpoints.
- **`orphan_sweep` skipped event emission** — was writing issues to `Failed` directly in the DB even though subscribers are already live at startup. Now calls `fail_issue()` so hooks fire for orphan recovery too.

### Test fixes

- **GH#157 — server unit tests coupled to real filesystem** — added `git_root: Option<PathBuf>` to `AppState`; `test_state()` injects an isolated temp repo with stub agent files and a bare origin so worktree creation stays contained. Test issues use real branch names.
- **GH#158 — CLI server startup fragile under load** — replaced stdout-parsing with a TCP health-check (10s deadline, 10ms poll). Consolidated 9 separate CLI integration test files into a single binary (`tests/integration_tests.rs`), reducing parallel binary count under `cargo llvm-cov` from 9 to 1.
- **Timing flakiness in ~30 server tests** — extracted `process_lifecycle_event` from the lifecycle subscriber loop. Tests that verify lifecycle logic now call it directly (no background tasks, no sleeps, fully deterministic). Remaining tests that go through the HTTP router replaced bare `tokio::time::sleep` calls with deadline poll loops.

## Test plan

- `cargo test` — full suite green
- `cargo clippy --tests -- -D warnings -W clippy::pedantic -W clippy::nursery` — clean
- All 159 server tests, 120 CLI integration tests, and unit tests across all crates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)